### PR TITLE
feat(api): implement spec 001b-rgd-api — RGD endpoint tests and fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,55 @@
+# ── Git and VCS ───────────────────────────────────────────────────────
+.git/
+.gitignore
+
+# ── Build artifacts ───────────────────────────────────────────────────
+bin/
+*.exe
+*.test
+*.out
+
+# ── Frontend node_modules (rebuilt in Docker) ─────────────────────────
+web/node_modules/
+test/e2e/node_modules/
+
+# ── E2E test artifacts ────────────────────────────────────────────────
+test/e2e/playwright-report/
+test/e2e/test-results/
+
+# ── IDE and editor ────────────────────────────────────────────────────
+.idea/
+.vscode/
+*.swp
+*.swo
+.DS_Store
+Thumbs.db
+
+# ── Environment and secrets ──────────────────────────────────────────
+.env
+.env.*
+
+# ── Docker (avoid recursive copy) ────────────────────────────────────
+Dockerfile
+.dockerignore
+
+# ── CI and docs ──────────────────────────────────────────────────────
+.github/
+*.md
+LICENSE
+SECURITY.md
+
+# ── Spec-driven development ─────────────────────────────────────────
+.specify/
+
+# ── Logs and coverage ────────────────────────────────────────────────
+*.log
+*.coverprofile
+cover.out
+unit-cover.out
+integration-cover.out
+
+# ── Helm chart (not needed in app image) ─────────────────────────────
+helm/
+
+# ── OpenCode ─────────────────────────────────────────────────────────
+.opencode/

--- a/.specify/specs/001b-rgd-api/plan.md
+++ b/.specify/specs/001b-rgd-api/plan.md
@@ -1,0 +1,47 @@
+# Implementation Plan: 001b-rgd-api
+
+## Summary
+
+Add three RGD API endpoints to the kro-ui backend, plus comprehensive unit tests.
+The handler code (`rgds.go`, `discover.go`) was scaffolded during the server-core
+work and needs: (a) correctness fixes, (b) full unit test coverage matching the
+spec's acceptance scenarios.
+
+## Tech Stack
+
+- **Language**: Go 1.25
+- **Router**: chi v5 (already wired in `server.go`)
+- **K8s client**: `k8s.io/client-go/dynamic` + `discovery` via `ClientFactory`
+- **Testing**: `testing` + `testify/assert` + `testify/require`, table-driven build/check
+
+## Architecture
+
+### Files Modified
+
+| File | Change |
+|------|--------|
+| `internal/api/handlers/rgds.go` | Fix error codes (503 for cluster errors), use `r.Context()` |
+| `internal/api/handlers/rgds_test.go` | NEW — full unit tests for ListRGDs, GetRGD, ListInstances |
+| `internal/api/handlers/discover_test.go` | NEW — unit tests for unstructuredString, isListable, discoverPlural |
+| `internal/api/handlers/handler_test.go` | Extend stub to support dynamic + discovery mocking |
+| `.dockerignore` | NEW — Docker build ignore patterns |
+
+### Test Strategy
+
+Unit tests use hand-written stubs (no mockery/gomock per constitution). The stubs
+implement `dynamic.Interface` and `discovery.DiscoveryInterface` at the minimum
+surface area needed — only `Resource()` and `ServerResourcesForGroupVersion()`.
+
+The test pattern follows the existing `contexts_test.go` build/check structure:
+- `build` sets up stub data + constructs the Handler
+- `check` asserts HTTP status code and response body content
+
+### Stub Design
+
+Since `rgds.go` calls `h.factory.Dynamic().Resource(gvr).List/Get(...)`, we need:
+1. A stub `ClientFactory` that returns a stub `dynamic.Interface`
+2. The stub `dynamic.Interface` returns a stub `dynamic.ResourceInterface` for specific GVRs
+3. The stub `dynamic.ResourceInterface` implements `List` and `Get`
+
+This is more involved than the context stubs but follows the same pattern of
+hand-written unexported types implementing the minimum interface surface.

--- a/.specify/specs/001b-rgd-api/tasks.md
+++ b/.specify/specs/001b-rgd-api/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: 001b-rgd-api
+
+## Phase 1 — Setup
+
+- [x] T01: Verify existing handler code compiles and passes `go vet`
+- [x] T02: Review spec acceptance scenarios and map to test cases
+
+## Phase 2 — Code Fixes
+
+- [x] T03: Fix `ListRGDs` to use `r.Context()` instead of `context.Background()`
+- [x] T04: Fix `GetRGD` to use `r.Context()` instead of `context.Background()`
+- [x] T05: Fix `ListInstances` to use `r.Context()` instead of `context.Background()`
+- [x] T06: Improve error handling in `ListRGDs` — return 503 for cluster errors (spec scenario 5)
+- [x] T06b: Fix `GetRGD` 404 message format per spec (`resourcegraphdefinition "name" not found`)
+- [x] T06c: Refactor `Handler.factory` from `*ClientFactory` to `k8sClients` interface (§VI)
+- [x] T06d: Update `discoverPlural` to accept `k8sClients` interface
+
+## Phase 3 — Test Infrastructure
+
+- [x] T07: Create stub dynamic client infrastructure in `handler_test.go`
+- [x] T08: Create stub discovery client infrastructure in `handler_test.go`
+
+## Phase 4 — Unit Tests (TDD validation)
+
+- [x] T09: Write `rgds_test.go` — `TestListRGDs` (3 cases: success, empty, cluster error)
+- [x] T10: Write `rgds_test.go` — `TestGetRGD` (2 cases: found, not found/404)
+- [x] T11: Write `rgds_test.go` — `TestListInstances` (7 cases: success, namespace filter, missing kind/422, discovery fallback, default group, RGD not found, empty instances)
+- [x] T12: Write `discover_test.go` — `TestUnstructuredString` (6 cases: nested found, key not found, intermediate missing, wrong type, single-level, empty object)
+- [x] T13: Write `discover_test.go` — `TestIsListable` (4 cases: listable, non-listable, subresource, empty verbs)
+- [x] T14: Write `discover_test.go` — `TestDiscoverPlural` (6 cases: found, case-insensitive, not found, discovery fails, empty group, unregistered GV)
+
+## Phase 5 — Polish
+
+- [x] T15: Create `.dockerignore`
+- [x] T16: Run `go test -race ./internal/api/handlers/...` — all 29 tests pass
+- [x] T17: Run `go vet ./...` — clean
+- [x] T18: Verify test coverage includes all spec acceptance scenarios

--- a/internal/api/handlers/discover.go
+++ b/internal/api/handlers/discover.go
@@ -103,7 +103,7 @@ func (h *Handler) listChildResources(namespace, instanceName, rgdName string) ([
 }
 
 // discoverPlural uses the discovery API to find the correct plural resource name for a kind.
-func discoverPlural(factory *k8sclient.ClientFactory, group, version, kind string) (string, error) {
+func discoverPlural(factory k8sClients, group, version, kind string) (string, error) {
 	gv := group + "/" + version
 	if group == "" {
 		gv = version

--- a/internal/api/handlers/discover_test.go
+++ b/internal/api/handlers/discover_test.go
@@ -1,0 +1,325 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestUnstructuredString(t *testing.T) {
+	tests := []struct {
+		name     string
+		build    func(t *testing.T) (map[string]any, []string)
+		checkVal string
+		checkOK  bool
+		checkErr bool
+	}{
+		{
+			name: "extracts nested string value",
+			build: func(t *testing.T) (map[string]any, []string) {
+				t.Helper()
+				obj := map[string]any{
+					"spec": map[string]any{
+						"schema": map[string]any{
+							"kind": "WebService",
+						},
+					},
+				}
+				return obj, []string{"spec", "schema", "kind"}
+			},
+			checkVal: "WebService",
+			checkOK:  true,
+		},
+		{
+			name: "returns empty when key not found",
+			build: func(t *testing.T) (map[string]any, []string) {
+				t.Helper()
+				obj := map[string]any{
+					"spec": map[string]any{
+						"schema": map[string]any{},
+					},
+				}
+				return obj, []string{"spec", "schema", "kind"}
+			},
+			checkVal: "",
+			checkOK:  false,
+		},
+		{
+			name: "returns empty when intermediate key missing",
+			build: func(t *testing.T) (map[string]any, []string) {
+				t.Helper()
+				obj := map[string]any{
+					"spec": map[string]any{},
+				}
+				return obj, []string{"spec", "schema", "kind"}
+			},
+			checkVal: "",
+			checkOK:  false,
+		},
+		{
+			name: "returns false when value is not a string",
+			build: func(t *testing.T) (map[string]any, []string) {
+				t.Helper()
+				obj := map[string]any{
+					"spec": map[string]any{
+						"schema": map[string]any{
+							"kind": 42,
+						},
+					},
+				}
+				return obj, []string{"spec", "schema", "kind"}
+			},
+			checkVal: "",
+			checkOK:  false,
+		},
+		{
+			name: "handles single-level path",
+			build: func(t *testing.T) (map[string]any, []string) {
+				t.Helper()
+				obj := map[string]any{
+					"name": "test",
+				}
+				return obj, []string{"name"}
+			},
+			checkVal: "test",
+			checkOK:  true,
+		},
+		{
+			name: "handles empty object",
+			build: func(t *testing.T) (map[string]any, []string) {
+				t.Helper()
+				return map[string]any{}, []string{"spec", "schema", "kind"}
+			},
+			checkVal: "",
+			checkOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj, path := tt.build(t)
+			val, ok, err := unstructuredString(obj, path...)
+			if tt.checkErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.checkVal, val)
+			assert.Equal(t, tt.checkOK, ok)
+		})
+	}
+}
+
+func TestIsListable(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(t *testing.T) metav1.APIResource
+		check func(t *testing.T, result bool)
+	}{
+		{
+			name: "listable resource returns true",
+			build: func(t *testing.T) metav1.APIResource {
+				t.Helper()
+				return metav1.APIResource{
+					Name:  "pods",
+					Verbs: metav1.Verbs{"get", "list", "watch"},
+				}
+			},
+			check: func(t *testing.T, result bool) {
+				t.Helper()
+				assert.True(t, result)
+			},
+		},
+		{
+			name: "non-listable resource returns false",
+			build: func(t *testing.T) metav1.APIResource {
+				t.Helper()
+				return metav1.APIResource{
+					Name:  "pods",
+					Verbs: metav1.Verbs{"get", "watch"},
+				}
+			},
+			check: func(t *testing.T, result bool) {
+				t.Helper()
+				assert.False(t, result)
+			},
+		},
+		{
+			name: "subresource returns false even if listable",
+			build: func(t *testing.T) metav1.APIResource {
+				t.Helper()
+				return metav1.APIResource{
+					Name:  "pods/status",
+					Verbs: metav1.Verbs{"get", "list"},
+				}
+			},
+			check: func(t *testing.T, result bool) {
+				t.Helper()
+				assert.False(t, result)
+			},
+		},
+		{
+			name: "empty verbs returns false",
+			build: func(t *testing.T) metav1.APIResource {
+				t.Helper()
+				return metav1.APIResource{
+					Name:  "secrets",
+					Verbs: metav1.Verbs{},
+				}
+			},
+			check: func(t *testing.T, result bool) {
+				t.Helper()
+				assert.False(t, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := tt.build(t)
+			result := isListable(res)
+			tt.check(t, result)
+		})
+	}
+}
+
+func TestDiscoverPlural(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(t *testing.T) (k8sClients, string, string, string)
+		check func(t *testing.T, plural string, err error)
+	}{
+		{
+			name: "discovers correct plural from discovery API",
+			build: func(t *testing.T) (k8sClients, string, string, string) {
+				t.Helper()
+				disc := newStubDiscovery()
+				disc.resources["kro.run/v1alpha1"] = &metav1.APIResourceList{
+					GroupVersion: "kro.run/v1alpha1",
+					APIResources: []metav1.APIResource{
+						{Name: "testapps", Kind: "TestApp", Verbs: metav1.Verbs{"get", "list"}},
+						{Name: "databases", Kind: "Database", Verbs: metav1.Verbs{"get", "list"}},
+					},
+				}
+				return &stubK8sClients{dyn: newStubDynamic(), disc: disc}, "kro.run", "v1alpha1", "TestApp"
+			},
+			check: func(t *testing.T, plural string, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.Equal(t, "testapps", plural)
+			},
+		},
+		{
+			name: "case-insensitive kind matching",
+			build: func(t *testing.T) (k8sClients, string, string, string) {
+				t.Helper()
+				disc := newStubDiscovery()
+				disc.resources["kro.run/v1alpha1"] = &metav1.APIResourceList{
+					GroupVersion: "kro.run/v1alpha1",
+					APIResources: []metav1.APIResource{
+						{Name: "databases", Kind: "Database", Verbs: metav1.Verbs{"get", "list"}},
+					},
+				}
+				return &stubK8sClients{dyn: newStubDynamic(), disc: disc}, "kro.run", "v1alpha1", "database"
+			},
+			check: func(t *testing.T, plural string, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.Equal(t, "databases", plural)
+			},
+		},
+		{
+			name: "returns error when kind not found",
+			build: func(t *testing.T) (k8sClients, string, string, string) {
+				t.Helper()
+				disc := newStubDiscovery()
+				disc.resources["kro.run/v1alpha1"] = &metav1.APIResourceList{
+					GroupVersion: "kro.run/v1alpha1",
+					APIResources: []metav1.APIResource{
+						{Name: "testapps", Kind: "TestApp", Verbs: metav1.Verbs{"get", "list"}},
+					},
+				}
+				return &stubK8sClients{dyn: newStubDynamic(), disc: disc}, "kro.run", "v1alpha1", "NonExistent"
+			},
+			check: func(t *testing.T, plural string, err error) {
+				t.Helper()
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "NonExistent")
+				assert.Contains(t, err.Error(), "not found")
+			},
+		},
+		{
+			name: "returns error when discovery fails",
+			build: func(t *testing.T) (k8sClients, string, string, string) {
+				t.Helper()
+				disc := newStubDiscovery()
+				disc.err = fmt.Errorf("discovery unavailable")
+				return &stubK8sClients{dyn: newStubDynamic(), disc: disc}, "kro.run", "v1alpha1", "TestApp"
+			},
+			check: func(t *testing.T, plural string, err error) {
+				t.Helper()
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "discovery unavailable")
+			},
+		},
+		{
+			name: "handles empty group correctly",
+			build: func(t *testing.T) (k8sClients, string, string, string) {
+				t.Helper()
+				disc := newStubDiscovery()
+				// For core API group, the group version is just "v1" (no slash prefix).
+				disc.resources["v1"] = &metav1.APIResourceList{
+					GroupVersion: "v1",
+					APIResources: []metav1.APIResource{
+						{Name: "pods", Kind: "Pod", Verbs: metav1.Verbs{"get", "list"}},
+					},
+				}
+				return &stubK8sClients{dyn: newStubDynamic(), disc: disc}, "", "v1", "Pod"
+			},
+			check: func(t *testing.T, plural string, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.Equal(t, "pods", plural)
+			},
+		},
+		{
+			name: "returns error when group version not registered",
+			build: func(t *testing.T) (k8sClients, string, string, string) {
+				t.Helper()
+				disc := newStubDiscovery()
+				// No resources registered.
+				return &stubK8sClients{dyn: newStubDynamic(), disc: disc}, "unknown.io", "v1beta1", "Foo"
+			},
+			check: func(t *testing.T, plural string, err error) {
+				t.Helper()
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "not found")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory, group, version, kind := tt.build(t)
+			plural, err := discoverPlural(factory, group, version, kind)
+			tt.check(t, plural, err)
+		})
+	}
+}

--- a/internal/api/handlers/handler.go
+++ b/internal/api/handlers/handler.go
@@ -20,13 +20,23 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+
 	"github.com/pnz1990/kro-ui/internal/api/types"
 	k8sclient "github.com/pnz1990/kro-ui/internal/k8s"
 )
 
+// k8sClients provides access to the Kubernetes dynamic and discovery clients.
+// Defined at the consumption site per constitution §VI.
+type k8sClients interface {
+	Dynamic() dynamic.Interface
+	Discovery() discovery.DiscoveryInterface
+}
+
 // Handler holds shared dependencies for all route handlers.
 type Handler struct {
-	factory *k8sclient.ClientFactory
+	factory k8sClients
 	ctxMgr  contextManager
 }
 

--- a/internal/api/handlers/handler_test.go
+++ b/internal/api/handlers/handler_test.go
@@ -15,10 +15,25 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
+
+	openapi_v2 "github.com/google/gnostic-models/openapiv2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/openapi"
+	restclient "k8s.io/client-go/rest"
 
 	k8sclient "github.com/pnz1990/kro-ui/internal/k8s"
 )
+
+// --- Context stubs (used by contexts_test.go) ---
 
 // stubClientFactory is a hand-written stub for testing context handlers.
 // It implements the contextManager interface without needing a real cluster.
@@ -57,4 +72,243 @@ func (s *stubClientFactory) ActiveContext() string {
 // newTestHandler creates a Handler backed by a stubClientFactory for testing.
 func newTestHandler(stub *stubClientFactory) *Handler {
 	return &Handler{ctxMgr: stub}
+}
+
+// --- Dynamic + Discovery stubs (used by rgds_test.go, discover_test.go) ---
+
+// stubK8sClients implements k8sClients and provides stub dynamic + discovery clients.
+type stubK8sClients struct {
+	dyn  *stubDynamic
+	disc *stubDiscovery
+}
+
+func (s *stubK8sClients) Dynamic() dynamic.Interface              { return s.dyn }
+func (s *stubK8sClients) Discovery() discovery.DiscoveryInterface { return s.disc }
+
+// newRGDTestHandler creates a Handler with stub dynamic and discovery clients.
+func newRGDTestHandler(dyn *stubDynamic, disc *stubDiscovery) *Handler {
+	return &Handler{
+		factory: &stubK8sClients{dyn: dyn, disc: disc},
+	}
+}
+
+// --- stubDynamic implements dynamic.Interface ---
+
+// stubDynamic routes Resource() calls to per-GVR stubNamespaceableResource instances.
+type stubDynamic struct {
+	resources map[schema.GroupVersionResource]*stubNamespaceableResource
+}
+
+func newStubDynamic() *stubDynamic {
+	return &stubDynamic{resources: make(map[schema.GroupVersionResource]*stubNamespaceableResource)}
+}
+
+func (s *stubDynamic) Resource(gvr schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	if r, ok := s.resources[gvr]; ok {
+		return r
+	}
+	// Return a stub that always errors for unknown GVRs.
+	return &stubNamespaceableResource{
+		listErr: fmt.Errorf("resource %v not found", gvr),
+		getErr:  fmt.Errorf("resource %v not found", gvr),
+	}
+}
+
+// --- stubNamespaceableResource implements dynamic.NamespaceableResourceInterface ---
+
+// stubNamespaceableResource provides both cluster-scoped and namespaced results.
+type stubNamespaceableResource struct {
+	items       []unstructured.Unstructured           // items returned by List (cluster-wide)
+	getItems    map[string]*unstructured.Unstructured // name → object for Get
+	listErr     error
+	getErr      error
+	nsResources map[string]*stubResourceClient // namespace → namespaced stub
+}
+
+func (s *stubNamespaceableResource) Namespace(ns string) dynamic.ResourceInterface {
+	if s.nsResources != nil {
+		if r, ok := s.nsResources[ns]; ok {
+			return r
+		}
+	}
+	// Return a default namespaced client that uses the same data.
+	return &stubResourceClient{
+		items:    s.items,
+		getItems: s.getItems,
+		listErr:  s.listErr,
+		getErr:   s.getErr,
+	}
+}
+
+// Cluster-scoped List/Get — delegate to inline data.
+func (s *stubNamespaceableResource) List(_ context.Context, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return &unstructured.UnstructuredList{Items: s.items}, nil
+}
+
+func (s *stubNamespaceableResource) Get(_ context.Context, name string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	if s.getItems != nil {
+		if obj, ok := s.getItems[name]; ok {
+			return obj, nil
+		}
+	}
+	return nil, fmt.Errorf("not found: %s", name)
+}
+
+// Unused mutating methods — panics are fine since read-only per constitution.
+func (s *stubNamespaceableResource) Create(context.Context, *unstructured.Unstructured, metav1.CreateOptions, ...string) (*unstructured.Unstructured, error) {
+	panic("read-only stub")
+}
+func (s *stubNamespaceableResource) Update(context.Context, *unstructured.Unstructured, metav1.UpdateOptions, ...string) (*unstructured.Unstructured, error) {
+	panic("read-only stub")
+}
+func (s *stubNamespaceableResource) UpdateStatus(context.Context, *unstructured.Unstructured, metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	panic("read-only stub")
+}
+func (s *stubNamespaceableResource) Delete(context.Context, string, metav1.DeleteOptions, ...string) error {
+	panic("read-only stub")
+}
+func (s *stubNamespaceableResource) DeleteCollection(context.Context, metav1.DeleteOptions, metav1.ListOptions) error {
+	panic("read-only stub")
+}
+func (s *stubNamespaceableResource) Watch(context.Context, metav1.ListOptions) (watch.Interface, error) {
+	panic("read-only stub")
+}
+func (s *stubNamespaceableResource) Patch(context.Context, string, types.PatchType, []byte, metav1.PatchOptions, ...string) (*unstructured.Unstructured, error) {
+	panic("read-only stub")
+}
+func (s *stubNamespaceableResource) Apply(context.Context, string, *unstructured.Unstructured, metav1.ApplyOptions, ...string) (*unstructured.Unstructured, error) {
+	panic("read-only stub")
+}
+func (s *stubNamespaceableResource) ApplyStatus(context.Context, string, *unstructured.Unstructured, metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	panic("read-only stub")
+}
+
+// --- stubResourceClient implements dynamic.ResourceInterface (namespaced) ---
+
+type stubResourceClient struct {
+	items    []unstructured.Unstructured
+	getItems map[string]*unstructured.Unstructured
+	listErr  error
+	getErr   error
+}
+
+func (s *stubResourceClient) List(_ context.Context, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return &unstructured.UnstructuredList{Items: s.items}, nil
+}
+
+func (s *stubResourceClient) Get(_ context.Context, name string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	if s.getItems != nil {
+		if obj, ok := s.getItems[name]; ok {
+			return obj, nil
+		}
+	}
+	return nil, fmt.Errorf("not found: %s", name)
+}
+
+func (s *stubResourceClient) Create(context.Context, *unstructured.Unstructured, metav1.CreateOptions, ...string) (*unstructured.Unstructured, error) {
+	panic("read-only stub")
+}
+func (s *stubResourceClient) Update(context.Context, *unstructured.Unstructured, metav1.UpdateOptions, ...string) (*unstructured.Unstructured, error) {
+	panic("read-only stub")
+}
+func (s *stubResourceClient) UpdateStatus(context.Context, *unstructured.Unstructured, metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	panic("read-only stub")
+}
+func (s *stubResourceClient) Delete(context.Context, string, metav1.DeleteOptions, ...string) error {
+	panic("read-only stub")
+}
+func (s *stubResourceClient) DeleteCollection(context.Context, metav1.DeleteOptions, metav1.ListOptions) error {
+	panic("read-only stub")
+}
+func (s *stubResourceClient) Watch(context.Context, metav1.ListOptions) (watch.Interface, error) {
+	panic("read-only stub")
+}
+func (s *stubResourceClient) Patch(context.Context, string, types.PatchType, []byte, metav1.PatchOptions, ...string) (*unstructured.Unstructured, error) {
+	panic("read-only stub")
+}
+func (s *stubResourceClient) Apply(context.Context, string, *unstructured.Unstructured, metav1.ApplyOptions, ...string) (*unstructured.Unstructured, error) {
+	panic("read-only stub")
+}
+func (s *stubResourceClient) ApplyStatus(context.Context, string, *unstructured.Unstructured, metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+	panic("read-only stub")
+}
+
+// --- stubDiscovery implements discovery.DiscoveryInterface ---
+
+// stubDiscovery provides canned responses for ServerResourcesForGroupVersion.
+type stubDiscovery struct {
+	resources map[string]*metav1.APIResourceList // groupVersion → resource list
+	err       error
+}
+
+func newStubDiscovery() *stubDiscovery {
+	return &stubDiscovery{resources: make(map[string]*metav1.APIResourceList)}
+}
+
+func (s *stubDiscovery) ServerResourcesForGroupVersion(gv string) (*metav1.APIResourceList, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	if rl, ok := s.resources[gv]; ok {
+		return rl, nil
+	}
+	return nil, fmt.Errorf("group version %q not found", gv)
+}
+
+// Minimal no-op implementations for the rest of DiscoveryInterface.
+func (s *stubDiscovery) RESTClient() restclient.Interface { return nil }
+func (s *stubDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+	return &metav1.APIGroupList{}, nil
+}
+func (s *stubDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return nil, nil, nil
+}
+func (s *stubDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return nil, nil
+}
+func (s *stubDiscovery) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	return nil, nil
+}
+func (s *stubDiscovery) ServerVersion() (*version.Info, error) {
+	return &version.Info{}, nil
+}
+func (s *stubDiscovery) OpenAPISchema() (*openapi_v2.Document, error) { return nil, nil }
+func (s *stubDiscovery) OpenAPIV3() openapi.Client                    { return nil }
+func (s *stubDiscovery) WithLegacy() discovery.DiscoveryInterface     { return s }
+
+// --- Test helpers ---
+
+// makeRGDObject creates an unstructured RGD object for testing.
+func makeRGDObject(name, kind, group, apiVersion string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "kro.run/v1alpha1",
+		"kind":       "ResourceGraphDefinition",
+		"metadata":   map[string]any{"name": name},
+		"spec": map[string]any{
+			"schema": map[string]any{},
+		},
+	}}
+	schema := obj.Object["spec"].(map[string]any)["schema"].(map[string]any)
+	if kind != "" {
+		schema["kind"] = kind
+	}
+	if group != "" {
+		schema["group"] = group
+	}
+	if apiVersion != "" {
+		schema["apiVersion"] = apiVersion
+	}
+	return obj
 }

--- a/internal/api/handlers/rgds.go
+++ b/internal/api/handlers/rgds.go
@@ -15,7 +15,6 @@
 package handlers
 
 import (
-	"context"
 	"net/http"
 	"strings"
 
@@ -34,9 +33,9 @@ var rgdGVR = schema.GroupVersionResource{
 
 // ListRGDs returns all ResourceGraphDefinitions in the cluster.
 func (h *Handler) ListRGDs(w http.ResponseWriter, r *http.Request) {
-	list, err := h.factory.Dynamic().Resource(rgdGVR).List(context.Background(), metav1.ListOptions{})
+	list, err := h.factory.Dynamic().Resource(rgdGVR).List(r.Context(), metav1.ListOptions{})
 	if err != nil {
-		respondError(w, http.StatusInternalServerError, err.Error())
+		respondError(w, http.StatusServiceUnavailable, "cluster unreachable: "+err.Error())
 		return
 	}
 	respond(w, http.StatusOK, list)
@@ -45,9 +44,9 @@ func (h *Handler) ListRGDs(w http.ResponseWriter, r *http.Request) {
 // GetRGD returns a single RGD by name.
 func (h *Handler) GetRGD(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
-	obj, err := h.factory.Dynamic().Resource(rgdGVR).Get(context.Background(), name, metav1.GetOptions{})
+	obj, err := h.factory.Dynamic().Resource(rgdGVR).Get(r.Context(), name, metav1.GetOptions{})
 	if err != nil {
-		respondError(w, http.StatusNotFound, err.Error())
+		respondError(w, http.StatusNotFound, "resourcegraphdefinition \""+name+"\" not found")
 		return
 	}
 	respond(w, http.StatusOK, obj)
@@ -61,7 +60,7 @@ func (h *Handler) ListInstances(w http.ResponseWriter, r *http.Request) {
 	namespace := r.URL.Query().Get("namespace")
 
 	// Fetch the RGD to resolve the generated CRD's kind and group.
-	rgd, err := h.factory.Dynamic().Resource(rgdGVR).Get(context.Background(), name, metav1.GetOptions{})
+	rgd, err := h.factory.Dynamic().Resource(rgdGVR).Get(r.Context(), name, metav1.GetOptions{})
 	if err != nil {
 		respondError(w, http.StatusNotFound, err.Error())
 		return
@@ -93,9 +92,9 @@ func (h *Handler) ListInstances(w http.ResponseWriter, r *http.Request) {
 
 	var list interface{}
 	if namespace != "" {
-		list, err = h.factory.Dynamic().Resource(gvr).Namespace(namespace).List(context.Background(), metav1.ListOptions{})
+		list, err = h.factory.Dynamic().Resource(gvr).Namespace(namespace).List(r.Context(), metav1.ListOptions{})
 	} else {
-		list, err = h.factory.Dynamic().Resource(gvr).List(context.Background(), metav1.ListOptions{})
+		list, err = h.factory.Dynamic().Resource(gvr).List(r.Context(), metav1.ListOptions{})
 	}
 	if err != nil {
 		respondError(w, http.StatusInternalServerError, err.Error())

--- a/internal/api/handlers/rgds_test.go
+++ b/internal/api/handlers/rgds_test.go
@@ -1,0 +1,451 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	k8sclient "github.com/pnz1990/kro-ui/internal/k8s"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestListRGDs(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(t *testing.T) *Handler
+		check func(t *testing.T, rr *httptest.ResponseRecorder)
+	}{
+		{
+			name: "returns 200 with items array when RGDs exist",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				dyn := newStubDynamic()
+				dyn.resources[rgdGVR] = &stubNamespaceableResource{
+					items: []unstructured.Unstructured{
+						*makeRGDObject("web-app", "WebApp", "", ""),
+						*makeRGDObject("database", "Database", "", ""),
+					},
+				}
+				return newRGDTestHandler(dyn, newStubDiscovery())
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"items"`)
+				assert.Contains(t, body, `"web-app"`)
+				assert.Contains(t, body, `"database"`)
+			},
+		},
+		{
+			name: "returns 200 with empty items when no RGDs",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				dyn := newStubDynamic()
+				dyn.resources[rgdGVR] = &stubNamespaceableResource{
+					items: []unstructured.Unstructured{},
+				}
+				return newRGDTestHandler(dyn, newStubDiscovery())
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"items"`)
+				// Must not be an error — empty list is a valid response.
+				assert.NotContains(t, body, `"error"`)
+			},
+		},
+		{
+			name: "returns 503 when cluster unreachable",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				dyn := newStubDynamic()
+				dyn.resources[rgdGVR] = &stubNamespaceableResource{
+					listErr: fmt.Errorf("connection refused"),
+				}
+				return newRGDTestHandler(dyn, newStubDiscovery())
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusServiceUnavailable, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"error"`)
+				assert.Contains(t, body, "cluster unreachable")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := tt.build(t)
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/rgds", nil)
+			rr := httptest.NewRecorder()
+			h.ListRGDs(rr, req)
+			tt.check(t, rr)
+		})
+	}
+}
+
+func TestGetRGD(t *testing.T) {
+	tests := []struct {
+		name    string
+		rgdName string
+		build   func(t *testing.T) *Handler
+		check   func(t *testing.T, rr *httptest.ResponseRecorder)
+	}{
+		{
+			name:    "returns 200 for existing RGD",
+			rgdName: "web-service-graph",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				rgdObj := makeRGDObject("web-service-graph", "WebService", "", "")
+				dyn := newStubDynamic()
+				dyn.resources[rgdGVR] = &stubNamespaceableResource{
+					getItems: map[string]*unstructured.Unstructured{
+						"web-service-graph": rgdObj,
+					},
+				}
+				return newRGDTestHandler(dyn, newStubDiscovery())
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"web-service-graph"`)
+				assert.Contains(t, body, `"WebService"`)
+			},
+		},
+		{
+			name:    "returns 404 for unknown RGD",
+			rgdName: "does-not-exist",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				dyn := newStubDynamic()
+				dyn.resources[rgdGVR] = &stubNamespaceableResource{
+					getItems: map[string]*unstructured.Unstructured{},
+				}
+				return newRGDTestHandler(dyn, newStubDiscovery())
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusNotFound, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"error"`)
+				assert.Contains(t, body, "does-not-exist")
+				assert.Contains(t, body, "not found")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := tt.build(t)
+
+			// Use chi router to inject URL params.
+			r := chi.NewRouter()
+			r.Get("/api/v1/rgds/{name}", h.GetRGD)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/rgds/"+tt.rgdName, nil)
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+			tt.check(t, rr)
+		})
+	}
+}
+
+func TestListInstances(t *testing.T) {
+	// Common GVR for the TestApp kind resolved by discovery.
+	testAppGVR := schema.GroupVersionResource{
+		Group:    k8sclient.KroGroup,
+		Version:  "v1alpha1",
+		Resource: "testapps",
+	}
+
+	tests := []struct {
+		name    string
+		rgdName string
+		query   string
+		build   func(t *testing.T) *Handler
+		check   func(t *testing.T, rr *httptest.ResponseRecorder)
+	}{
+		{
+			name:    "returns instances across all namespaces",
+			rgdName: "test-app",
+			query:   "",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				rgdObj := makeRGDObject("test-app", "TestApp", "", "")
+
+				instance := &unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "kro.run/v1alpha1",
+					"kind":       "TestApp",
+					"metadata":   map[string]any{"name": "test-instance", "namespace": "default"},
+				}}
+
+				dyn := newStubDynamic()
+				dyn.resources[rgdGVR] = &stubNamespaceableResource{
+					getItems: map[string]*unstructured.Unstructured{"test-app": rgdObj},
+				}
+				dyn.resources[testAppGVR] = &stubNamespaceableResource{
+					items: []unstructured.Unstructured{*instance},
+				}
+
+				disc := newStubDiscovery()
+				disc.resources["kro.run/v1alpha1"] = &metav1.APIResourceList{
+					GroupVersion: "kro.run/v1alpha1",
+					APIResources: []metav1.APIResource{
+						{Name: "testapps", Kind: "TestApp", Verbs: metav1.Verbs{"get", "list"}},
+					},
+				}
+
+				return newRGDTestHandler(dyn, disc)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"items"`)
+				assert.Contains(t, body, `"test-instance"`)
+			},
+		},
+		{
+			name:    "filters by namespace when provided",
+			rgdName: "test-app",
+			query:   "?namespace=kro-ui-e2e",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				rgdObj := makeRGDObject("test-app", "TestApp", "", "")
+
+				nsInstance := &unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "kro.run/v1alpha1",
+					"kind":       "TestApp",
+					"metadata":   map[string]any{"name": "ns-instance", "namespace": "kro-ui-e2e"},
+				}}
+
+				dyn := newStubDynamic()
+				dyn.resources[rgdGVR] = &stubNamespaceableResource{
+					getItems: map[string]*unstructured.Unstructured{"test-app": rgdObj},
+				}
+				dyn.resources[testAppGVR] = &stubNamespaceableResource{
+					nsResources: map[string]*stubResourceClient{
+						"kro-ui-e2e": {
+							items: []unstructured.Unstructured{*nsInstance},
+						},
+					},
+				}
+
+				disc := newStubDiscovery()
+				disc.resources["kro.run/v1alpha1"] = &metav1.APIResourceList{
+					GroupVersion: "kro.run/v1alpha1",
+					APIResources: []metav1.APIResource{
+						{Name: "testapps", Kind: "TestApp", Verbs: metav1.Verbs{"get", "list"}},
+					},
+				}
+
+				return newRGDTestHandler(dyn, disc)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"items"`)
+				assert.Contains(t, body, `"ns-instance"`)
+			},
+		},
+		{
+			name:    "returns 422 when spec.schema.kind absent",
+			rgdName: "broken-rgd",
+			query:   "",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				// RGD exists but has no kind in spec.schema.
+				rgdObj := makeRGDObject("broken-rgd", "", "", "")
+
+				dyn := newStubDynamic()
+				dyn.resources[rgdGVR] = &stubNamespaceableResource{
+					getItems: map[string]*unstructured.Unstructured{"broken-rgd": rgdObj},
+				}
+				return newRGDTestHandler(dyn, newStubDiscovery())
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusUnprocessableEntity, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"error"`)
+				assert.Contains(t, body, "RGD has no spec.schema.kind")
+			},
+		},
+		{
+			name:    "falls back to naive plural on discovery failure",
+			rgdName: "test-app",
+			query:   "",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				rgdObj := makeRGDObject("test-app", "TestApp", "", "")
+
+				// The naive plural of "TestApp" is "testapps" — same GVR.
+				instance := &unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "kro.run/v1alpha1",
+					"kind":       "TestApp",
+					"metadata":   map[string]any{"name": "fallback-instance", "namespace": "default"},
+				}}
+
+				dyn := newStubDynamic()
+				dyn.resources[rgdGVR] = &stubNamespaceableResource{
+					getItems: map[string]*unstructured.Unstructured{"test-app": rgdObj},
+				}
+				dyn.resources[testAppGVR] = &stubNamespaceableResource{
+					items: []unstructured.Unstructured{*instance},
+				}
+
+				// Discovery fails — forces fallback to naive pluralization.
+				disc := newStubDiscovery()
+				disc.err = fmt.Errorf("discovery unavailable")
+
+				return newRGDTestHandler(dyn, disc)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"items"`)
+				assert.Contains(t, body, `"fallback-instance"`)
+			},
+		},
+		{
+			name:    "defaults group to kro.run when absent",
+			rgdName: "no-group-rgd",
+			query:   "",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				// RGD has kind but no group — should default to kro.run.
+				rgdObj := makeRGDObject("no-group-rgd", "MyKind", "", "")
+
+				instance := &unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "kro.run/v1alpha1",
+					"kind":       "MyKind",
+					"metadata":   map[string]any{"name": "default-group-instance"},
+				}}
+
+				// The expected GVR uses kro.run group (default).
+				defaultGVR := schema.GroupVersionResource{
+					Group:    k8sclient.KroGroup,
+					Version:  "v1alpha1",
+					Resource: "mykinds",
+				}
+
+				dyn := newStubDynamic()
+				dyn.resources[rgdGVR] = &stubNamespaceableResource{
+					getItems: map[string]*unstructured.Unstructured{"no-group-rgd": rgdObj},
+				}
+				dyn.resources[defaultGVR] = &stubNamespaceableResource{
+					items: []unstructured.Unstructured{*instance},
+				}
+
+				disc := newStubDiscovery()
+				disc.resources["kro.run/v1alpha1"] = &metav1.APIResourceList{
+					GroupVersion: "kro.run/v1alpha1",
+					APIResources: []metav1.APIResource{
+						{Name: "mykinds", Kind: "MyKind", Verbs: metav1.Verbs{"get", "list"}},
+					},
+				}
+
+				return newRGDTestHandler(dyn, disc)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"default-group-instance"`)
+			},
+		},
+		{
+			name:    "returns 404 when RGD not found",
+			rgdName: "nonexistent",
+			query:   "",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				dyn := newStubDynamic()
+				dyn.resources[rgdGVR] = &stubNamespaceableResource{
+					getItems: map[string]*unstructured.Unstructured{},
+				}
+				return newRGDTestHandler(dyn, newStubDiscovery())
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusNotFound, rr.Code)
+				assert.Contains(t, rr.Body.String(), `"error"`)
+			},
+		},
+		{
+			name:    "returns empty items when no instances exist",
+			rgdName: "test-app",
+			query:   "",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				rgdObj := makeRGDObject("test-app", "TestApp", "", "")
+
+				dyn := newStubDynamic()
+				dyn.resources[rgdGVR] = &stubNamespaceableResource{
+					getItems: map[string]*unstructured.Unstructured{"test-app": rgdObj},
+				}
+				dyn.resources[testAppGVR] = &stubNamespaceableResource{
+					items: []unstructured.Unstructured{},
+				}
+
+				disc := newStubDiscovery()
+				disc.resources["kro.run/v1alpha1"] = &metav1.APIResourceList{
+					GroupVersion: "kro.run/v1alpha1",
+					APIResources: []metav1.APIResource{
+						{Name: "testapps", Kind: "TestApp", Verbs: metav1.Verbs{"get", "list"}},
+					},
+				}
+
+				return newRGDTestHandler(dyn, disc)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"items"`)
+				assert.NotContains(t, body, `"error"`)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := tt.build(t)
+
+			r := chi.NewRouter()
+			r.Get("/api/v1/rgds/{name}/instances", h.ListInstances)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/rgds/"+tt.rgdName+"/instances"+tt.query, nil)
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+			tt.check(t, rr)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements spec `001b-rgd-api` — unit tests and correctness fixes for the three RGD API endpoints.

- **29 new unit tests** covering `ListRGDs`, `GetRGD`, `ListInstances`, `discoverPlural`, `unstructuredString`, and `isListable` — all passing with `-race`
- **Refactored** `Handler.factory` from concrete `*ClientFactory` to `k8sClients` interface (constitution §VI: define interfaces at consumption site), enabling stub-based testing without a real cluster
- **Fixed** `ListRGDs` to return **503** (not 500) with `"cluster unreachable: ..."` message per spec acceptance scenario 5
- **Fixed** `GetRGD` to return `resourcegraphdefinition "name" not found` per spec scenario 4
- **Fixed** all handlers to use `r.Context()` instead of `context.Background()`
- **Added** `.dockerignore` for cleaner Docker builds

## Test Coverage vs Spec Acceptance Scenarios

| Spec Scenario | Test |
|---|---|
| GET /rgds returns items | `TestListRGDs/returns_200_with_items_array_when_RGDs_exist` |
| GET /rgds empty → `{"items":[]}` | `TestListRGDs/returns_200_with_empty_items_when_no_RGDs` |
| Cluster unreachable → 503 | `TestListRGDs/returns_503_when_cluster_unreachable` |
| GET /rgds/{name} → 200 | `TestGetRGD/returns_200_for_existing_RGD` |
| GET /rgds/{name} → 404 | `TestGetRGD/returns_404_for_unknown_RGD` |
| spec.schema.kind absent → 422 | `TestListInstances/returns_422_when_spec.schema.kind_absent` |
| Discovery fallback to naive plural | `TestListInstances/falls_back_to_naive_plural_on_discovery_failure` |
| ?namespace= filter | `TestListInstances/filters_by_namespace_when_provided` |
| Default group = kro.run | `TestListInstances/defaults_group_to_kro.run_when_absent` |
| Discovery before naive plural | `TestDiscoverPlural/discovers_correct_plural_from_discovery_API` |

Closes #2