### PR TITLE
feat(api): implement spec 001c-instance-api — instance endpoint fixes and tests

### DIFF
--- a/.specify/specs/001c-instance-api/tasks.md
+++ b/.specify/specs/001c-instance-api/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: 001c-instance-api
+
+## Phase 1 — Code Fixes
+
+- [x] 1.1 Fix `GetResource` to treat `_` in `{group}` path segment as core (empty) group (FR-005)
+- [x] 1.2 Fix `GetMetrics` stub message to match spec: `"metrics integration not yet implemented (phase 2)"`
+
+## Phase 2 — Test Infrastructure
+
+- [x] 2.1 Enhance `stubDiscovery.ServerGroupsAndResources()` to return canned API resource lists from the `resources` map
+- [x] 2.2 Add `labelItems` field to `stubResourceClient` to support label-selector filtering for children tests
+
+## Phase 3 — Unit Tests
+
+- [x] 3.1 Create `instances_test.go` with table-driven tests for `GetInstance`
+  - Returns 400 when `?rgd=` is missing
+  - Returns 404 for unknown instance
+  - Returns 200 for valid instance
+- [x] 3.2 Add table-driven tests for `GetInstanceEvents`
+  - Returns 200 with events
+  - Returns 200 with empty items when no events
+- [x] 3.3 Add table-driven tests for `GetInstanceChildren`
+  - Returns 200 with children
+  - Skips subresources
+  - Skips non-listable resources
+  - Returns empty items when no matches
+- [x] 3.4 Add table-driven tests for `GetResource`
+  - Returns 200 for valid resource
+  - Treats `_` group as core group
+  - Returns 404 for missing resource
+- [x] 3.5 Add test for `GetMetrics` always returns 501
+
+## Phase 4 — Verify
+
+- [x] 4.1 Run `go vet ./...` — must pass clean
+- [x] 4.2 Run `go test -race ./internal/...` — all tests pass
+- [x] 4.3 Mark tasks complete, commit

--- a/internal/api/handlers/handler_test.go
+++ b/internal/api/handlers/handler_test.go
@@ -192,15 +192,23 @@ func (s *stubNamespaceableResource) ApplyStatus(context.Context, string, *unstru
 // --- stubResourceClient implements dynamic.ResourceInterface (namespaced) ---
 
 type stubResourceClient struct {
-	items    []unstructured.Unstructured
-	getItems map[string]*unstructured.Unstructured
-	listErr  error
-	getErr   error
+	items      []unstructured.Unstructured
+	getItems   map[string]*unstructured.Unstructured
+	labelItems map[string][]unstructured.Unstructured // label selector → items
+	listErr    error
+	getErr     error
 }
 
-func (s *stubResourceClient) List(_ context.Context, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+func (s *stubResourceClient) List(_ context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	if s.listErr != nil {
 		return nil, s.listErr
+	}
+	// If a label selector is present and labelItems is populated, return filtered results.
+	if opts.LabelSelector != "" && s.labelItems != nil {
+		if items, ok := s.labelItems[opts.LabelSelector]; ok {
+			return &unstructured.UnstructuredList{Items: items}, nil
+		}
+		return &unstructured.UnstructuredList{Items: nil}, nil
 	}
 	return &unstructured.UnstructuredList{Items: s.items}, nil
 }
@@ -273,7 +281,14 @@ func (s *stubDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
 	return &metav1.APIGroupList{}, nil
 }
 func (s *stubDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
-	return nil, nil, nil
+	if s.err != nil {
+		return nil, nil, s.err
+	}
+	var lists []*metav1.APIResourceList
+	for _, rl := range s.resources {
+		lists = append(lists, rl)
+	}
+	return nil, lists, nil
 }
 func (s *stubDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
 	return nil, nil

--- a/internal/api/handlers/instances.go
+++ b/internal/api/handlers/instances.go
@@ -81,12 +81,19 @@ func (h *Handler) GetInstanceChildren(w http.ResponseWriter, r *http.Request) {
 
 // GetResource returns the raw unstructured YAML/JSON for any resource.
 // This is used by the frontend for node YAML inspection — works for any k8s kind.
+// The {group} path segment uses "_" to represent the core (empty) API group,
+// since chi cannot route an empty path segment.
 func (h *Handler) GetResource(w http.ResponseWriter, r *http.Request) {
 	namespace := chi.URLParam(r, "namespace")
 	group := chi.URLParam(r, "group")
 	version := chi.URLParam(r, "version")
 	kind := chi.URLParam(r, "kind")
 	name := chi.URLParam(r, "name")
+
+	// Treat "_" as the core (empty) API group — chi cannot route empty segments.
+	if group == "_" {
+		group = ""
+	}
 
 	plural, err := discoverPlural(h.factory, group, version, kind)
 	if err != nil {
@@ -104,5 +111,5 @@ func (h *Handler) GetResource(w http.ResponseWriter, r *http.Request) {
 
 // GetMetrics is a stub — returns 501 until phase 2 implements Prometheus integration.
 func (h *Handler) GetMetrics(w http.ResponseWriter, r *http.Request) {
-	respondError(w, http.StatusNotImplemented, "metrics integration coming in phase 2")
+	respondError(w, http.StatusNotImplemented, "metrics integration not yet implemented (phase 2)")
 }

--- a/internal/api/handlers/instances_test.go
+++ b/internal/api/handlers/instances_test.go
@@ -1,0 +1,628 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	k8sclient "github.com/pnz1990/kro-ui/internal/k8s"
+)
+
+func TestGetInstance(t *testing.T) {
+	// Common GVR for the TestApp kind resolved by discovery.
+	testAppGVR := schema.GroupVersionResource{
+		Group:    k8sclient.KroGroup,
+		Version:  "v1alpha1",
+		Resource: "testapps",
+	}
+
+	tests := []struct {
+		name  string
+		ns    string
+		iname string
+		query string
+		build func(t *testing.T) *Handler
+		check func(t *testing.T, rr *httptest.ResponseRecorder)
+	}{
+		{
+			name:  "returns 400 when rgd param missing",
+			ns:    "default",
+			iname: "test-instance",
+			query: "",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				dyn := newStubDynamic()
+				return newRGDTestHandler(dyn, newStubDiscovery())
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusBadRequest, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"error"`)
+				assert.Contains(t, body, "rgd query param required")
+			},
+		},
+		{
+			name:  "returns 404 for unknown instance",
+			ns:    "default",
+			iname: "does-not-exist",
+			query: "?rgd=test-app",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				rgdObj := makeRGDObject("test-app", "TestApp", "", "")
+
+				dyn := newStubDynamic()
+				dyn.resources[rgdGVR] = &stubNamespaceableResource{
+					getItems: map[string]*unstructured.Unstructured{"test-app": rgdObj},
+				}
+				// TestApp GVR exists but has no instances.
+				dyn.resources[testAppGVR] = &stubNamespaceableResource{
+					nsResources: map[string]*stubResourceClient{
+						"default": {
+							getItems: map[string]*unstructured.Unstructured{},
+						},
+					},
+				}
+
+				disc := newStubDiscovery()
+				disc.resources["kro.run/v1alpha1"] = &metav1.APIResourceList{
+					GroupVersion: "kro.run/v1alpha1",
+					APIResources: []metav1.APIResource{
+						{Name: "testapps", Kind: "TestApp", Verbs: metav1.Verbs{"get", "list"}},
+					},
+				}
+
+				return newRGDTestHandler(dyn, disc)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusNotFound, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"error"`)
+				assert.Contains(t, body, "not found")
+			},
+		},
+		{
+			name:  "returns 200 for valid instance",
+			ns:    "kro-ui-e2e",
+			iname: "test-instance",
+			query: "?rgd=test-app",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				rgdObj := makeRGDObject("test-app", "TestApp", "", "")
+
+				instance := &unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "kro.run/v1alpha1",
+					"kind":       "TestApp",
+					"metadata":   map[string]any{"name": "test-instance", "namespace": "kro-ui-e2e"},
+					"spec":       map[string]any{"replicas": int64(3)},
+					"status":     map[string]any{"ready": true},
+				}}
+
+				dyn := newStubDynamic()
+				dyn.resources[rgdGVR] = &stubNamespaceableResource{
+					getItems: map[string]*unstructured.Unstructured{"test-app": rgdObj},
+				}
+				dyn.resources[testAppGVR] = &stubNamespaceableResource{
+					nsResources: map[string]*stubResourceClient{
+						"kro-ui-e2e": {
+							getItems: map[string]*unstructured.Unstructured{
+								"test-instance": instance,
+							},
+						},
+					},
+				}
+
+				disc := newStubDiscovery()
+				disc.resources["kro.run/v1alpha1"] = &metav1.APIResourceList{
+					GroupVersion: "kro.run/v1alpha1",
+					APIResources: []metav1.APIResource{
+						{Name: "testapps", Kind: "TestApp", Verbs: metav1.Verbs{"get", "list"}},
+					},
+				}
+
+				return newRGDTestHandler(dyn, disc)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"test-instance"`)
+				assert.Contains(t, body, `"kro-ui-e2e"`)
+				assert.Contains(t, body, `"TestApp"`)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := tt.build(t)
+
+			r := chi.NewRouter()
+			r.Get("/api/v1/instances/{namespace}/{name}", h.GetInstance)
+
+			req := httptest.NewRequest(http.MethodGet,
+				"/api/v1/instances/"+tt.ns+"/"+tt.iname+tt.query, nil)
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+			tt.check(t, rr)
+		})
+	}
+}
+
+func TestGetInstanceEvents(t *testing.T) {
+	eventsGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "events"}
+
+	tests := []struct {
+		name  string
+		ns    string
+		iname string
+		build func(t *testing.T) *Handler
+		check func(t *testing.T, rr *httptest.ResponseRecorder)
+	}{
+		{
+			name:  "returns 200 with events",
+			ns:    "kro-ui-e2e",
+			iname: "test-instance",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				event := unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "Event",
+					"metadata":   map[string]any{"name": "test-instance.17a2b3c", "namespace": "kro-ui-e2e"},
+					"involvedObject": map[string]any{
+						"name":      "test-instance",
+						"namespace": "kro-ui-e2e",
+					},
+					"reason":  "Reconciled",
+					"message": "Successfully reconciled",
+				}}
+
+				dyn := newStubDynamic()
+				dyn.resources[eventsGVR] = &stubNamespaceableResource{
+					nsResources: map[string]*stubResourceClient{
+						"kro-ui-e2e": {
+							items: []unstructured.Unstructured{event},
+						},
+					},
+				}
+
+				return newRGDTestHandler(dyn, newStubDiscovery())
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"items"`)
+				assert.Contains(t, body, `"Reconciled"`)
+				assert.Contains(t, body, `"test-instance"`)
+			},
+		},
+		{
+			name:  "returns 200 with empty items when no events",
+			ns:    "kro-ui-e2e",
+			iname: "test-instance",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				dyn := newStubDynamic()
+				dyn.resources[eventsGVR] = &stubNamespaceableResource{
+					nsResources: map[string]*stubResourceClient{
+						"kro-ui-e2e": {
+							items: []unstructured.Unstructured{},
+						},
+					},
+				}
+
+				return newRGDTestHandler(dyn, newStubDiscovery())
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"items"`)
+				assert.NotContains(t, body, `"error"`)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := tt.build(t)
+
+			r := chi.NewRouter()
+			r.Get("/api/v1/instances/{namespace}/{name}/events", h.GetInstanceEvents)
+
+			req := httptest.NewRequest(http.MethodGet,
+				"/api/v1/instances/"+tt.ns+"/"+tt.iname+"/events", nil)
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+			tt.check(t, rr)
+		})
+	}
+}
+
+func TestGetInstanceChildren(t *testing.T) {
+	tests := []struct {
+		name  string
+		ns    string
+		iname string
+		query string
+		build func(t *testing.T) *Handler
+		check func(t *testing.T, rr *httptest.ResponseRecorder)
+	}{
+		{
+			name:  "returns 200 with children",
+			ns:    "kro-ui-e2e",
+			iname: "test-instance",
+			query: "?rgd=test-app",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				configMap := unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]any{
+						"name":      "kro-ui-test-config",
+						"namespace": "kro-ui-e2e",
+						"labels": map[string]any{
+							"kro.run/instance-name": "test-instance",
+						},
+					},
+				}}
+
+				configMapGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+				dyn := newStubDynamic()
+				dyn.resources[configMapGVR] = &stubNamespaceableResource{
+					nsResources: map[string]*stubResourceClient{
+						"kro-ui-e2e": {
+							labelItems: map[string][]unstructured.Unstructured{
+								"kro.run/instance-name=test-instance": {configMap},
+							},
+						},
+					},
+				}
+
+				disc := newStubDiscovery()
+				disc.resources["v1"] = &metav1.APIResourceList{
+					GroupVersion: "v1",
+					APIResources: []metav1.APIResource{
+						{Name: "configmaps", Kind: "ConfigMap", Verbs: metav1.Verbs{"get", "list", "watch"}},
+					},
+				}
+
+				return newRGDTestHandler(dyn, disc)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"items"`)
+				assert.Contains(t, body, `"kro-ui-test-config"`)
+				assert.Contains(t, body, `"ConfigMap"`)
+			},
+		},
+		{
+			name:  "skips subresources",
+			ns:    "kro-ui-e2e",
+			iname: "test-instance",
+			query: "?rgd=test-app",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				// Only register a subresource (pods/status) — should be skipped.
+				dyn := newStubDynamic()
+
+				disc := newStubDiscovery()
+				disc.resources["v1"] = &metav1.APIResourceList{
+					GroupVersion: "v1",
+					APIResources: []metav1.APIResource{
+						{Name: "pods/status", Kind: "Pod", Verbs: metav1.Verbs{"get", "list"}},
+					},
+				}
+
+				return newRGDTestHandler(dyn, disc)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"items"`)
+				// The items array should be empty or null since subresources are skipped.
+				assert.NotContains(t, body, `"Pod"`)
+			},
+		},
+		{
+			name:  "skips non-listable resources",
+			ns:    "kro-ui-e2e",
+			iname: "test-instance",
+			query: "?rgd=test-app",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				dyn := newStubDynamic()
+
+				disc := newStubDiscovery()
+				disc.resources["v1"] = &metav1.APIResourceList{
+					GroupVersion: "v1",
+					APIResources: []metav1.APIResource{
+						// Only supports "get" — not listable.
+						{Name: "secrets", Kind: "Secret", Verbs: metav1.Verbs{"get"}},
+					},
+				}
+
+				return newRGDTestHandler(dyn, disc)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"items"`)
+				// No Secret should appear since it's not listable.
+				assert.NotContains(t, body, `"Secret"`)
+			},
+		},
+		{
+			name:  "returns empty items when no matches",
+			ns:    "kro-ui-e2e",
+			iname: "test-instance",
+			query: "?rgd=test-app",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				configMapGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+				dyn := newStubDynamic()
+				dyn.resources[configMapGVR] = &stubNamespaceableResource{
+					nsResources: map[string]*stubResourceClient{
+						"kro-ui-e2e": {
+							labelItems: map[string][]unstructured.Unstructured{
+								"kro.run/instance-name=test-instance": {},
+							},
+						},
+					},
+				}
+
+				disc := newStubDiscovery()
+				disc.resources["v1"] = &metav1.APIResourceList{
+					GroupVersion: "v1",
+					APIResources: []metav1.APIResource{
+						{Name: "configmaps", Kind: "ConfigMap", Verbs: metav1.Verbs{"get", "list"}},
+					},
+				}
+
+				return newRGDTestHandler(dyn, disc)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"items"`)
+				assert.NotContains(t, body, `"error"`)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := tt.build(t)
+
+			r := chi.NewRouter()
+			r.Get("/api/v1/instances/{namespace}/{name}/children", h.GetInstanceChildren)
+
+			req := httptest.NewRequest(http.MethodGet,
+				"/api/v1/instances/"+tt.ns+"/"+tt.iname+"/children"+tt.query, nil)
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+			tt.check(t, rr)
+		})
+	}
+}
+
+func TestGetResource(t *testing.T) {
+	tests := []struct {
+		name    string
+		ns      string
+		group   string
+		version string
+		kind    string
+		rname   string
+		build   func(t *testing.T) *Handler
+		check   func(t *testing.T, rr *httptest.ResponseRecorder)
+	}{
+		{
+			name:    "returns 200 for valid resource",
+			ns:      "kro-ui-e2e",
+			group:   "apps",
+			version: "v1",
+			kind:    "Deployment",
+			rname:   "my-deploy",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				deploy := &unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "apps/v1",
+					"kind":       "Deployment",
+					"metadata":   map[string]any{"name": "my-deploy", "namespace": "kro-ui-e2e"},
+				}}
+
+				deployGVR := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+				dyn := newStubDynamic()
+				dyn.resources[deployGVR] = &stubNamespaceableResource{
+					nsResources: map[string]*stubResourceClient{
+						"kro-ui-e2e": {
+							getItems: map[string]*unstructured.Unstructured{
+								"my-deploy": deploy,
+							},
+						},
+					},
+				}
+
+				disc := newStubDiscovery()
+				disc.resources["apps/v1"] = &metav1.APIResourceList{
+					GroupVersion: "apps/v1",
+					APIResources: []metav1.APIResource{
+						{Name: "deployments", Kind: "Deployment", Verbs: metav1.Verbs{"get", "list"}},
+					},
+				}
+
+				return newRGDTestHandler(dyn, disc)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"my-deploy"`)
+				assert.Contains(t, body, `"Deployment"`)
+			},
+		},
+		{
+			name:    "treats _ group as core group",
+			ns:      "kro-ui-e2e",
+			group:   "_",
+			version: "v1",
+			kind:    "ConfigMap",
+			rname:   "my-config",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				cm := &unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata":   map[string]any{"name": "my-config", "namespace": "kro-ui-e2e"},
+				}}
+
+				// Core group GVR has empty group string.
+				coreGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}
+				dyn := newStubDynamic()
+				dyn.resources[coreGVR] = &stubNamespaceableResource{
+					nsResources: map[string]*stubResourceClient{
+						"kro-ui-e2e": {
+							getItems: map[string]*unstructured.Unstructured{
+								"my-config": cm,
+							},
+						},
+					},
+				}
+
+				disc := newStubDiscovery()
+				// Core group uses just "v1" as the group version string.
+				disc.resources["v1"] = &metav1.APIResourceList{
+					GroupVersion: "v1",
+					APIResources: []metav1.APIResource{
+						{Name: "configmaps", Kind: "ConfigMap", Verbs: metav1.Verbs{"get", "list"}},
+					},
+				}
+
+				return newRGDTestHandler(dyn, disc)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"my-config"`)
+				assert.Contains(t, body, `"ConfigMap"`)
+			},
+		},
+		{
+			name:    "returns 404 for missing resource",
+			ns:      "default",
+			group:   "apps",
+			version: "v1",
+			kind:    "Deployment",
+			rname:   "nonexistent",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				deployGVR := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+				dyn := newStubDynamic()
+				dyn.resources[deployGVR] = &stubNamespaceableResource{
+					nsResources: map[string]*stubResourceClient{
+						"default": {
+							getItems: map[string]*unstructured.Unstructured{},
+						},
+					},
+				}
+
+				disc := newStubDiscovery()
+				disc.resources["apps/v1"] = &metav1.APIResourceList{
+					GroupVersion: "apps/v1",
+					APIResources: []metav1.APIResource{
+						{Name: "deployments", Kind: "Deployment", Verbs: metav1.Verbs{"get", "list"}},
+					},
+				}
+
+				return newRGDTestHandler(dyn, disc)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusNotFound, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"error"`)
+				assert.Contains(t, body, "not found")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := tt.build(t)
+
+			r := chi.NewRouter()
+			r.Get("/api/v1/resources/{namespace}/{group}/{version}/{kind}/{name}", h.GetResource)
+
+			url := fmt.Sprintf("/api/v1/resources/%s/%s/%s/%s/%s",
+				tt.ns, tt.group, tt.version, tt.kind, tt.rname)
+			req := httptest.NewRequest(http.MethodGet, url, nil)
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+			tt.check(t, rr)
+		})
+	}
+}
+
+func TestGetMetrics(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(t *testing.T) *Handler
+		check func(t *testing.T, rr *httptest.ResponseRecorder)
+	}{
+		{
+			name: "always returns 501",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				return newRGDTestHandler(newStubDynamic(), newStubDiscovery())
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusNotImplemented, rr.Code)
+				body := rr.Body.String()
+				assert.Contains(t, body, `"error"`)
+				assert.Contains(t, body, "metrics integration not yet implemented (phase 2)")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := tt.build(t)
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/metrics", nil)
+			rr := httptest.NewRecorder()
+			h.GetMetrics(rr, req)
+			tt.check(t, rr)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fix `GetResource` to treat `_` in `{group}` path segment as the core (empty) API group (FR-005), since chi cannot route empty path segments
- Fix `GetMetrics` stub message to match spec: `"metrics integration not yet implemented (phase 2)"`
- Enhance test infrastructure: `stubDiscovery.ServerGroupsAndResources()` returns canned API resource lists; `stubResourceClient` supports label-selector filtering via `labelItems` field
- Add 13 table-driven unit tests in `instances_test.go` covering all 5 instance handlers (`GetInstance`, `GetInstanceEvents`, `GetInstanceChildren`, `GetResource`, `GetMetrics`)

## Test Results

All 44 tests pass with `go test -race ./internal/...` (31 existing + 13 new).

| Test | Cases |
|------|-------|
| `TestGetInstance` | 400 missing rgd, 404 unknown, 200 valid |
| `TestGetInstanceEvents` | 200 with events, 200 empty items |
| `TestGetInstanceChildren` | 200 with children, skips subresources, skips non-listable, empty items |
| `TestGetResource` | 200 valid, `_` → core group, 404 missing |
| `TestGetMetrics` | always 501 |

## Spec Reference

Implements [spec 001c-instance-api](https://github.com/pnz1990/kro-ui/issues/3).
Depends on: `001b-rgd-api` (merged). Unblocks: `004-instance-list`, `005-instance-detail-live`.