### PR TITLE
fix(e2e): replace shell execSync with execFileSync to prevent injection

### DIFF
--- a/test/e2e/setup/global-setup.ts
+++ b/test/e2e/setup/global-setup.ts
@@ -35,7 +35,7 @@
  */
 
 import { execFileSync, execSync, spawn, ChildProcess } from 'node:child_process'
-import { existsSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { resolve, join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { tmpdir } from 'node:os'
@@ -53,7 +53,8 @@ const FIXTURES_DIR = resolve(__dirname, '../fixtures')
 const ROOT_DIR = resolve(__dirname, '../../..')
 
 // Shared kubeconfig path written by setup, read by teardown and all tests.
-const KUBECONFIG_PATH = join(tmpdir(), 'kro-ui-e2e-kubeconfig.yaml')
+// Uses a randomly-named temp directory to avoid predictable-path (TOCTOU) attacks.
+const KUBECONFIG_PATH = join(mkdtempSync(join(tmpdir(), 'kro-ui-e2e-')), 'kubeconfig.yaml')
 
 /** Semver pattern — only digits and dots. Used to validate KRO_CHART_VERSION. */
 const SEMVER_RE = /^\d+\.\d+\.\d+$/


### PR DESCRIPTION
## Summary

- Replaces all `execSync` calls that interpolate env-derived values (`KUBECONFIG_PATH`, `KRO_CHART_VERSION`) into shell strings with `execFileSync` using explicit argument arrays — no shell involved, no injection possible
- Adds a `sanitizeVersion()` guard that validates `KRO_CHART_VERSION` matches a strict semver pattern (`^\d+\.\d+\.\d+$`) before use
- Converts the pipe-based namespace creation (`kubectl create | kubectl apply`) into two separate `execFileSync` calls using stdin piping instead of a shell pipe
- Converts `kind get kubeconfig > file` shell redirect into a captured output written via `writeFileSync`

## Resolves

- CodeQL alert #1: `js/shell-command-injection-from-environment`
- CodeQL alert #2: `js/indirect-command-line-injection`

Both alerts pointed to `test/e2e/setup/global-setup.ts` line 162 (`execSync(cmd, ...)`) where `cmd` was built from env-controlled values.