### PR TITLE
feat(web): implement spec 017-rgd-validation-linting — RGD validation tab

### DIFF
--- a/.specify/specs/017-rgd-validation-linting/plan.md
+++ b/.specify/specs/017-rgd-validation-linting/plan.md
@@ -1,0 +1,99 @@
+# Implementation Plan: RGD Validation & Linting View
+
+**Spec**: 017-rgd-validation-linting
+**Created**: 2026-03-21
+**Stack**: React 19 / TypeScript / Vite (frontend only — no backend changes needed)
+
+---
+
+## Overview
+
+Add a "Validation" tab to the RGD detail page (`RGDDetail.tsx`) that surfaces
+`status.conditions` from the already-loaded RGD object and displays a resource
+summary computed from `spec.resources`. No new API endpoints are required.
+
+---
+
+## Architecture
+
+### Component Tree
+
+```
+RGDDetail.tsx              (modified — adds 4th tab: "validation")
+└── ValidationTab.tsx      (new — container, orchestrates child components)
+    ├── ConditionItem.tsx  (new — single condition row with icon/reason/message)
+    └── ResourceSummary.tsx (new — node type breakdown + CEL cross-ref list)
+```
+
+### Data Flow
+
+1. `RGDDetail` already fetches `rgd` via `getRGD(name)` on mount
+2. `ValidationTab` receives `rgd` as a prop (no additional API call — FR-001)
+3. `ConditionItem` receives a single condition object
+4. `ResourceSummary` receives `rgd.spec` and calls `buildDAGGraph` to compute the breakdown (FR-004)
+
+---
+
+## File Structure
+
+### New files
+
+```
+web/src/components/ValidationTab.tsx      # Main validation tab container
+web/src/components/ValidationTab.css      # Styles (tokens.css only)
+web/src/components/ConditionItem.tsx      # Single condition row
+web/src/components/ResourceSummary.tsx    # Node type breakdown + CEL refs
+web/src/components/ValidationTab.test.tsx # Unit tests (Vitest)
+```
+
+### Modified files
+
+```
+web/src/pages/RGDDetail.tsx               # Add "validation" to TabId, tab bar, tab content
+```
+
+---
+
+## Key Decisions
+
+### No new CSS files for ConditionItem / ResourceSummary
+
+`ConditionItem` and `ResourceSummary` are styled via `ValidationTab.css` to
+keep the file count low (§V Simplicity). They are not independently reusable
+pages — they are sub-components of `ValidationTab` only.
+
+### Known condition types (FR-002)
+
+The four known condition types have friendly labels; unknown types render
+generically with their raw `type` value (FR-003). The known set is a constant
+array to allow future additions in one place.
+
+### Message truncation (edge case)
+
+Messages longer than 200 characters are truncated with a "Show more" toggle
+implemented via React `useState` inside `ConditionItem`.
+
+### CEL cross-reference extraction (FR-005)
+
+`ResourceSummary` reuses `buildDAGGraph` from `web/src/lib/dag.ts`. The edges
+in the result represent CEL cross-references (from → to), which are displayed
+as a list.
+
+### URL param: `?tab=validation` (FR-006)
+
+`TabId` union is extended to include `"validation"`. The `setTab("graph")`
+clean-URL logic is preserved; `setTab("validation")` sets `{ tab: "validation" }`.
+
+---
+
+## Acceptance Criteria Checklist
+
+- [ ] FR-001: Validation tab reads from already-loaded RGD — no extra API call
+- [ ] FR-002: Known conditions shown with icon (✓/✗/○), reason, message, timestamp
+- [ ] FR-003: Unknown conditions rendered generically without crashing
+- [ ] FR-004: Resource summary computed client-side from spec.resources via buildDAGGraph
+- [ ] FR-005: CEL cross-references extracted from graph edges
+- [ ] FR-006: Tab accessible via ?tab=validation
+- [ ] NFR-001: Renders within 200ms (synchronous — no API call)
+- [ ] NFR-002: TypeScript strict mode passes (tsc --noEmit)
+- [ ] Unit tests pass for all 5 ValidationTab test cases from spec

--- a/web/src/components/ConditionItem.tsx
+++ b/web/src/components/ConditionItem.tsx
@@ -1,0 +1,118 @@
+// ConditionItem.tsx — Single validation condition row.
+//
+// Displays status icon (✓/✗/○), condition type, reason, message, and
+// last transition time. Long messages (>200 chars) are truncated with a
+// "Show more" toggle.
+//
+// Spec: .specify/specs/017-rgd-validation-linting/ FR-002, FR-003
+
+import { useState } from 'react'
+
+/** Maximum message length before truncation. */
+const MESSAGE_PREVIEW_LEN = 200
+
+export interface RGDCondition {
+  type: string
+  status: string   // "True" | "False" | "Unknown"
+  reason?: string
+  message?: string
+  lastTransitionTime?: string
+}
+
+interface ConditionItemProps {
+  condition: RGDCondition
+  /** Human-friendly label for the condition type, e.g. "Graph Verified". */
+  label: string
+}
+
+function formatTime(ts: string | undefined): string {
+  if (!ts) return 'N/A'
+  try {
+    const d = new Date(ts)
+    // Zero time (0001-01-01T00:00:00Z) — treat as N/A
+    if (d.getFullYear() < 1970) return 'N/A'
+    return d.toLocaleString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return ts
+  }
+}
+
+/**
+ * ConditionItem — renders one row of the validation checklist.
+ *
+ * Spec: .specify/specs/017-rgd-validation-linting/ FR-002, FR-003
+ */
+export default function ConditionItem({ condition, label }: ConditionItemProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const status = condition.status
+  const message = condition.message ?? ''
+  const isLong = message.length > MESSAGE_PREVIEW_LEN
+  const displayMessage = isLong && !expanded
+    ? message.slice(0, MESSAGE_PREVIEW_LEN) + '…'
+    : message
+
+  let statusClass: string
+  let statusIcon: string
+  let statusLabel: string
+
+  if (status === 'True') {
+    statusClass = 'condition-item--true'
+    statusIcon = '✓'
+    statusLabel = 'Passed'
+  } else if (status === 'False') {
+    statusClass = 'condition-item--false'
+    statusIcon = '✗'
+    statusLabel = 'Failed'
+  } else {
+    statusClass = 'condition-item--pending'
+    statusIcon = '○'
+    statusLabel = 'Pending'
+  }
+
+  return (
+    <div className={`condition-item ${statusClass}`} data-testid={`condition-item-${condition.type}`}>
+      <div className="condition-item__header">
+        <span className="condition-item__icon" aria-hidden="true">{statusIcon}</span>
+        <span className="condition-item__label">{label}</span>
+        <span className="condition-item__status-label">{statusLabel}</span>
+        {condition.reason && (
+          <span className="condition-item__reason">{condition.reason}</span>
+        )}
+      </div>
+
+      {message && (
+        <div className="condition-item__message">
+          <pre className="condition-item__message-pre">{displayMessage}</pre>
+          {isLong && (
+            <button
+              type="button"
+              className="condition-item__toggle"
+              onClick={() => setExpanded((e) => !e)}
+            >
+              {expanded ? 'Show less' : 'Show more'}
+            </button>
+          )}
+        </div>
+      )}
+
+      {!message && status !== 'True' && (
+        <div className="condition-item__message">
+          <span className="condition-item__pending-hint">
+            Awaiting controller processing
+          </span>
+        </div>
+      )}
+
+      <div className="condition-item__time">
+        Last transition: {formatTime(condition.lastTransitionTime)}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/ResourceSummary.tsx
+++ b/web/src/components/ResourceSummary.tsx
@@ -1,0 +1,138 @@
+// ResourceSummary.tsx — Node type breakdown and CEL cross-reference list.
+//
+// Computes the resource summary client-side from spec.resources using
+// buildDAGGraph — the same logic as the Graph tab (FR-004).
+// CEL cross-references are extracted from the DAG edges (FR-005).
+//
+// Spec: .specify/specs/017-rgd-validation-linting/ US2, FR-004, FR-005
+
+import { useMemo } from 'react'
+import { buildDAGGraph } from '@/lib/dag'
+
+interface ResourceSummaryProps {
+  /** The spec object of a kro RGD (rgd.spec). */
+  spec: Record<string, unknown>
+}
+
+interface NodeCounts {
+  total: number
+  managed: number
+  collections: number
+  externalRefs: number
+}
+
+interface CELRef {
+  from: string
+  to: string
+}
+
+function computeSummary(spec: Record<string, unknown>): {
+  counts: NodeCounts
+  celRefs: CELRef[]
+} {
+  const graph = buildDAGGraph(spec)
+
+  // Count node types (exclude the root 'schema' / 'instance' node)
+  let managed = 0
+  let collections = 0
+  let externalRefs = 0
+
+  for (const node of graph.nodes) {
+    if (node.nodeType === 'instance') continue // skip root
+    if (node.nodeType === 'resource') managed++
+    else if (node.nodeType === 'collection') collections++
+    else if (node.nodeType === 'external' || node.nodeType === 'externalCollection') externalRefs++
+  }
+
+  const total = managed + collections + externalRefs
+
+  // CEL cross-references come from edges (dependency → dependent).
+  // Exclude edges to/from the root 'schema' node that are implicit reachability
+  // edges — they don't represent real CEL references. Real edges only exist
+  // if the dependent node's template/externalRef actually referenced the source.
+  // Since buildDAGGraph only adds schema→X edges for unreachable nodes, we
+  // filter those out by checking if any node's celExpressions reference the
+  // source.
+  const nodeById = new Map(graph.nodes.map((n) => [n.id, n]))
+  const celRefs: CELRef[] = []
+
+  for (const edge of graph.edges) {
+    const toNode = nodeById.get(edge.to)
+    if (!toNode) continue
+    // Only include edge if the target node actually references the source in CEL
+    const allExprs = [
+      ...toNode.celExpressions,
+      ...toNode.includeWhen,
+      ...toNode.readyWhen,
+    ]
+    const referencesSource = allExprs.some((expr) =>
+      expr.includes(edge.from),
+    )
+    if (referencesSource) {
+      celRefs.push({ from: edge.from, to: edge.to })
+    }
+  }
+
+  return {
+    counts: { total, managed, collections, externalRefs },
+    celRefs,
+  }
+}
+
+/**
+ * ResourceSummary — shows node type breakdown and CEL cross-references.
+ *
+ * Spec: .specify/specs/017-rgd-validation-linting/ US2
+ */
+export default function ResourceSummary({ spec }: ResourceSummaryProps) {
+  const { counts, celRefs } = useMemo(() => computeSummary(spec), [spec])
+
+  return (
+    <div className="resource-summary" data-testid="resource-summary">
+      <div className="resource-summary__heading">Resource Summary</div>
+
+      <div className="resource-summary__counts">
+        <span className="resource-summary__total">
+          {counts.total} resource{counts.total !== 1 ? 's' : ''}
+        </span>
+        <span className="resource-summary__breakdown">
+          {counts.managed > 0 && (
+            <span className="resource-summary__type resource-summary__type--managed">
+              {counts.managed} managed
+            </span>
+          )}
+          {counts.collections > 0 && (
+            <span className="resource-summary__type resource-summary__type--collection">
+              {counts.collections} collection{counts.collections !== 1 ? 's' : ''}
+            </span>
+          )}
+          {counts.externalRefs > 0 && (
+            <span className="resource-summary__type resource-summary__type--external">
+              {counts.externalRefs} external ref{counts.externalRefs !== 1 ? 's' : ''}
+            </span>
+          )}
+          {counts.total === 0 && (
+            <span className="resource-summary__type resource-summary__type--empty">
+              none
+            </span>
+          )}
+        </span>
+      </div>
+
+      {celRefs.length > 0 && (
+        <div className="resource-summary__refs">
+          <div className="resource-summary__refs-heading">CEL Cross-References</div>
+          <ul className="resource-summary__refs-list">
+            {celRefs.map((ref, i) => (
+              <li key={i} className="resource-summary__ref-item">
+                <span className="resource-summary__ref-from">{ref.from}</span>
+                <span className="resource-summary__ref-arrow" aria-hidden="true"> → </span>
+                <span className="resource-summary__ref-to">{ref.to}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/ValidationTab.css
+++ b/web/src/components/ValidationTab.css
@@ -1,0 +1,279 @@
+/* ValidationTab.css — Validation tab layout and condition item styles.
+ *
+ * All colors from tokens.css custom properties.
+ * Spec: .specify/specs/017-rgd-validation-linting/
+ */
+
+/* ── Tab container ────────────────────────────────────────────────────────── */
+
+.validation-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+/* ── Section ──────────────────────────────────────────────────────────────── */
+
+.validation-tab__section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.validation-tab__section-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+/* ── Checklist ────────────────────────────────────────────────────────────── */
+
+.validation-tab__checklist {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* ── Condition item ───────────────────────────────────────────────────────── */
+
+.condition-item {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border-left-width: 3px;
+}
+
+.condition-item--true {
+  border-left-color: var(--color-alive);
+}
+
+.condition-item--false {
+  border-left-color: var(--color-error);
+}
+
+.condition-item--pending {
+  border-left-color: var(--color-not-found);
+}
+
+/* ── Condition header ─────────────────────────────────────────────────────── */
+
+.condition-item__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.condition-item__icon {
+  font-size: 14px;
+  line-height: 1;
+  width: 16px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.condition-item--true  .condition-item__icon { color: var(--color-alive); }
+.condition-item--false .condition-item__icon { color: var(--color-error); }
+.condition-item--pending .condition-item__icon { color: var(--color-not-found); }
+
+.condition-item__label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.condition-item__status-label {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  border: 1px solid;
+}
+
+.condition-item--true .condition-item__status-label {
+  background: var(--node-alive-bg);
+  border-color: var(--node-alive-border);
+  color: var(--color-alive);
+}
+
+.condition-item--false .condition-item__status-label {
+  background: var(--node-error-bg);
+  border-color: var(--node-error-border);
+  color: var(--color-error);
+}
+
+.condition-item--pending .condition-item__status-label {
+  background: var(--node-notfound-bg);
+  border-color: var(--node-notfound-border);
+  color: var(--color-not-found);
+}
+
+.condition-item__reason {
+  font-size: 11px;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  background: var(--color-surface-2);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+}
+
+/* ── Condition message ────────────────────────────────────────────────────── */
+
+.condition-item__message {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.condition-item__message-pre {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-text-muted);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.condition-item__pending-hint {
+  font-size: 12px;
+  color: var(--color-text-faint);
+  font-style: italic;
+}
+
+.condition-item__toggle {
+  align-self: flex-start;
+  background: transparent;
+  border: none;
+  color: var(--color-primary);
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+  transition: color var(--transition-fast);
+}
+
+.condition-item__toggle:hover {
+  color: var(--color-primary-hover);
+}
+
+/* ── Timestamp ────────────────────────────────────────────────────────────── */
+
+.condition-item__time {
+  font-size: 11px;
+  color: var(--color-text-faint);
+}
+
+/* ── Resource summary ─────────────────────────────────────────────────────── */
+
+.resource-summary {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.resource-summary__heading {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.resource-summary__counts {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.resource-summary__total {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.resource-summary__breakdown {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.resource-summary__type {
+  font-size: 11px;
+  font-weight: 500;
+  padding: 1px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid;
+}
+
+.resource-summary__type--managed {
+  background: var(--node-default-bg);
+  border-color: var(--node-default-border);
+  color: var(--color-text-muted);
+}
+
+.resource-summary__type--collection {
+  background: var(--node-collection-bg);
+  border-color: var(--node-collection-border);
+  color: var(--color-pending);
+}
+
+.resource-summary__type--external {
+  background: var(--node-external-bg);
+  border-color: var(--node-external-border);
+  color: var(--color-text-muted);
+}
+
+.resource-summary__type--empty {
+  color: var(--color-text-faint);
+  border-color: var(--color-border);
+  background: transparent;
+}
+
+/* ── CEL cross-references ─────────────────────────────────────────────────── */
+
+.resource-summary__refs {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.resource-summary__refs-heading {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.resource-summary__refs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.resource-summary__ref-item {
+  font-size: 12px;
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+}
+
+.resource-summary__ref-from,
+.resource-summary__ref-to {
+  color: var(--color-text);
+}
+
+.resource-summary__ref-arrow {
+  color: var(--color-text-faint);
+}

--- a/web/src/components/ValidationTab.test.tsx
+++ b/web/src/components/ValidationTab.test.tsx
@@ -1,0 +1,197 @@
+// ValidationTab.test.tsx — Unit tests for ValidationTab, ConditionItem, ResourceSummary.
+//
+// Spec: .specify/specs/017-rgd-validation-linting/ (Testing Requirements)
+
+import { render, screen, fireEvent } from '@testing-library/react'
+import ValidationTab from './ValidationTab'
+
+// ── Test fixtures ──────────────────────────────────────────────────────────
+
+/** Build a minimal RGD object with given conditions. */
+function makeRGD(
+  conditions: Array<{
+    type: string
+    status: string
+    reason?: string
+    message?: string
+    lastTransitionTime?: string
+  }>,
+  resources: unknown[] = [],
+) {
+  return {
+    apiVersion: 'kro.run/v1alpha1',
+    kind: 'ResourceGraphDefinition',
+    metadata: { name: 'test-app' },
+    spec: {
+      schema: { kind: 'WebApp', apiVersion: 'v1alpha1', group: 'test.dev' },
+      resources,
+    },
+    status: { conditions },
+  }
+}
+
+/** Standard "all passing" condition set. */
+const allTrueConditions = [
+  { type: 'GraphVerified',                  status: 'True',  reason: 'GraphVerified',    message: '' },
+  { type: 'TopologyReady',                  status: 'True',  reason: 'TopologyReady',    message: '' },
+  { type: 'CustomResourceDefinitionSynced', status: 'True',  reason: 'CRDSynced',        message: '' },
+  { type: 'Ready',                          status: 'True',  reason: 'Ready',            message: '' },
+]
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function renderValidationTab(rgd: ReturnType<typeof makeRGD>) {
+  return render(<ValidationTab rgd={rgd} />)
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('ValidationTab', () => {
+
+  // ── SC-001 / FR-002: Green checkmarks for True conditions ──────────────
+
+  it('shows green checkmark (✓) and "Passed" for True conditions', () => {
+    renderValidationTab(makeRGD(allTrueConditions))
+
+    // All four known condition items should be rendered
+    const graphItem = screen.getByTestId('condition-item-GraphVerified')
+    expect(graphItem).toBeInTheDocument()
+    expect(graphItem).toHaveClass('condition-item--true')
+    expect(graphItem).toHaveTextContent('✓')
+    expect(graphItem).toHaveTextContent('Passed')
+
+    const readyItem = screen.getByTestId('condition-item-Ready')
+    expect(readyItem).toHaveClass('condition-item--true')
+    expect(readyItem).toHaveTextContent('✓')
+  })
+
+  // ── SC-002 / FR-002: Red X for False conditions with error message ──────
+
+  it('shows red X (✗) and reason/message for False conditions', () => {
+    const rgd = makeRGD([
+      {
+        type: 'GraphVerified',
+        status: 'False',
+        reason: 'CycleDetected',
+        message: 'cycle detected: A → B → A',
+      },
+    ])
+    renderValidationTab(rgd)
+
+    const item = screen.getByTestId('condition-item-GraphVerified')
+    expect(item).toHaveClass('condition-item--false')
+    expect(item).toHaveTextContent('✗')
+    expect(item).toHaveTextContent('Failed')
+    expect(item).toHaveTextContent('CycleDetected')
+    expect(item).toHaveTextContent('cycle detected: A → B → A')
+  })
+
+  // ── FR-002: Gray pending indicator for absent conditions ────────────────
+
+  it('shows gray pending (○) for absent conditions', () => {
+    // RGD with NO conditions — all four known types should show as Pending
+    renderValidationTab(makeRGD([]))
+
+    for (const type of ['GraphVerified', 'TopologyReady', 'CustomResourceDefinitionSynced', 'Ready']) {
+      const item = screen.getByTestId(`condition-item-${type}`)
+      expect(item).toHaveClass('condition-item--pending')
+      expect(item).toHaveTextContent('○')
+      expect(item).toHaveTextContent('Pending')
+    }
+  })
+
+  // ── FR-003: Unknown condition types rendered generically ────────────────
+
+  it('renders unknown condition types generically without crashing', () => {
+    const rgd = makeRGD([
+      ...allTrueConditions,
+      {
+        type: 'FutureConditionType',
+        status: 'False',
+        reason: 'SomeReason',
+        message: 'Some future validation failed',
+      },
+    ])
+    renderValidationTab(rgd)
+
+    // The unknown type should render — type name used as label
+    const unknownItem = screen.getByTestId('condition-item-FutureConditionType')
+    expect(unknownItem).toBeInTheDocument()
+    expect(unknownItem).toHaveTextContent('FutureConditionType')
+    expect(unknownItem).toHaveTextContent('Failed')
+    expect(unknownItem).toHaveTextContent('Some future validation failed')
+  })
+
+  // ── FR-004 / SC-003: Resource summary with correct type breakdown ────────
+
+  it('shows resource summary with correct type breakdown', () => {
+    const resources = [
+      {
+        id: 'appNamespace',
+        template: { apiVersion: 'v1', kind: 'Namespace', metadata: { name: '${schema.spec.appName}' } },
+      },
+      {
+        id: 'appDeployment',
+        template: { apiVersion: 'apps/v1', kind: 'Deployment', metadata: { name: '${schema.spec.appName}' } },
+      },
+      {
+        id: 'appService',
+        template: { apiVersion: 'v1', kind: 'Service', metadata: { name: '${schema.spec.appName}' } },
+      },
+      {
+        id: 'regionalDeployments',
+        template: { apiVersion: 'apps/v1', kind: 'Deployment' },
+        forEach: '${schema.spec.regions}',
+      },
+      {
+        id: 'existingCM',
+        externalRef: {
+          apiVersion: 'v1',
+          kind: 'ConfigMap',
+          metadata: { name: 'my-config' },
+        },
+      },
+    ]
+    renderValidationTab(makeRGD(allTrueConditions, resources))
+
+    const summary = screen.getByTestId('resource-summary')
+    expect(summary).toBeInTheDocument()
+    // 5 resources total: 3 managed, 1 collection, 1 external ref
+    expect(summary).toHaveTextContent('5 resources')
+    expect(summary).toHaveTextContent('3 managed')
+    expect(summary).toHaveTextContent('1 collection')
+    expect(summary).toHaveTextContent('1 external ref')
+  })
+
+  // ── Edge case: long message truncation with "Show more" toggle ───────────
+
+  it('truncates long messages and shows a "Show more" toggle', () => {
+    const longMessage = 'x'.repeat(300)
+    const rgd = makeRGD([
+      { type: 'GraphVerified', status: 'False', reason: 'SomeError', message: longMessage },
+    ])
+    renderValidationTab(rgd)
+
+    // The full message should not be visible initially
+    expect(screen.queryByText(longMessage)).not.toBeInTheDocument()
+    // But the truncated version should be
+    expect(screen.getByText(longMessage.slice(0, 200) + '…')).toBeInTheDocument()
+
+    // Toggle "Show more"
+    const toggle = screen.getByRole('button', { name: 'Show more' })
+    fireEvent.click(toggle)
+
+    // Full message is now visible
+    expect(screen.getByText(longMessage)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Show less' })).toBeInTheDocument()
+  })
+
+  // ── FR-006: ?tab=validation tab renders the component ───────────────────
+  // This is tested at the RGDDetail level in RGDDetail.test.tsx (added separately).
+  // Here we just verify ValidationTab renders when conditions are empty and spec is present.
+
+  it('renders validation tab container with data-testid', () => {
+    renderValidationTab(makeRGD([]))
+    expect(screen.getByTestId('validation-tab')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/ValidationTab.tsx
+++ b/web/src/components/ValidationTab.tsx
@@ -1,0 +1,111 @@
+// ValidationTab.tsx — Validation checklist + resource summary tab for RGDDetail.
+//
+// Reads status.conditions from the already-loaded RGD object (no API call).
+// Displays known conditions with status icons and renders a resource summary
+// computed client-side from spec.resources.
+//
+// Spec: .specify/specs/017-rgd-validation-linting/
+
+import type { K8sObject } from '@/lib/api'
+import ConditionItem from './ConditionItem'
+import type { RGDCondition } from './ConditionItem'
+import ResourceSummary from './ResourceSummary'
+import './ValidationTab.css'
+
+/** The four condition types kro sets on every RGD, in display order. */
+const KNOWN_CONDITION_TYPES: ReadonlyArray<{ type: string; label: string }> = [
+  { type: 'GraphVerified',                    label: 'Graph Verified' },
+  { type: 'TopologyReady',                    label: 'Topology Ready' },
+  { type: 'CustomResourceDefinitionSynced',   label: 'CRD Synced' },
+  { type: 'Ready',                            label: 'Ready' },
+]
+
+/** Friendly label for a condition type. Unknown types use the raw type value. */
+function conditionLabel(type: string): string {
+  return KNOWN_CONDITION_TYPES.find((k) => k.type === type)?.label ?? type
+}
+
+function extractConditions(rgd: K8sObject): RGDCondition[] {
+  const status = rgd.status as Record<string, unknown> | undefined
+  if (!status) return []
+  const conditions = status.conditions
+  if (!Array.isArray(conditions)) return []
+  // Cast to RGDCondition — fields are validated by ConditionItem at render time
+  return conditions as RGDCondition[]
+}
+
+/**
+ * Build the display list:
+ *   - Known condition types are shown in fixed order; missing ones show as "Pending".
+ *   - Unknown condition types (future kro versions) are appended at the end.
+ */
+function buildDisplayConditions(
+  conditions: RGDCondition[],
+): Array<{ condition: RGDCondition; label: string }> {
+  const byType = new Map<string, RGDCondition>()
+  for (const c of conditions) {
+    if (c.type) byType.set(c.type, c)
+  }
+
+  const result: Array<{ condition: RGDCondition; label: string }> = []
+
+  // Known types first, in order
+  for (const { type, label } of KNOWN_CONDITION_TYPES) {
+    const c = byType.get(type) ?? {
+      type,
+      status: 'Unknown',
+    }
+    result.push({ condition: c, label })
+  }
+
+  // Append any unknown types that are present in the actual conditions
+  for (const c of conditions) {
+    const isKnown = KNOWN_CONDITION_TYPES.some((k) => k.type === c.type)
+    if (!isKnown) {
+      result.push({ condition: c, label: conditionLabel(c.type) })
+    }
+  }
+
+  return result
+}
+
+interface ValidationTabProps {
+  /** The already-loaded RGD object. */
+  rgd: K8sObject
+}
+
+/**
+ * ValidationTab — shows the RGD validation checklist and resource summary.
+ *
+ * Spec: .specify/specs/017-rgd-validation-linting/
+ */
+export default function ValidationTab({ rgd }: ValidationTabProps) {
+  const conditions = extractConditions(rgd)
+  const displayConditions = buildDisplayConditions(conditions)
+  const spec = rgd.spec as Record<string, unknown> | undefined
+
+  return (
+    <div className="validation-tab" data-testid="validation-tab">
+      {/* ── Validation Checklist ──────────────────────────────────────── */}
+      <section className="validation-tab__section">
+        <h2 className="validation-tab__section-title">Validation Conditions</h2>
+        <div className="validation-tab__checklist">
+          {displayConditions.map(({ condition, label }) => (
+            <ConditionItem
+              key={condition.type}
+              condition={condition}
+              label={label}
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* ── Resource Summary ─────────────────────────────────────────── */}
+      {spec && (
+        <section className="validation-tab__section">
+          <ResourceSummary spec={spec} />
+        </section>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/RGDDetail.test.tsx
+++ b/web/src/pages/RGDDetail.test.tsx
@@ -106,6 +106,17 @@ describe('RGDDetail', () => {
     expect(screen.getByTestId('dag-svg')).toBeInTheDocument()
   })
 
+  // ── T034g: ?tab=validation shows ValidationTab ────────────────────────
+
+  it('T034g: ?tab=validation shows Validation tab content', async () => {
+    renderDetail('?tab=validation')
+    await waitFor(() =>
+      expect(screen.getByTestId('tab-validation')).toHaveAttribute('aria-selected', 'true'),
+    )
+    expect(screen.getByTestId('validation-tab')).toBeInTheDocument()
+    expect(screen.queryByTestId('dag-svg')).not.toBeInTheDocument()
+  })
+
   // ── T034e: Node click opens NodeDetailPanel ────────────────────────────
 
   it('T034e: clicking a DAG node opens NodeDetailPanel', async () => {

--- a/web/src/pages/RGDDetail.tsx
+++ b/web/src/pages/RGDDetail.tsx
@@ -9,22 +9,24 @@ import DAGGraph from "@/components/DAGGraph"
 import NodeDetailPanel from "@/components/NodeDetailPanel"
 import InstanceTable from "@/components/InstanceTable"
 import NamespaceFilter from "@/components/NamespaceFilter"
+import ValidationTab from "@/components/ValidationTab"
 import "./RGDDetail.css"
 
 /** Valid tab values. Anything else falls back to 'graph'. */
-type TabId = "graph" | "instances" | "yaml"
+type TabId = "graph" | "instances" | "yaml" | "validation"
 
 function isValidTab(t: string | null): t is TabId {
-  return t === "graph" || t === "instances" || t === "yaml"
+  return t === "graph" || t === "instances" || t === "yaml" || t === "validation"
 }
 
 /**
- * RGDDetail — RGD detail page with three tabs: Graph, Instances, YAML.
+ * RGDDetail — RGD detail page with four tabs: Graph, Instances, YAML, Validation.
  *
  * Active tab is reflected in and restored from `?tab=` URL query parameter.
  * Default tab is "graph".
  *
- * Spec: .specify/specs/003-rgd-detail-dag/ and .specify/specs/004-instance-list/
+ * Spec: .specify/specs/003-rgd-detail-dag/, .specify/specs/004-instance-list/,
+ *       and .specify/specs/017-rgd-validation-linting/
  */
 export default function RGDDetail() {
   const { name } = useParams<{ name: string }>()
@@ -192,6 +194,16 @@ export default function RGDDetail() {
         >
           YAML
         </button>
+        <button
+          data-testid="tab-validation"
+          className="rgd-tab-btn"
+          role="tab"
+          aria-selected={activeTab === "validation"}
+          onClick={() => setTab("validation")}
+          type="button"
+        >
+          Validation
+        </button>
       </div>
 
       {/* Tab content */}
@@ -286,6 +298,12 @@ export default function RGDDetail() {
         {activeTab === "yaml" && (
           <div className="rgd-tab-panel">
             <KroCodeBlock code={toYaml(rgd)} title="ResourceGraphDefinition" />
+          </div>
+        )}
+
+        {activeTab === "validation" && (
+          <div className="rgd-tab-panel">
+            <ValidationTab rgd={rgd} />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

- Adds a **Validation** tab to the RGD detail page (`?tab=validation`) that surfaces `status.conditions` from the already-loaded RGD object — no additional API call
- Displays all four known kro condition types (`GraphVerified`, `TopologyReady`, `CustomResourceDefinitionSynced`, `Ready`) in fixed order with ✓/✗/○ status icons, reason, message, and last-transition timestamp
- Unknown future condition types rendered generically without crashing (FR-003)
- Messages longer than 200 characters are truncated with a "Show more" toggle
- Resource summary computed client-side via `buildDAGGraph`: node type breakdown (managed / collection / external refs) and CEL cross-reference list (FR-004, FR-005)

## Components

| File | Role |
|------|------|
| `ValidationTab.tsx` | Tab container — checklist + resource summary |
| `ConditionItem.tsx` | Single condition row with icon, reason, message, timestamp |
| `ResourceSummary.tsx` | Node type breakdown + CEL cross-reference list |
| `ValidationTab.css` | All styles via `tokens.css` custom properties only |
| `ValidationTab.test.tsx` | 7 new unit tests |

## Testing

- 207/207 tests pass (`bun run test`)
- `tsc --noEmit` clean (NFR-002)
- All acceptance scenarios from spec covered: True, False, absent (Pending), unknown types, long message truncation, resource summary counts

Closes #18