### PR TITLE
fix: UX batch — 11 issues (ARN disambiguation, DAG height, clickable cards, filter inputs, page titles, 404, breadcrumb, column sort, fleet refresh, RBAC ClusterRole)

### DIFF
--- a/internal/api/handlers/access.go
+++ b/internal/api/handlers/access.go
@@ -78,6 +78,7 @@ func (h *Handler) GetRGDAccess(w http.ResponseWriter, r *http.Request) {
 	respond(w, http.StatusOK, types.AccessResponse{
 		ServiceAccount:      result.ServiceAccount,
 		ServiceAccountFound: result.ServiceAccountFound,
+		ClusterRole:         result.ClusterRole,
 		HasGaps:             result.HasGaps,
 		Permissions:         perms,
 	})

--- a/internal/api/types/response.go
+++ b/internal/api/types/response.go
@@ -55,10 +55,13 @@ type GVRPermission struct {
 
 // AccessResponse is the response payload for GET /api/v1/rgds/{name}/access.
 type AccessResponse struct {
-	ServiceAccount      string          `json:"serviceAccount"`
-	ServiceAccountFound bool            `json:"serviceAccountFound"`
-	HasGaps             bool            `json:"hasGaps"`
-	Permissions         []GVRPermission `json:"permissions"`
+	ServiceAccount      string `json:"serviceAccount"`
+	ServiceAccountFound bool   `json:"serviceAccountFound"`
+	// ClusterRole is the name of the primary ClusterRole bound to kro's service account.
+	// Empty string means it could not be determined — the frontend should fall back to a placeholder.
+	ClusterRole string          `json:"clusterRole"`
+	HasGaps     bool            `json:"hasGaps"`
+	Permissions []GVRPermission `json:"permissions"`
 }
 
 // ClusterHealth represents the aggregated health status of a single cluster context.

--- a/internal/k8s/rbac.go
+++ b/internal/k8s/rbac.go
@@ -46,10 +46,13 @@ type ResourcePermission struct {
 
 // AccessResult is the full permission matrix for an RGD.
 type AccessResult struct {
-	ServiceAccount      string               `json:"serviceAccount"`
-	ServiceAccountFound bool                 `json:"serviceAccountFound"`
-	HasGaps             bool                 `json:"hasGaps"`
-	Permissions         []ResourcePermission `json:"permissions"`
+	ServiceAccount      string `json:"serviceAccount"`
+	ServiceAccountFound bool   `json:"serviceAccountFound"`
+	// ClusterRole is the name of the primary ClusterRole bound to kro's service account.
+	// Empty string means it could not be determined.
+	ClusterRole string               `json:"clusterRole"`
+	HasGaps     bool                 `json:"hasGaps"`
+	Permissions []ResourcePermission `json:"permissions"`
 }
 
 // ManagedVerbs are the verbs required for resources kro actively manages.
@@ -205,6 +208,29 @@ func CheckPermissions(rules []policyRule, group, resource string, required []str
 	return granted
 }
 
+// ResolveKroClusterRole returns the name of the first ClusterRole bound to the given
+// service account via a ClusterRoleBinding. Returns an empty string if none is found.
+// The first match with a ClusterRole (not a Role) is returned; typically kro has a
+// single ClusterRoleBinding.
+func ResolveKroClusterRole(ctx context.Context, clients K8sClients, saNamespace, saName string) string {
+	crbGVR := schema.GroupVersionResource{Group: rbacGroup, Version: "v1", Resource: "clusterrolebindings"}
+	crbList, err := clients.Dynamic().Resource(crbGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return ""
+	}
+	for _, crb := range crbList.Items {
+		if !bindingMatchesSA(crb.Object, saNamespace, saName) {
+			continue
+		}
+		roleKind, _, _ := UnstructuredString(crb.Object, "roleRef", "kind")
+		roleName, _, _ := UnstructuredString(crb.Object, "roleRef", "name")
+		if roleKind == "ClusterRole" && roleName != "" {
+			return roleName
+		}
+	}
+	return ""
+}
+
 // ComputeAccessResult extracts all GVRs from the RGD's spec.resources, fetches kro's
 // service account, reads its effective RBAC rules, and returns the full permission matrix.
 func ComputeAccessResult(ctx context.Context, clients K8sClients, rgdObj map[string]any) (*AccessResult, error) {
@@ -259,6 +285,7 @@ func ComputeAccessResult(ctx context.Context, clients K8sClients, rgdObj map[str
 	return &AccessResult{
 		ServiceAccount:      saDisplay,
 		ServiceAccountFound: saFound,
+		ClusterRole:         ResolveKroClusterRole(ctx, clients, saNS, saName),
 		HasGaps:             hasGaps,
 		Permissions:         permissions,
 	}, nil

--- a/web/src/components/AccessTab.test.tsx
+++ b/web/src/components/AccessTab.test.tsx
@@ -42,6 +42,7 @@ function makeAccessResponse(overrides: Partial<AccessResponse> = {}): AccessResp
   return {
     serviceAccount: 'kro-system/kro',
     serviceAccountFound: true,
+    clusterRole: 'kro-manager-role',
     hasGaps: false,
     permissions: [],
     ...overrides,

--- a/web/src/components/AccessTab.tsx
+++ b/web/src/components/AccessTab.tsx
@@ -23,12 +23,14 @@ function resourceLabel(p: GVRPermission): string {
 }
 
 /**
- * Infer a best-guess ClusterRole name from the service account display string.
- * e.g. "kro-system/kro" → "kro-manager-role"
- * The generated command includes a disclaimer to replace if different.
+ * Return the ClusterRole name to use in fix suggestions.
+ * Prefer the backend-resolved name; fall back to a descriptive placeholder
+ * so the user knows to replace it (issue #74).
  */
-function inferClusterRoleName(serviceAccount: string): string {
-  const saName = serviceAccount.split("/")[1] ?? serviceAccount
+function resolvedClusterRoleName(data: AccessResponse): string {
+  if (data.clusterRole) return data.clusterRole
+  // Fallback: derive a guess from the SA name, clearly marked as a placeholder
+  const saName = data.serviceAccount.split('/')[1] ?? data.serviceAccount
   return `${saName}-manager-role`
 }
 
@@ -201,7 +203,7 @@ export default function AccessTab({ rgdName }: AccessTabProps) {
               <RBACFixSuggestion
                 key={resourceLabel(p)}
                 permission={p}
-                clusterRoleName={inferClusterRoleName(data.serviceAccount)}
+                clusterRoleName={resolvedClusterRoleName(data)}
               />
             ))}
         </div>

--- a/web/src/components/CatalogCard.css
+++ b/web/src/components/CatalogCard.css
@@ -13,6 +13,19 @@
   border-color: var(--color-border-focus);
 }
 
+/* Body link — covers header + meta (issue #65) */
+.catalog-card__body-link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+}
+
+.catalog-card__body-link:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
 /* ── Header ──────────────────────────────────────────────────────── */
 
 .catalog-card__header {

--- a/web/src/components/CatalogCard.tsx
+++ b/web/src/components/CatalogCard.tsx
@@ -40,27 +40,35 @@ export default function CatalogCard({
 
   return (
     <article className="catalog-card" data-testid={`catalog-card-${name}`}>
-      <div className="catalog-card__header">
-        <StatusDot state={state} reason={reason} message={message} />
-        <h2 className="catalog-card__name" data-testid="catalog-card-name">
-          {name}
-        </h2>
-      </div>
+      {/* Primary link — wraps header + meta (issue #65) */}
+      <Link
+        to={`/rgds/${encodedName}`}
+        className="catalog-card__body-link"
+        data-testid="btn-graph"
+        aria-label={`View ${name} graph`}
+      >
+        <div className="catalog-card__header">
+          <StatusDot state={state} reason={reason} message={message} />
+          <h2 className="catalog-card__name" data-testid="catalog-card-name">
+            {name}
+          </h2>
+        </div>
 
-      <div className="catalog-card__meta">
-        {kind && (
-          <span className="catalog-card__kind" data-testid="catalog-card-kind">
-            {kind}
+        <div className="catalog-card__meta">
+          {kind && (
+            <span className="catalog-card__kind" data-testid="catalog-card-kind">
+              {kind}
+            </span>
+          )}
+          <span className="catalog-card__stat" data-testid="catalog-card-resources">
+            {resourceCount} resource{resourceCount !== 1 ? 's' : ''}
           </span>
-        )}
-        <span className="catalog-card__stat" data-testid="catalog-card-resources">
-          {resourceCount} resource{resourceCount !== 1 ? 's' : ''}
-        </span>
-        <span className="catalog-card__stat" data-testid="catalog-card-instances">
-          {instanceDisplay} instance{instanceCount !== 1 ? 's' : ''}
-        </span>
-        <span className="catalog-card__age">{formatAge(createdAt)}</span>
-      </div>
+          <span className="catalog-card__stat" data-testid="catalog-card-instances">
+            {instanceDisplay} instance{instanceCount !== 1 ? 's' : ''}
+          </span>
+          <span className="catalog-card__age">{formatAge(createdAt)}</span>
+        </div>
+      </Link>
 
       {Object.keys(labels).length > 0 && (
         <div className="catalog-card__labels" data-testid="catalog-card-labels">
@@ -96,13 +104,6 @@ export default function CatalogCard({
       )}
 
       <div className="catalog-card__actions">
-        <Link
-          to={`/rgds/${encodedName}`}
-          className="catalog-card__btn"
-          data-testid="btn-graph"
-        >
-          Graph
-        </Link>
         <Link
           to={`/rgds/${encodedName}?tab=instances`}
           className="catalog-card__btn"

--- a/web/src/components/ContextSwitcher.css
+++ b/web/src/components/ContextSwitcher.css
@@ -94,7 +94,7 @@
 /* Option */
 .context-switcher__option {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
   padding: 8px 10px;
   border-radius: var(--radius-sm);
@@ -104,9 +104,24 @@
   cursor: pointer;
   transition: background var(--transition-fast);
   user-select: none;
-  white-space: nowrap;
+}
+
+/* Option text wrapper — allows subtitle below the label */
+.context-switcher__option-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+/* Subtitle — shows the full context name for disambiguation */
+.context-switcher__option-subtitle {
+  font-size: 10px;
+  color: var(--color-text-faint);
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 300px;
 }
 
 .context-switcher__option:hover {

--- a/web/src/components/ContextSwitcher.test.tsx
+++ b/web/src/components/ContextSwitcher.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
-import ContextSwitcher from './ContextSwitcher'
+import ContextSwitcher, { truncateContextName } from './ContextSwitcher'
 import type { KubeContext } from '@/lib/api'
 
 vi.mock('@/lib/api', () => ({
@@ -32,6 +32,36 @@ function renderSwitcher(props?: {
     />,
   )
 }
+
+describe('truncateContextName', () => {
+  it('returns name unchanged when ≤40 chars', () => {
+    expect(truncateContextName('dev')).toBe('dev')
+    expect(truncateContextName('a'.repeat(40))).toBe('a'.repeat(40))
+  })
+
+  it('abbreviates AWS EKS ARNs to accountPrefix…/clusterName', () => {
+    const arn1 = 'arn:aws:eks:us-west-2:319279230668:cluster/krombat'
+    expect(truncateContextName(arn1)).toBe('319279\u2026/krombat')
+
+    const arn2 = 'arn:aws:eks:us-west-2:569190534191:cluster/krombat'
+    expect(truncateContextName(arn2)).toBe('569190\u2026/krombat')
+
+    // The two ARNs that both used to truncate to "…/krombat" are now distinct
+    expect(truncateContextName(arn1)).not.toBe(truncateContextName(arn2))
+  })
+
+  it('falls back to prefix…/lastName for long generic paths', () => {
+    const name = 'some-very-long-context-name/cluster-name-here'
+    const result = truncateContextName(name)
+    expect(result).toContain('\u2026/')
+    expect(result).toContain('cluster-name-here')
+  })
+
+  it('truncates non-path names at 40 chars with …', () => {
+    const name = 'x'.repeat(50)
+    expect(truncateContextName(name)).toBe('x'.repeat(40) + '\u2026')
+  })
+})
 
 describe('ContextSwitcher', () => {
   beforeEach(() => {

--- a/web/src/components/ContextSwitcher.tsx
+++ b/web/src/components/ContextSwitcher.tsx
@@ -1,5 +1,6 @@
 // ContextSwitcher — dropdown to switch kubeconfig contexts at runtime.
 // Implements an accessible ARIA listbox pattern per spec 007-context-switcher.
+// Fix #63: ARN truncation now shows account-ID fragment + cluster name for disambiguation.
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { switchContext } from '@/lib/api'
 import type { KubeContext } from '@/lib/api'
@@ -8,16 +9,40 @@ import './ContextSwitcher.css'
 const MAX_DISPLAY_LENGTH = 40
 const SWITCH_TIMEOUT_MS = 10_000
 
-/** Return a display-friendly truncation of a context name.
- *  For names >40 chars that contain '/', extract the last segment and
- *  prepend '…/'. Otherwise truncate at 40 chars with '…'.
+/**
+ * Return a display-friendly label for a context name that may be ambiguous.
+ *
+ * Rules (in order):
+ *  1. If ≤40 chars: return as-is.
+ *  2. If it looks like an AWS EKS ARN
+ *     (`arn:aws:eks:<region>:<accountId>:cluster/<clusterName>`):
+ *     return `<accountPrefix>…/<clusterName>` where accountPrefix is the
+ *     first 6 digits of the account ID — enough to disambiguate.
+ *  3. If it contains '/' (other long paths): `<account_or_prefix>…/<lastName>`.
+ *  4. Fallback: truncate at 40 with '…'.
+ *
+ * The full name is always exposed via `title` attribute.
  */
-function truncateContextName(name: string): string {
+export function truncateContextName(name: string): string {
   if (name.length <= MAX_DISPLAY_LENGTH) return name
+
+  // AWS EKS ARN: arn:aws:eks:region:accountId:cluster/clusterName
+  const eksMatch = /^arn:aws:eks:[^:]+:(\d+):cluster\/(.+)$/.exec(name)
+  if (eksMatch) {
+    const accountPrefix = eksMatch[1].slice(0, 6)
+    const clusterName = eksMatch[2]
+    return `${accountPrefix}\u2026/${clusterName}`
+  }
+
+  // Generic long path with slashes: keep last segment + prefix hint
   const slashIdx = name.lastIndexOf('/')
   if (slashIdx !== -1) {
-    return '\u2026/' + name.slice(slashIdx + 1)
+    const lastName = name.slice(slashIdx + 1)
+    // Include a short prefix hint so two paths with same basename differ
+    const prefix = name.slice(0, Math.min(6, slashIdx))
+    return `${prefix}\u2026/${lastName}`
   }
+
   return name.slice(0, MAX_DISPLAY_LENGTH) + '\u2026'
 }
 
@@ -232,7 +257,12 @@ export default function ContextSwitcher({
                   ) : (
                     <span className="context-switcher__check-placeholder" aria-hidden="true" />
                   )}
-                  <span className="context-switcher__label">{ctx.name}</span>
+                  <span className="context-switcher__option-text">
+                    <span className="context-switcher__label">{truncateContextName(ctx.name)}</span>
+                    {ctx.name.length > MAX_DISPLAY_LENGTH && (
+                      <span className="context-switcher__option-subtitle">{ctx.name}</span>
+                    )}
+                  </span>
                 </div>
               )
             })

--- a/web/src/components/DAGGraph.tsx
+++ b/web/src/components/DAGGraph.tsx
@@ -2,6 +2,7 @@
 //
 // Data-driven: accepts {nodes, edges} — zero kro-specific logic.
 // All kro knowledge lives in web/src/lib/dag.ts.
+// Fix #64: SVG height is fitted to actual node bounding box, not layout estimate.
 
 import type { DAGGraph, DAGNode } from '@/lib/dag'
 import './DAGGraph.css'
@@ -10,6 +11,18 @@ interface DAGGraphProps {
   graph: DAGGraph
   onNodeClick?: (nodeId: string) => void
   selectedNodeId?: string
+}
+
+const PADDING = 32
+
+/**
+ * Compute the actual content height from node bounding boxes.
+ * Prevents empty space below the last row of nodes (issue #64).
+ */
+function fittedHeight(graph: DAGGraph): number {
+  if (graph.nodes.length === 0) return graph.height
+  const maxBottom = Math.max(...graph.nodes.map((n) => n.y + n.height))
+  return maxBottom + PADDING
 }
 
 /** Cubic bezier edge path from parent bottom-center to child top-center. */
@@ -124,14 +137,15 @@ export default function DAGGraph({
   selectedNodeId,
 }: DAGGraphProps) {
   const nodeMap = new Map(graph.nodes.map((n) => [n.id, n]))
+  const svgHeight = fittedHeight(graph)
 
   return (
     <div className="dag-graph-container">
       <svg
         data-testid="dag-svg"
         width={graph.width}
-        height={graph.height}
-        viewBox={`0 0 ${graph.width} ${graph.height}`}
+        height={svgHeight}
+        viewBox={`0 0 ${graph.width} ${svgHeight}`}
         xmlns="http://www.w3.org/2000/svg"
         aria-label="Resource dependency graph"
         role="img"

--- a/web/src/components/InstanceTable.css
+++ b/web/src/components/InstanceTable.css
@@ -1,4 +1,4 @@
-/* InstanceTable — live CR instance rows. */
+/* InstanceTable — live CR instance rows. Issue #71: sortable headers. */
 
 .instance-table {
   width: 100%;
@@ -15,6 +15,31 @@
   border-bottom: 1px solid var(--color-border);
   white-space: nowrap;
   user-select: none;
+}
+
+.instance-table__th--sortable {
+  cursor: pointer;
+  transition: color var(--transition-fast);
+}
+
+.instance-table__th--sortable:hover {
+  color: var(--color-text);
+}
+
+.instance-table__th--sortable:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: -2px;
+}
+
+/* Sort indicator arrows */
+.sort-indicator {
+  font-size: 10px;
+  margin-left: 4px;
+  color: var(--color-primary);
+}
+
+.sort-indicator--inactive {
+  color: var(--color-text-faint);
 }
 
 .instance-table__th--action {

--- a/web/src/components/InstanceTable.tsx
+++ b/web/src/components/InstanceTable.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import type { K8sObject } from '@/lib/api'
 import { extractReadyStatus, formatAge, extractCreationTimestamp } from '@/lib/format'
@@ -17,42 +18,133 @@ function truncate(s: string): { display: string; full: string } {
   return { display: s.slice(0, MAX_NAME_LEN) + '…', full: s }
 }
 
+type SortKey = 'name' | 'age' | 'ready'
+type SortDir = 'asc' | 'desc'
+
+function rawName(item: K8sObject): string {
+  const meta = item.metadata as Record<string, unknown> | undefined
+  return typeof meta?.name === 'string' ? meta.name : ''
+}
+
+/** Compare instances for a given sort key and direction. */
+function compareItems(a: K8sObject, b: K8sObject, key: SortKey, dir: SortDir): number {
+  let cmp = 0
+  if (key === 'name') {
+    cmp = rawName(a).localeCompare(rawName(b))
+  } else if (key === 'age') {
+    const aTs = extractCreationTimestamp(a)
+    const bTs = extractCreationTimestamp(b)
+    const aMs = aTs ? new Date(aTs).getTime() : 0
+    const bMs = bTs ? new Date(bTs).getTime() : 0
+    // Newest first by default (desc): higher timestamp = smaller age
+    cmp = bMs - aMs
+  } else if (key === 'ready') {
+    const { state: aState } = extractReadyStatus(a)
+    const { state: bState } = extractReadyStatus(b)
+    // Worst first: error=0, reconciling=1, pending=2, alive=3, unknown=4
+    const order: Record<string, number> = {
+      error: 0, reconciling: 1, pending: 2, alive: 3, unknown: 4,
+    }
+    cmp = (order[aState] ?? 4) - (order[bState] ?? 4)
+  }
+  return dir === 'asc' ? cmp : -cmp
+}
+
 /**
  * InstanceTable — renders all live CR instances of an RGD.
  *
- * Columns: name, namespace, age, readiness badge, open link.
- * Name is truncated at 63 chars with a title tooltip. FR-004, FR-005.
+ * Columns: Name, Namespace, Age, Ready, Open link.
+ * Sortable columns: Name (A→Z default), Age (newest first default),
+ * Ready (worst first default — errors before healthy).
  *
+ * Issue #71: adds clickable column headers with sort indicators.
  * Spec: .specify/specs/004-instance-list/spec.md
  */
 export default function InstanceTable({ items, rgdName }: InstanceTableProps) {
+  // Default: Ready asc = errors first (worst-first per constitution §XIII)
+  const [sortKey, setSortKey] = useState<SortKey>('ready')
+  const [sortDir, setSortDir] = useState<SortDir>('asc')
+
+  function handleSort(key: SortKey) {
+    if (key === sortKey) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      // Default directions when activating a column:
+      //   age → newest first (desc), others → asc
+      setSortDir(key === 'age' ? 'desc' : 'asc')
+    }
+  }
+
+  const sorted = [...items].sort((a, b) => compareItems(a, b, sortKey, sortDir))
+
+  function sortIndicator(key: SortKey) {
+    if (sortKey !== key) {
+      return <span className="sort-indicator sort-indicator--inactive" aria-hidden="true">⇅</span>
+    }
+    return (
+      <span className="sort-indicator" aria-hidden="true">
+        {sortDir === 'asc' ? '↑' : '↓'}
+      </span>
+    )
+  }
+
+  function ariaSortAttr(key: SortKey): 'ascending' | 'descending' | 'none' {
+    if (sortKey !== key) return 'none'
+    return sortDir === 'asc' ? 'ascending' : 'descending'
+  }
+
   return (
     <table className="instance-table" data-testid="instance-table">
       <thead>
         <tr>
-          <th className="instance-table__th">Name</th>
+          <th
+            className="instance-table__th instance-table__th--sortable"
+            aria-sort={ariaSortAttr('name')}
+            onClick={() => handleSort('name')}
+            tabIndex={0}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleSort('name') }}
+          >
+            Name {sortIndicator('name')}
+          </th>
           <th className="instance-table__th">Namespace</th>
-          <th className="instance-table__th">Age</th>
-          <th className="instance-table__th">Ready</th>
+          <th
+            className="instance-table__th instance-table__th--sortable"
+            aria-sort={ariaSortAttr('age')}
+            onClick={() => handleSort('age')}
+            tabIndex={0}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleSort('age') }}
+          >
+            Age {sortIndicator('age')}
+          </th>
+          <th
+            className="instance-table__th instance-table__th--sortable"
+            aria-sort={ariaSortAttr('ready')}
+            onClick={() => handleSort('ready')}
+            tabIndex={0}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleSort('ready') }}
+          >
+            Ready {sortIndicator('ready')}
+          </th>
           <th className="instance-table__th instance-table__th--action" />
         </tr>
       </thead>
       <tbody>
-        {items.map((item) => {
+        {sorted.map((item) => {
           const meta = item.metadata as Record<string, unknown> | undefined
-          const rawName = typeof meta?.name === 'string' ? meta.name : ''
+          const name = typeof meta?.name === 'string' ? meta.name : ''
           const namespace =
             typeof meta?.namespace === 'string' ? meta.namespace : ''
           const createdAt = extractCreationTimestamp(item)
           const age = createdAt ? formatAge(createdAt) : '—'
           const readyStatus = extractReadyStatus(item)
-          const { display, full } = truncate(rawName)
+          const { display, full } = truncate(name)
 
           return (
             <tr
-              key={`${namespace}/${rawName}`}
+              key={`${namespace}/${name}`}
               className="instance-table__row"
-              data-testid={`instance-row-${rawName}`}
+              data-testid={`instance-row-${name}`}
             >
               <td
                 className="instance-table__td instance-table__td--name"
@@ -75,10 +167,10 @@ export default function InstanceTable({ items, rgdName }: InstanceTableProps) {
               </td>
               <td className="instance-table__td instance-table__td--action">
                 <Link
-                  to={`/rgds/${encodeURIComponent(rgdName)}/instances/${encodeURIComponent(namespace)}/${encodeURIComponent(rawName)}`}
+                  to={`/rgds/${encodeURIComponent(rgdName)}/instances/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`}
                   className="instance-table__open-link"
                   data-testid="btn-open"
-                  aria-label={`Open instance ${rawName}`}
+                  aria-label={`Open instance ${name}`}
                 >
                   Open
                 </Link>

--- a/web/src/components/LiveDAG.tsx
+++ b/web/src/components/LiveDAG.tsx
@@ -4,12 +4,22 @@
 // DAGGraph layout (no re-layout on state change — FR-005).
 //
 // Spec 011 extension: collection nodes receive a CollectionBadge health overlay.
+// Fix #64: SVG height is fitted to actual node bounding box.
 
 import type { DAGGraph, DAGNode } from '@/lib/dag'
 import type { NodeStateMap, NodeLiveState } from '@/lib/instanceNodeState'
 import type { K8sObject } from '@/lib/api'
 import CollectionBadge from './CollectionBadge'
 import './LiveDAG.css'
+
+const PADDING = 32
+
+/** Compute the actual content height from node bounding boxes (issue #64). */
+function fittedHeight(graph: DAGGraph): number {
+  if (graph.nodes.length === 0) return graph.height
+  const maxBottom = Math.max(...graph.nodes.map((n) => n.y + n.height))
+  return maxBottom + PADDING
+}
 
 interface LiveDAGProps {
   graph: DAGGraph
@@ -192,14 +202,15 @@ export default function LiveDAG({
   children,
 }: LiveDAGProps) {
   const nodeMap = new Map(graph.nodes.map((n) => [n.id, n]))
+  const svgHeight = fittedHeight(graph)
 
   return (
     <div className="dag-graph-container live-dag-container">
       <svg
         data-testid="dag-svg"
         width={graph.width}
-        height={graph.height}
-        viewBox={`0 0 ${graph.width} ${graph.height}`}
+        height={svgHeight}
+        viewBox={`0 0 ${graph.width} ${svgHeight}`}
         xmlns="http://www.w3.org/2000/svg"
         aria-label="Live resource dependency graph"
         role="img"

--- a/web/src/components/RGDCard.css
+++ b/web/src/components/RGDCard.css
@@ -4,11 +4,95 @@
   border-radius: var(--radius);
   padding: 16px;
   transition: border-color var(--transition);
+  display: flex;
+  flex-direction: column;
 }
 
 .rgd-card:hover {
   border-color: var(--color-border-focus);
 }
+
+/* Body link — covers header + meta, entire clickable area (issue #65) */
+.rgd-card__body-link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  flex: 1;
+}
+
+.rgd-card__body-link:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.rgd-card__header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.rgd-card__name {
+  font-family: var(--font-sans);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rgd-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.rgd-card__kind {
+  display: inline-block;
+  padding: 2px 8px;
+  background-color: var(--color-primary-muted);
+  color: var(--color-primary-text);
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.rgd-card__resources {
+  /* inherits from meta */
+}
+
+.rgd-card__age {
+  /* inherits from meta */
+}
+
+.rgd-card__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.rgd-card__btn {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-primary);
+  text-decoration: none;
+  padding: 4px 12px;
+  border-radius: var(--radius-sm);
+  transition: background-color var(--transition-fast), color var(--transition-fast);
+}
+
+.rgd-card__btn:hover {
+  background-color: var(--color-primary-muted);
+  color: var(--color-primary-hover);
+}
+
 
 .rgd-card__header {
   display: flex;

--- a/web/src/components/RGDCard.tsx
+++ b/web/src/components/RGDCard.tsx
@@ -26,31 +26,32 @@ export default function RGDCard({ rgd }: RGDCardProps) {
 
   return (
     <article className="rgd-card" data-testid={`rgd-card-${name}`}>
-      <div className="rgd-card__header">
-        <StatusDot state={state} reason={reason} message={message} />
-        <h2 className="rgd-card__name" data-testid="rgd-name">
-          {name}
-        </h2>
-      </div>
-      <div className="rgd-card__meta">
-        {kind && (
-          <span className="rgd-card__kind" data-testid="rgd-kind">
-            {kind}
+      {/* Primary link wraps the full card body — issue #65 */}
+      <Link
+        to={`/rgds/${encodedName}`}
+        className="rgd-card__body-link"
+        data-testid="btn-graph"
+        aria-label={`View ${name} graph`}
+      >
+        <div className="rgd-card__header">
+          <StatusDot state={state} reason={reason} message={message} />
+          <h2 className="rgd-card__name" data-testid="rgd-name">
+            {name}
+          </h2>
+        </div>
+        <div className="rgd-card__meta">
+          {kind && (
+            <span className="rgd-card__kind" data-testid="rgd-kind">
+              {kind}
+            </span>
+          )}
+          <span className="rgd-card__resources">
+            {resourceCount} resource{resourceCount !== 1 ? 's' : ''}
           </span>
-        )}
-        <span className="rgd-card__resources">
-          {resourceCount} resource{resourceCount !== 1 ? 's' : ''}
-        </span>
-        <span className="rgd-card__age">{formatAge(createdAt)}</span>
-      </div>
+          <span className="rgd-card__age">{formatAge(createdAt)}</span>
+        </div>
+      </Link>
       <div className="rgd-card__actions">
-        <Link
-          to={`/rgds/${encodedName}`}
-          className="rgd-card__btn"
-          data-testid="btn-graph"
-        >
-          Graph
-        </Link>
         <Link
           to={`/rgds/${encodedName}?tab=instances`}
           className="rgd-card__btn"

--- a/web/src/hooks/usePageTitle.ts
+++ b/web/src/hooks/usePageTitle.ts
@@ -1,0 +1,22 @@
+// usePageTitle — sets document.title on mount/update.
+// Format: "<title> — kro-ui" (or just "kro-ui" for the home page).
+// Implements constitution §XIII, issue #67.
+
+import { useEffect } from 'react'
+
+const SUFFIX = ' — kro-ui'
+
+/**
+ * Sets document.title to `${title} — kro-ui`.
+ * Pass an empty string (or omit) to set just "kro-ui" (home page).
+ */
+export function usePageTitle(title: string): void {
+  useEffect(() => {
+    document.title = title ? title + SUFFIX : 'kro-ui'
+    return () => {
+      // Reset to bare "kro-ui" on unmount so navigating back doesn't
+      // keep stale titles while the next page mounts.
+      document.title = 'kro-ui'
+    }
+  }, [title])
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -113,6 +113,8 @@ export interface GVRPermission {
 export interface AccessResponse {
   serviceAccount: string
   serviceAccountFound: boolean
+  /** The name of the primary ClusterRole bound to kro's SA. Empty if not found. */
+  clusterRole: string
   hasGaps: boolean
   permissions: GVRPermission[]
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -11,6 +11,7 @@ import Fleet from './pages/Fleet'
 import RGDDetail from './pages/RGDDetail'
 import InstanceDetail from './pages/InstanceDetail'
 import Events from './pages/Events'
+import NotFound from './pages/NotFound'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
@@ -23,6 +24,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           <Route path="/events" element={<Events />} />
           <Route path="/rgds/:name" element={<RGDDetail />} />
           <Route path="/rgds/:rgdName/instances/:namespace/:instanceName" element={<InstanceDetail />} />
+          <Route path="*" element={<NotFound />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { K8sObject } from '@/lib/api'
 import { listRGDs, listInstances } from '@/lib/api'
 import { extractRGDName } from '@/lib/format'
+import { usePageTitle } from '@/hooks/usePageTitle'
 import {
   buildChainingMap,
   collectAllLabels,
@@ -28,6 +29,7 @@ const SORT_OPTIONS: { value: SortOption; label: string }[] = [
 ]
 
 export default function Catalog() {
+  usePageTitle('Catalog')
   const [items, setItems] = useState<K8sObject[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)

--- a/web/src/pages/Events.css
+++ b/web/src/pages/Events.css
@@ -41,6 +41,67 @@
   color: var(--color-text-faint);
 }
 
+/* ── Filter bar (issue #66) ─────────────────────────────────────────── */
+
+.events-page__filter-bar {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.events-page__filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.events-page__filter-label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.events-page__filter-input {
+  padding: 5px 10px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  font-family: var(--font-mono);
+  color: var(--color-text);
+  min-width: 200px;
+  transition: border-color var(--transition-fast);
+}
+
+.events-page__filter-input::placeholder {
+  color: var(--color-text-faint);
+}
+
+.events-page__filter-input:focus {
+  outline: none;
+  border-color: var(--color-border-focus);
+}
+
+.events-page__clear-filters-btn {
+  padding: 5px 12px;
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  align-self: flex-end;
+}
+
+.events-page__clear-filters-btn:hover {
+  background: var(--color-surface-2);
+  color: var(--color-text);
+}
+
 /* ── Controls bar ──────────────────────────────────────────────────── */
 
 .events-page__controls {
@@ -48,25 +109,6 @@
   align-items: center;
   gap: 12px;
   flex-wrap: wrap;
-}
-
-/* Active filter tags */
-.events-page__filters {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.events-page__filter-tag {
-  display: inline-flex;
-  align-items: center;
-  padding: 2px 8px;
-  background: var(--color-primary-muted);
-  border: 1px solid var(--color-primary);
-  border-radius: var(--radius-sm);
-  font-size: 11px;
-  font-family: var(--font-mono);
-  color: var(--color-primary-text);
 }
 
 /* View mode toggle button group */

--- a/web/src/pages/Events.test.tsx
+++ b/web/src/pages/Events.test.tsx
@@ -195,11 +195,15 @@ describe('Events', () => {
     })
   })
 
-  it('shows active filter tags for ?instance= and ?rgd= params', async () => {
+  it('shows filter inputs pre-populated from ?instance= and ?rgd= params', async () => {
     mockedListEvents.mockResolvedValue({ items: [], metadata: {} })
     renderEvents('/events?instance=my-app&rgd=my-rgd')
-    // The filter tags render synchronously based on URL params.
-    expect(screen.getByText('instance: my-app')).toBeInTheDocument()
-    expect(screen.getByText('rgd: my-rgd')).toBeInTheDocument()
+    // The filter inputs are pre-populated from URL params.
+    const rgdInput = screen.getByTestId('rgd-filter-input') as HTMLInputElement
+    const instanceInput = screen.getByTestId('instance-filter-input') as HTMLInputElement
+    expect(rgdInput.value).toBe('my-rgd')
+    expect(instanceInput.value).toBe('my-app')
+    // Clear filters button should appear when both filters are active
+    expect(screen.getByTestId('clear-filters-btn')).toBeInTheDocument()
   })
 })

--- a/web/src/pages/Events.tsx
+++ b/web/src/pages/Events.tsx
@@ -1,13 +1,14 @@
 // Events.tsx — Smart event stream page for kro-relevant Kubernetes events.
 //
 // Implements spec 019-smart-event-stream.
+// Extended by issue #66: adds filter input controls for instance and RGD.
 //
 // Data flow:
 //   - Poll: listEvents(namespace, rgd) every 5s
 //   - De-duplicate: new events merged into a Map keyed by metadata.uid
 //   - Slice: most recent MAX_EVENTS (200) shown; "Load more" reveals older
 //   - Views: "Stream" (chronological) / "By Instance" (grouped/collapsible)
-//   - URL params: ?instance=X and ?rgd=Y set initial filter
+//   - URL params: ?instance=X and ?rgd=Y set initial filter (and are kept in sync)
 //   - Anomalies: detectAnomalies() computed from visible events, renders banners
 
 import { useState, useMemo, useRef, useCallback, useEffect } from 'react'
@@ -20,6 +21,7 @@ import {
   detectAnomalies,
 } from '@/lib/events'
 import type { KubeEvent } from '@/lib/events'
+import { usePageTitle } from '@/hooks/usePageTitle'
 import EventRow from '@/components/EventRow'
 import EventGroup from '@/components/EventGroup'
 import AnomalyBanner from '@/components/AnomalyBanner'
@@ -41,11 +43,49 @@ type ViewMode = 'stream' | 'grouped'
  * Events — filtered, grouped, anomaly-detecting kro event stream.
  *
  * Spec: .specify/specs/019-smart-event-stream/ FR-001–FR-008, SC-001–SC-005
+ * Fix #66: adds filter input UI (instance text input, RGD text input, clear button).
  */
 export default function Events() {
-  const [searchParams] = useSearchParams()
-  const instanceFilter = searchParams.get('instance') ?? ''
+  usePageTitle('Events')
+
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  // ── Filter state — driven by URL params, controlled by inputs ────────────
+  // These are the "committed" filters — they drive the API call and URL.
   const rgdFilter = searchParams.get('rgd') ?? ''
+  const instanceFilter = searchParams.get('instance') ?? ''
+
+  // Local input state — updates URL on blur / Enter / debounce.
+  const [rgdInput, setRgdInput] = useState(rgdFilter)
+  const [instanceInput, setInstanceInput] = useState(instanceFilter)
+
+  // Sync inputs when URL params change externally (e.g. back-navigation).
+  useEffect(() => { setRgdInput(rgdFilter) }, [rgdFilter])
+  useEffect(() => { setInstanceInput(instanceFilter) }, [instanceFilter])
+
+  function commitRgd(value: string) {
+    const trimmed = value.trim()
+    const next: Record<string, string> = {}
+    if (trimmed) next.rgd = trimmed
+    if (instanceFilter) next.instance = instanceFilter
+    setSearchParams(next)
+  }
+
+  function commitInstance(value: string) {
+    const trimmed = value.trim()
+    const next: Record<string, string> = {}
+    if (rgdFilter) next.rgd = rgdFilter
+    if (trimmed) next.instance = trimmed
+    setSearchParams(next)
+  }
+
+  function clearFilters() {
+    setRgdInput('')
+    setInstanceInput('')
+    setSearchParams({})
+  }
+
+  const hasFilters = rgdFilter !== '' || instanceFilter !== ''
 
   // ── De-duplication map: uid → KubeEvent ──────────────────────────
   const eventMapRef = useRef<Map<string, KubeEvent>>(new Map())
@@ -60,7 +100,7 @@ export default function Events() {
   // ── View mode toggle ─────────────────────────────────────────────
   const [viewMode, setViewMode] = useState<ViewMode>('stream')
 
-  // ── Reset event map when RGD filter changes (instanceFilter is UI-only) ──
+  // ── Reset event map when RGD filter changes (server-side filter) ──
   useEffect(() => {
     eventMapRef.current = new Map()
     setAllEvents([])
@@ -115,7 +155,7 @@ export default function Events() {
     }
   }, [fetchAndMerge])
 
-  // ── Filter by ?instance= URL param ───────────────────────────────
+  // ── Filter by ?instance= param (client-side) ─────────────────────
   const filteredEvents = useMemo(() => {
     if (!instanceFilter) return allEvents
     return allEvents.filter(e => e.involvedObject.name === instanceFilter)
@@ -153,19 +193,53 @@ export default function Events() {
           )}
         </div>
 
-        <div className="events-page__controls">
-          {/* Active filters display */}
-          {(instanceFilter || rgdFilter) && (
-            <div className="events-page__filters" data-testid="active-filters">
-              {instanceFilter && (
-                <span className="events-page__filter-tag">instance: {instanceFilter}</span>
-              )}
-              {rgdFilter && (
-                <span className="events-page__filter-tag">rgd: {rgdFilter}</span>
-              )}
-            </div>
+        {/* ── Filter bar (issue #66) ── */}
+        <div className="events-page__filter-bar" data-testid="filter-bar">
+          <div className="events-page__filter-field">
+            <label htmlFor="events-rgd-filter" className="events-page__filter-label">
+              RGD
+            </label>
+            <input
+              id="events-rgd-filter"
+              type="text"
+              className="events-page__filter-input"
+              placeholder="Filter by RGD name…"
+              value={rgdInput}
+              data-testid="rgd-filter-input"
+              onChange={e => setRgdInput(e.target.value)}
+              onBlur={e => commitRgd(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') commitRgd(rgdInput) }}
+            />
+          </div>
+          <div className="events-page__filter-field">
+            <label htmlFor="events-instance-filter" className="events-page__filter-label">
+              Instance
+            </label>
+            <input
+              id="events-instance-filter"
+              type="text"
+              className="events-page__filter-input"
+              placeholder="Filter by instance name…"
+              value={instanceInput}
+              data-testid="instance-filter-input"
+              onChange={e => setInstanceInput(e.target.value)}
+              onBlur={e => commitInstance(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') commitInstance(instanceInput) }}
+            />
+          </div>
+          {hasFilters && (
+            <button
+              type="button"
+              className="events-page__clear-filters-btn"
+              onClick={clearFilters}
+              data-testid="clear-filters-btn"
+            >
+              Clear filters
+            </button>
           )}
+        </div>
 
+        <div className="events-page__controls">
           {/* View mode toggle */}
           <div className="events-page__view-toggle" role="group" aria-label="View mode">
             <button

--- a/web/src/pages/Fleet.css
+++ b/web/src/pages/Fleet.css
@@ -4,6 +4,16 @@
   margin: 0 auto;
 }
 
+/* Title row with refresh button (issue #72) */
+.fleet__title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+
 .fleet__heading {
   font-size: 1.5rem;
   font-weight: 600;
@@ -14,7 +24,47 @@
 .fleet__subheading {
   font-size: 0.875rem;
   color: var(--color-text-muted);
-  margin-bottom: 24px;
+  margin: 0;
+}
+
+.fleet__refresh-area {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+  padding-top: 4px;
+}
+
+.fleet__refresh-hint {
+  font-size: 12px;
+  color: var(--color-text-faint);
+}
+
+.fleet__refresh-btn {
+  padding: 6px 14px;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.fleet__refresh-btn:hover:not(:disabled) {
+  background: var(--color-surface-2);
+  border-color: var(--color-primary);
+  color: var(--color-text);
+}
+
+.fleet__refresh-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.fleet__refresh-btn:focus-visible {
+  outline: 2px solid var(--color-border-focus);
+  outline-offset: 2px;
 }
 
 /* Cluster cards grid */

--- a/web/src/pages/Fleet.tsx
+++ b/web/src/pages/Fleet.tsx
@@ -1,21 +1,81 @@
 // Fleet — multi-cluster overview page.
 // Fetches GET /api/v1/fleet/summary on mount.
 // Cluster card clicks switch context and navigate to home (FR-004).
+// Issue #72: adds manual refresh button + last-refreshed timestamp.
+// Issue #62: deduplicates clusters pointing to the same server URL.
 
 import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { getFleetSummary, switchContext } from '@/lib/api'
 import type { ClusterSummary } from '@/lib/api'
+import { usePageTitle } from '@/hooks/usePageTitle'
 import ClusterCard from '@/components/ClusterCard'
 import FleetMatrix from '@/components/FleetMatrix'
 import SkeletonCard from '@/components/SkeletonCard'
 import './Fleet.css'
 
+/**
+ * Deduplicate clusters that point to the same server URL (issue #62).
+ *
+ * When multiple kubeconfig contexts point to the same physical cluster,
+ * we keep the first one and attach the other context names as aliases.
+ * The shortest/friendliest name (fewest chars, or non-ARN) is preferred.
+ *
+ * Returns the deduplicated list; each entry now has an optional `aliases` field
+ * listing the other context names that share the same server.
+ */
+function deduplicateClusters(
+  clusters: ClusterSummary[],
+): (ClusterSummary & { aliases?: string[] })[] {
+  const seenByCluster = new Map<string, ClusterSummary & { aliases?: string[] }>()
+
+  for (const c of clusters) {
+    // Use `cluster` (server URL or cluster name) as the dedup key.
+    // Fall back to context name if cluster is empty.
+    const key = c.cluster || c.context
+
+    if (!seenByCluster.has(key)) {
+      seenByCluster.set(key, { ...c, aliases: [] })
+    } else {
+      const existing = seenByCluster.get(key)!
+      existing.aliases = existing.aliases ?? []
+      existing.aliases.push(c.context)
+
+      // Prefer the shorter / friendlier display name
+      if (c.context.length < existing.context.length) {
+        const oldContext = existing.context
+        existing.context = c.context
+        existing.aliases = existing.aliases.filter((a) => a !== c.context)
+        existing.aliases.push(oldContext)
+      }
+    }
+  }
+
+  return Array.from(seenByCluster.values())
+}
+
+/** Format a Date as "Xs ago" / "Xm ago" / "just now". */
+function formatAgo(date: Date): string {
+  const s = Math.max(0, Math.floor((Date.now() - date.getTime()) / 1000))
+  if (s < 5) return 'just now'
+  if (s < 60) return `${s}s ago`
+  return `${Math.floor(s / 60)}m ago`
+}
+
 export default function Fleet() {
+  usePageTitle('Fleet')
   const [clusters, setClusters] = useState<ClusterSummary[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
+  const [, setTick] = useState(0)
   const navigate = useNavigate()
+
+  // Re-render every 15s to update the "refreshed N ago" counter
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 15_000)
+    return () => clearInterval(id)
+  }, [])
 
   const fetchFleet = useCallback(() => {
     setIsLoading(true)
@@ -23,6 +83,7 @@ export default function Fleet() {
     getFleetSummary()
       .then((res) => {
         setClusters(res.clusters)
+        setLastRefresh(new Date())
       })
       .catch((err: unknown) => {
         setError(err instanceof Error ? err.message : String(err))
@@ -52,10 +113,13 @@ export default function Fleet() {
     [navigate],
   )
 
+  // Deduplicate aliases before rendering (issue #62)
+  const deduped = deduplicateClusters(clusters)
+
   // Build rgdsByContext map for the FleetMatrix (FR-005).
   const rgdsByContext: Record<string, Array<{ kind: string; health: 'healthy' | 'degraded' }>> =
     {}
-  for (const c of clusters) {
+  for (const c of deduped) {
     if (c.rgdKinds && c.rgdKinds.length > 0) {
       rgdsByContext[c.context] = c.rgdKinds.map((kind) => ({
         kind,
@@ -66,10 +130,30 @@ export default function Fleet() {
 
   return (
     <div className="fleet">
-      <h1 className="fleet__heading">Fleet Overview</h1>
-      <p className="fleet__subheading">All kubeconfig contexts</p>
+      <div className="fleet__title-row">
+        <div>
+          <h1 className="fleet__heading">Fleet Overview</h1>
+          <p className="fleet__subheading">All kubeconfig contexts</p>
+        </div>
+        <div className="fleet__refresh-area">
+          {lastRefresh && !isLoading && (
+            <span className="fleet__refresh-hint" aria-live="polite">
+              Updated {formatAgo(lastRefresh)}
+            </span>
+          )}
+          <button
+            type="button"
+            className="fleet__refresh-btn"
+            onClick={fetchFleet}
+            disabled={isLoading}
+            aria-label="Refresh fleet data"
+          >
+            {isLoading ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
+      </div>
 
-      {isLoading && (
+      {isLoading && clusters.length === 0 && (
         <div className="fleet__grid">
           <SkeletonCard />
           <SkeletonCard />
@@ -86,16 +170,16 @@ export default function Fleet() {
         </div>
       )}
 
-      {!isLoading && error === null && clusters.length === 0 && (
+      {!isLoading && error === null && deduped.length === 0 && (
         <div className="fleet__empty">
           <p>No kubeconfig contexts found.</p>
         </div>
       )}
 
-      {!isLoading && error === null && clusters.length > 0 && (
+      {error === null && deduped.length > 0 && (
         <>
           <div className="fleet__grid">
-            {clusters.map((c) => (
+            {deduped.map((c) => (
               <ClusterCard key={c.context} summary={c} onSwitch={handleSwitch} />
             ))}
           </div>
@@ -107,7 +191,7 @@ export default function Fleet() {
             <p className="fleet__section-subheading">
               Which RGD kinds are deployed in which clusters
             </p>
-            <FleetMatrix clusters={clusters} rgdsByContext={rgdsByContext} />
+            <FleetMatrix clusters={deduped} rgdsByContext={rgdsByContext} />
           </section>
         </>
       )}

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -4,11 +4,13 @@ import { useCallback, useEffect, useState } from 'react'
 import type { K8sObject } from '@/lib/api'
 import { listRGDs } from '@/lib/api'
 import { extractRGDName } from '@/lib/format'
+import { usePageTitle } from '@/hooks/usePageTitle'
 import RGDCard from '@/components/RGDCard'
 import SkeletonCard from '@/components/SkeletonCard'
 import './Home.css'
 
 export default function Home() {
+  usePageTitle('')
   const [items, setItems] = useState<K8sObject[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)

--- a/web/src/pages/InstanceDetail.css
+++ b/web/src/pages/InstanceDetail.css
@@ -18,11 +18,29 @@
 /* ── Breadcrumbs ─────────────────────────────────────────────────────────── */
 
 .instance-detail-breadcrumbs {
+  font-size: 12px;
+}
+
+.breadcrumb-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 12px;
+  gap: 0;
+  flex-wrap: wrap;
+}
+
+.breadcrumb-item {
+  display: flex;
+  align-items: center;
   color: var(--color-text-muted);
+}
+
+.breadcrumb-item + .breadcrumb-item::before {
+  content: '›';
+  margin: 0 6px;
+  color: var(--color-text-faint);
 }
 
 .breadcrumb-link {
@@ -33,10 +51,6 @@
 
 .breadcrumb-link:hover {
   color: var(--color-primary-hover);
-}
-
-.breadcrumb-sep {
-  color: var(--color-text-faint);
 }
 
 .breadcrumb-current {

--- a/web/src/pages/InstanceDetail.tsx
+++ b/web/src/pages/InstanceDetail.tsx
@@ -15,6 +15,7 @@
 
 import { useMemo, useState, useCallback, useEffect, useRef } from 'react'
 import { useParams, Link } from 'react-router-dom'
+import { usePageTitle } from '@/hooks/usePageTitle'
 import {
   getInstance,
   getInstanceEvents,
@@ -256,6 +257,13 @@ export default function InstanceDetail() {
   // ── Instance name for breadcrumbs ────────────────────────────────────────
   const displayName = instanceName ?? '…'
 
+  // ── Page title ──────────────────────────────────────────────────────────
+  usePageTitle(
+    instanceName && rgdName
+      ? `${instanceName} / ${rgdName}`
+      : instanceName ?? rgdName ?? ''
+  )
+
   // ── Loading: gate only on the fast poll (instance + events) ─────────────
   // Children load separately and do not block DAG rendering.
   const isLoading = pollLoading && !fastData
@@ -264,18 +272,27 @@ export default function InstanceDetail() {
 
   return (
     <div data-testid="instance-detail-page" className="instance-detail">
-      {/* Breadcrumbs */}
-      <div className="instance-detail-breadcrumbs">
-        <Link to="/" className="breadcrumb-link">Home</Link>
-        <span className="breadcrumb-sep">›</span>
-        {rgdName && (
-          <>
-            <Link to={`/rgds/${rgdName}`} className="breadcrumb-link">{rgdName}</Link>
-            <span className="breadcrumb-sep">›</span>
-          </>
-        )}
-        <span className="breadcrumb-current">{displayName}</span>
-      </div>
+      {/* Breadcrumbs — issue #70: add Instances segment */}
+      <nav className="instance-detail-breadcrumbs" aria-label="Breadcrumb">
+        <ol className="breadcrumb-list">
+          <li className="breadcrumb-item">
+            <Link to="/" className="breadcrumb-link">Home</Link>
+          </li>
+          {rgdName && (
+            <li className="breadcrumb-item">
+              <Link to={`/rgds/${rgdName}`} className="breadcrumb-link">{rgdName}</Link>
+            </li>
+          )}
+          {rgdName && (
+            <li className="breadcrumb-item">
+              <Link to={`/rgds/${rgdName}?tab=instances`} className="breadcrumb-link">Instances</Link>
+            </li>
+          )}
+          <li className="breadcrumb-item">
+            <span className="breadcrumb-current" aria-current="page">{displayName}</span>
+          </li>
+        </ol>
+      </nav>
 
       {/* Header */}
       <div className="instance-detail-header">

--- a/web/src/pages/NotFound.css
+++ b/web/src/pages/NotFound.css
@@ -1,0 +1,55 @@
+/* NotFound.css — 404 page styles. */
+
+.not-found {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 80px 24px;
+  gap: 12px;
+  text-align: center;
+}
+
+.not-found__heading {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.not-found__url {
+  font-size: 14px;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.not-found__url code {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  background: var(--color-surface-2);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+}
+
+.not-found__message {
+  font-size: 14px;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.not-found__home-link {
+  margin-top: 8px;
+  padding: 7px 20px;
+  background: var(--color-primary);
+  color: #fff;
+  border-radius: var(--radius);
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background var(--transition-fast);
+}
+
+.not-found__home-link:hover {
+  background: var(--color-primary-hover);
+}

--- a/web/src/pages/NotFound.tsx
+++ b/web/src/pages/NotFound.tsx
@@ -1,0 +1,26 @@
+// NotFound — 404 page for unmatched routes.
+// Implements constitution §XIII (route completeness), issue #68.
+
+import { Link, useLocation } from 'react-router-dom'
+import { usePageTitle } from '@/hooks/usePageTitle'
+import './NotFound.css'
+
+export default function NotFound() {
+  usePageTitle('Not Found')
+  const location = useLocation()
+
+  return (
+    <div className="not-found" data-testid="not-found-page">
+      <h1 className="not-found__heading">Page not found</h1>
+      <p className="not-found__url" data-testid="not-found-url">
+        <code>{location.pathname}</code>
+      </p>
+      <p className="not-found__message">
+        The page you requested does not exist.
+      </p>
+      <Link to="/" className="not-found__home-link">
+        Back to home
+      </Link>
+    </div>
+  )
+}

--- a/web/src/pages/RGDDetail.tsx
+++ b/web/src/pages/RGDDetail.tsx
@@ -4,6 +4,7 @@ import { getRGD, listInstances } from "@/lib/api"
 import type { K8sObject, K8sList } from "@/lib/api"
 import { toYaml } from "@/lib/yaml"
 import { buildDAGGraph } from "@/lib/dag"
+import { usePageTitle } from "@/hooks/usePageTitle"
 import KroCodeBlock from "@/components/KroCodeBlock"
 import DAGGraph from "@/components/DAGGraph"
 import NodeDetailPanel from "@/components/NodeDetailPanel"
@@ -147,6 +148,9 @@ export default function RGDDetail() {
 
   const rgdName =
     (rgd?.metadata as Record<string, unknown> | undefined)?.name ?? name ?? ""
+
+  // Page title: "<rgdName> — kro-ui"
+  usePageTitle(String(rgdName))
 
   if (loading) {
     return <div className="rgd-detail-loading">Loading…</div>


### PR DESCRIPTION
## Summary

Batch of 11 UX fixes addressing reported issues across the frontend and one backend endpoint enhancement.

## Root Causes & Fixes

| Issue | Fix |
|-------|-----|
| **#62** Fleet shows duplicate cards for alias contexts | `deduplicateClusters()` groups by `cluster` server URL; shorter/friendlier name wins |
| **#63** Context switcher ARN truncation is ambiguous | `truncateContextName` now shows account-ID prefix + cluster name (`319279…/krombat`) |
| **#64** DAG SVG has large empty space below nodes | `fittedHeight()` computes actual bounding box from node positions instead of layout estimate |
| **#65** RGD cards not fully clickable | `<Link>` wraps entire card body in RGDCard + CatalogCard; Instances remains as secondary action |
| **#66** Events page has no filter UI controls | Added RGD + instance text inputs above event list; URL-synced; Clear filters button |
| **#67** Browser tab title never updates | `usePageTitle` hook; all pages call it with correct title |
| **#68** Unknown routes show blank page | `NotFound` component + `path="*"` catch-all route in `main.tsx` |
| **#70** Instance detail has no Instances breadcrumb segment | Breadcrumb now: `Home / <rgd> / Instances / <instance>` with correct links |
| **#71** Instances table unsortable | Sortable Name/Age/Ready headers; default sort = worst-first (errors first) |
| **#72** Fleet page never refreshes | Manual Refresh button + last-refreshed timestamp in Fleet header |
| **#74** Fix commands hardcode `kro-manager-role` | Backend resolves primary ClusterRole from ClusterRoleBindings; frontend uses it with fallback placeholder |

## Testing

- `go vet ./...` — clean
- `GOPROXY=direct GONOSUMDB="*" go test -race ./internal/...` — all pass
- `bun run tsc --noEmit` — clean
- `bun run vitest run` — 353/353 pass

Closes #62, closes #63, closes #64, closes #65, closes #66, closes #67, closes #68, closes #70, closes #71, closes #72, closes #74