### PR TITLE
feat(web): add Kind badge and status dot to RGD detail header

### DIFF
--- a/.specify/specs/036-rgd-detail-header/data-model.md
+++ b/.specify/specs/036-rgd-detail-header/data-model.md
@@ -1,0 +1,127 @@
+# Data Model: 036 — RGD Detail Header Kind Label + Status Badge
+
+**Phase 1 output** for `.specify/specs/036-rgd-detail-header/plan.md`
+
+---
+
+## Entities and Data Flow
+
+This feature introduces no new data entities. All data is derived from the
+`K8sObject` (raw `unstructured.Unstructured`) already fetched by `RGDDetail`
+via `GET /api/v1/rgds/{name}`.
+
+### Consumed Data
+
+| Field path in K8sObject | Extraction function | TypeScript type | Used for |
+|---|---|---|---|
+| `metadata.name` | `extractRGDName(rgd)` | `string` | RGD name `<h1>` (already rendered) |
+| `spec.schema.kind` | `extractRGDKind(rgd)` | `string` (empty if absent) | Kind badge |
+| `status.conditions[type=Ready]` | `extractReadyStatus(rgd)` | `ReadyStatus` | StatusDot |
+
+### `ReadyStatus` shape (from `@/lib/format`)
+
+```ts
+type ReadyState = 'ready' | 'error' | 'unknown'
+
+interface ReadyStatus {
+  state:   ReadyState  // 'ready' | 'error' | 'unknown'
+  reason:  string      // empty string if absent
+  message: string      // empty string if absent
+}
+```
+
+### Degradation rules (from constitution §XII and `extractReadyStatus` implementation)
+
+| Cluster condition | Rendered result |
+|---|---|
+| `status.conditions[type=Ready].status === 'True'` | StatusDot green (`--color-status-ready`) |
+| `status.conditions[type=Ready].status === 'False'` | StatusDot red (`--color-status-error`) |
+| `status.conditions` absent / no Ready entry | StatusDot gray (`--color-status-unknown`), never an error state |
+| `spec.schema.kind` absent or empty | Kind badge omitted entirely — not `?`, not empty string |
+
+---
+
+## Component Changes
+
+### `RGDDetail.tsx` — header block (lines 198–201)
+
+**Before:**
+```tsx
+{/* Header */}
+<div className="rgd-detail-header">
+  <h1 className="rgd-detail-name">{String(rgdName)}</h1>
+</div>
+```
+
+**After (conceptual):**
+```tsx
+{/* Header */}
+<div className="rgd-detail-header">
+  <div className="rgd-detail-header-row">
+    <StatusDot state={readyState.state} reason={readyState.reason} message={readyState.message} />
+    <h1 className="rgd-detail-name">{String(rgdName)}</h1>
+  </div>
+  {rgdKind && (
+    <span className="rgd-detail-kind">{rgdKind}</span>
+  )}
+</div>
+```
+
+New local variables extracted once from `rgd` (before the early-return guards):
+```ts
+const rgdKind = extractRGDKind(rgd)
+const readyState = extractReadyStatus(rgd)
+```
+
+### `RGDDetail.css` — new styles
+
+```css
+/* Header row: StatusDot + name on one line */
+.rgd-detail-header-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+/* Kind badge — visually identical to .rgd-card__kind */
+.rgd-detail-kind {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  background-color: var(--color-primary-muted);
+  color: var(--color-primary-text);
+  margin-bottom: 12px;
+}
+```
+
+The existing `.rgd-detail-name` margin-bottom adjusts from `16px` to `0` (margin
+is moved to `.rgd-detail-header-row` and `.rgd-detail-kind` instead).
+
+---
+
+## Validation Rules
+
+- `rgdKind` guard: `{rgdKind && <span ...>}` — empty string is falsy, so absent
+  Kind automatically omits the badge. This is consistent with `RGDCard.tsx:43`.
+- `readyState` is always a valid `ReadyStatus` (never null); `extractReadyStatus`
+  returns `{ state: 'unknown', ... }` as a safe default.
+
+---
+
+## State Transitions
+
+Not applicable — this feature renders static data from a single fetch.
+The RGD `state` is: `ready | error | unknown` as defined by `extractReadyStatus`.
+
+---
+
+## No new interfaces / contracts
+
+This is a pure frontend UI change. The API contract (`GET /api/v1/rgds/{name}`)
+is unchanged. No new HTTP endpoints, no new response fields.
+The "contracts" directory is skipped per the template note:
+> "Skip if project is purely internal"  
+> (this change exposes nothing new to users or external systems beyond visual polish)

--- a/.specify/specs/036-rgd-detail-header/plan.md
+++ b/.specify/specs/036-rgd-detail-header/plan.md
@@ -1,0 +1,92 @@
+# Implementation Plan: RGD Detail Header — Kind Label + Status Badge
+
+**Branch**: `036-rgd-detail-header` | **Date**: 2026-03-23 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `.specify/specs/036-rgd-detail-header/spec.md`  
+**GitHub Issue**: #130
+
+---
+
+## Summary
+
+The RGD detail page (`/rgds/:name`) currently renders only the RGD name in its
+header `<h1>`. The home page card (`RGDCard`) shows the same name alongside a
+Kind badge (muted blue pill) and a `StatusDot` (green/red/gray circle). This
+feature adds those two missing elements to the detail header using the exact
+same extraction functions and components already used by `RGDCard` — no new
+API calls, no new extraction logic, and no new components.
+
+The change is a minimal, targeted CSS + JSX edit to `RGDDetail.tsx` and
+`RGDDetail.css`.
+
+---
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x + React 19 (frontend only; no backend changes)  
+**Primary Dependencies**: React Router v7, existing `@/lib/format` utilities, existing `StatusDot` component  
+**Storage**: N/A  
+**Testing**: `bun run typecheck` (TypeScript), manual visual verification  
+**Target Platform**: Browser (SPA embedded in Go binary)  
+**Project Type**: Web application — frontend-only change  
+**Performance Goals**: Zero additional API calls; header renders immediately from already-fetched RGD data  
+**Constraints**: All colors must use `tokens.css` custom properties; no hardcoded hex/rgba; no new npm deps  
+**Scale/Scope**: Single component edit — 2 files touched (`RGDDetail.tsx`, `RGDDetail.css`)
+
+---
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Rule | Status | Notes |
+|------|--------|-------|
+| § I Iterative-First | ✅ PASS | Single self-contained change; all dependencies already merged |
+| § II Cluster Adaptability | ✅ PASS | Uses `extractRGDKind` / `extractReadyStatus` from `format.ts` — the only place that knows kro field paths |
+| § III Read-Only | ✅ PASS | No mutation; no API change |
+| § IV Single Binary | ✅ PASS | Frontend-only change; still embedded via `go:embed` |
+| § V Simplicity — no new deps | ✅ PASS | Reuses `StatusDot` + extraction functions already present |
+| § V Simplicity — no CSS frameworks | ✅ PASS | Plain CSS, tokens.css only |
+| § VI Go Standards | ✅ PASS (N/A) | No Go changes |
+| § IX No hardcoded colors | ✅ PASS | Will use `--color-primary-muted`, `--color-primary-text` tokens (same as `.rgd-card__kind`) |
+| § IX Shared helpers | ✅ PASS | `extractRGDKind`, `extractReadyStatus`, `StatusDot` imported — not duplicated |
+| § XII Graceful Degradation | ✅ PASS | Kind omitted when empty; StatusDot shows `unknown` when conditions absent |
+| § XIII Page titles | ✅ PASS | `document.title` remains `<rgdName> — kro-ui` |
+| § XIII No hardcoded config | ✅ PASS | No config values in this change |
+
+**Post-design re-check**: No violations anticipated; feature is a subset of existing patterns.
+
+---
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+.specify/specs/036-rgd-detail-header/
+├── plan.md              ← this file
+├── spec.md              ← feature requirements
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output
+├── quickstart.md        ← Phase 1 output
+└── tasks.md             ← Phase 2 output (/speckit.tasks — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+web/src/pages/
+├── RGDDetail.tsx        ← add StatusDot + Kind badge to header (lines 198–201)
+└── RGDDetail.css        ← add .rgd-detail-header-row, .rgd-detail-kind styles
+
+# No new files. No backend changes.
+```
+
+**Structure Decision**: Single project, frontend-only. All logic lives in the
+existing `web/src/pages/RGDDetail.tsx` and its companion CSS file. The change
+is localized to the `{/* Header */}` block at line 198.
+
+---
+
+## Complexity Tracking
+
+> No constitution violations — section left blank per template instructions.

--- a/.specify/specs/036-rgd-detail-header/quickstart.md
+++ b/.specify/specs/036-rgd-detail-header/quickstart.md
@@ -1,0 +1,36 @@
+# Quickstart: 036 — RGD Detail Header Kind Label + Status Badge
+
+## What this feature does
+
+Adds a Kind label and status dot to the RGD detail page header (`/rgds/:name`),
+matching the information shown on the home page RGD card.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `web/src/pages/RGDDetail.tsx` | Import `StatusDot`, `extractRGDKind`, `extractReadyStatus`; add variables; update header JSX |
+| `web/src/pages/RGDDetail.css` | Add `.rgd-detail-header-row` and `.rgd-detail-kind` CSS rules |
+
+## How to verify
+
+1. Start the dev server:
+   ```bash
+   cd web && bun run dev
+   ```
+2. Navigate to the home page and note the Kind label and status dot on any RGD card.
+3. Click through to the RGD detail page (`/rgds/:name`).
+4. Verify: header shows RGD name, status dot (green/gray/red), and Kind badge.
+5. Verify: if `spec.schema.kind` is absent, the Kind badge is omitted.
+6. Run TypeScript typecheck:
+   ```bash
+   bun run typecheck
+   ```
+
+## Key design decisions
+
+- **No new components** — `StatusDot` is reused directly.
+- **No new extraction functions** — `extractRGDKind` and `extractReadyStatus`
+  from `@/lib/format` cover all needed data.
+- **No new tokens** — all colors come from existing `tokens.css` custom properties.
+- **No new API calls** — status and kind come from the RGD object already fetched.

--- a/.specify/specs/036-rgd-detail-header/research.md
+++ b/.specify/specs/036-rgd-detail-header/research.md
@@ -1,0 +1,123 @@
+# Research: 036 — RGD Detail Header Kind Label + Status Badge
+
+**Phase 0 output** for `.specify/specs/036-rgd-detail-header/plan.md`
+
+---
+
+## Research Task 1: Where is Kind extracted and how is it rendered on the home card?
+
+**Decision**: Use `extractRGDKind(rgd)` from `@/lib/format` (walks `spec.schema.kind`)
+and render with the same `.rgd-card__kind` CSS class pattern: a `<span>` with
+`background: var(--color-primary-muted)` and `color: var(--color-primary-text)`.
+
+**Rationale**: `extractRGDKind` is already the canonical extraction path. The home
+card uses it with a conditional guard (`{kind && <span>...`). Reusing the same
+guard in the detail header ensures graceful degradation when `spec.schema.kind`
+is absent.
+
+**Alternatives considered**:
+- Reading `spec.schema.kind` directly in the component — rejected: would duplicate
+  field path knowledge outside of `format.ts`, violating constitution §II.
+- Showing the raw `kind` from `metadata.labels["kro.run/kind"]` — rejected: label
+  may not exist; `spec.schema.kind` is the authoritative source.
+
+---
+
+## Research Task 2: How is the ReadyStatus extracted and what component renders it?
+
+**Decision**: Use `extractReadyStatus(rgd)` from `@/lib/format` and render the
+existing `StatusDot` component (`web/src/components/StatusDot.tsx`).
+
+**Rationale**: `extractReadyStatus` walks `status.conditions[]`, finds the entry
+with `type === 'Ready'`, and returns `{ state: ReadyState; reason: string; message: string }`.
+When conditions are absent it returns `{ state: 'unknown', reason: '', message: '' }`.
+This matches the graceful-degradation requirement (§XII). `StatusDot` already
+accepts exactly this shape and renders with `role="img"`, `aria-label`, and a
+`title` tooltip — no additional accessibility work needed.
+
+**Alternatives considered**:
+- Using `ReadinessBadge` (text pill with "Ready" / "Not Ready") instead of `StatusDot`
+  (dot) — rejected: the spec says the detail header should match what the home
+  card shows, which uses `StatusDot`.
+- Adding a new combined component — rejected: constitution §V (simplicity) and
+  §IX (shared helpers) both prefer reusing existing components over creating new ones.
+
+---
+
+## Research Task 3: What CSS tokens are needed for the Kind badge?
+
+**Decision**: Reuse the same token set already used by `.rgd-card__kind`:
+
+| CSS property | Token | Value (dark) |
+|---|---|---|
+| `background-color` | `--color-primary-muted` | `rgba(91,142,240,0.12)` |
+| `color` | `--color-primary-text` | `#93b4f8` |
+| `border-radius` | `--radius-sm` | (defined in tokens.css) |
+
+A new CSS class `.rgd-detail-kind` will be added to `RGDDetail.css` rather than
+reusing `.rgd-card__kind` from `RGDCard.css` — the classes live in separate
+component scopes and cross-importing would create coupling.
+
+**No new tokens needed.** All required tokens already exist in `tokens.css`.
+
+**Alternatives considered**:
+- Sharing `.rgd-card__kind` across both components — rejected: CSS is scoped
+  per component; sharing would require moving the rule to a global scope or
+  creating a shared stylesheet, adding unnecessary complexity.
+
+---
+
+## Research Task 4: What is the correct header layout for name + status + kind?
+
+**Decision**: The header will use a two-row layout:
+
+```
+Row 1: [StatusDot] [RGD name h1]
+Row 2:             [Kind badge]  (conditional)
+```
+
+This matches the home card layout exactly (StatusDot + h2 on one line, Kind badge
+in `.rgd-card__meta` below).
+
+A `.rgd-detail-header-row` flexbox wrapper will be added for the first row
+(dot + name), keeping the existing `.rgd-detail-name` `<h1>` in place.
+
+**Rationale**: Placing the Kind below the name matches the information hierarchy
+of the home card (name is primary, kind is secondary). Placing StatusDot inline
+with the name follows the same visual grammar.
+
+**Alternatives considered**:
+- Side-by-side on one line (name → kind badge → status dot) — rejected: the
+  name can be long; crowding additional elements on the same line risks overflow.
+- Kind badge to the right of the name on the same line — acceptable but less
+  consistent with the home card's two-row treatment.
+
+---
+
+## Research Task 5: Does the header need polling / live updates?
+
+**Decision**: No polling needed for the header. The detail page already fetches
+the RGD object once on mount. The status dot will reflect the status at page load
+time, consistent with the rest of the header.
+
+**Rationale**: The spec does not require live-updating the header status. The
+existing page already polls for DAG/instance data in other parts; adding
+independent header polling would increase complexity with minimal user value.
+
+**Alternatives considered**:
+- Deriving status from the already-polled DAG data — not applicable: the detail
+  page fetches a single RGD object, and the status is available directly from it.
+
+---
+
+## All NEEDS CLARIFICATION items resolved
+
+| Item | Resolution |
+|---|---|
+| Which component renders the status in the header? | `StatusDot` — already imported in `RGDCard.tsx`, will be imported in `RGDDetail.tsx` |
+| Which extraction function for Kind? | `extractRGDKind` from `@/lib/format` |
+| Which extraction function for status? | `extractReadyStatus` from `@/lib/format` |
+| New CSS tokens needed? | None — all tokens already in `tokens.css` |
+| New API calls needed? | None — uses the RGD object already fetched |
+| New components needed? | None — `StatusDot` reused |
+| Files to touch? | `RGDDetail.tsx` (lines 198–201 header block), `RGDDetail.css` |

--- a/.specify/specs/036-rgd-detail-header/spec.md
+++ b/.specify/specs/036-rgd-detail-header/spec.md
@@ -1,0 +1,79 @@
+# Spec 036 — RGD Detail Page Header: Kind Label + Status Badge
+
+**GitHub Issue**: #130  
+**Branch**: `036-rgd-detail-header`  
+**Category**: UX Enhancement  
+**Severity**: Low  
+
+---
+
+## Problem
+
+The home page RGD card (`RGDCard`) shows three pieces of information in its header:
+
+1. **RGD name** (e.g. `dungeon-graph`) — as `<h2>`
+2. **Kind label** (e.g. `Dungeon`) — in a muted blue pill badge
+3. **Status dot** — a green/red/gray circle indicating Ready / Not Ready / Unknown
+
+When a user navigates to the RGD detail page (`/rgds/:name`), the `<h1>` shows **only the RGD name**. The Kind label and status badge are **dropped entirely**.
+
+A user who navigates directly to an RGD detail URL (e.g. via a bookmark or deep link) loses important contextual information that was visible on the home card.
+
+---
+
+## Requirements
+
+### FR-001 — Kind Label in Detail Header
+
+The RGD detail page header MUST display the `spec.schema.kind` value as a secondary
+label below (or beside) the RGD name. If `spec.schema.kind` is absent or empty,
+the label MUST be omitted (not rendered as empty or `?`). The visual treatment
+MUST match the Kind badge on the home card (muted blue pill: `--color-primary-muted`
+background, `--color-primary-text` foreground).
+
+### FR-002 — Status Dot in Detail Header
+
+The RGD detail page header MUST display the same `StatusDot` component that the
+home card uses, positioned to the left of or above the RGD name. The dot MUST
+reflect the current `status.conditions[type=Ready]` value. Absent conditions
+render as `unknown` state (gray dot) — never as "Pending" or an error.
+
+### FR-003 — Consistency with Home Card
+
+The three data elements (name, kind, status) MUST be sourced from the same
+extraction functions (`extractRGDName`, `extractRGDKind`, `extractReadyStatus`)
+used by `RGDCard`. No new extraction logic.
+
+### FR-004 — No New API Calls
+
+The Kind and status information MUST be derived from the RGD object already
+fetched by the detail page (`GET /api/v1/rgds/{name}`). No additional API
+requests.
+
+### FR-005 — Document Title Unchanged
+
+The `document.title` format (`<rgdName> — kro-ui`) MUST remain unchanged.
+The title should not include the Kind.
+
+---
+
+## Acceptance Criteria
+
+- [ ] RGD detail header shows RGD name + Kind badge (when Kind is available)
+- [ ] RGD detail header shows StatusDot with correct ready state
+- [ ] Kind badge is omitted when `extractRGDKind` returns empty string
+- [ ] StatusDot shows `unknown` (gray) when `status.conditions` is absent
+- [ ] Layout is visually consistent with the home card header
+- [ ] All colors use tokens from `tokens.css` (no hardcoded hex)
+- [ ] Page title remains `<rgdName> — kro-ui`
+- [ ] TypeScript typecheck passes (`bun run typecheck`)
+- [ ] No new CSS rules use hardcoded `rgba()` or hex values
+
+---
+
+## Out of Scope
+
+- Adding the resource count or age to the detail header
+- Changing the tab bar or breadcrumb
+- Adding tooltips or hover states beyond what `StatusDot` already provides
+- Polling / live-updating the status in the header (the page already polls for graph data)

--- a/.specify/specs/036-rgd-detail-header/tasks.md
+++ b/.specify/specs/036-rgd-detail-header/tasks.md
@@ -1,0 +1,145 @@
+# Tasks: 036 — RGD Detail Header: Kind Label + Status Badge
+
+**Input**: Design documents from `.specify/specs/036-rgd-detail-header/`  
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, quickstart.md ✓  
+**GitHub Issue**: #130  
+**Tests**: Not requested in spec — no test tasks generated.
+
+**Organization**: Single user story (US1) covers all requirements. Phase 1 is skipped
+(no project initialization needed — editing existing files). Phase 2 is trivial
+(no blocking infrastructure). Implementation goes straight to Phase 3.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to
+- Exact file paths included in all descriptions
+
+---
+
+## Phase 1: Setup
+
+> No setup needed — this feature edits two existing files in an already-initialized
+> project. No new directories, dependencies, or infrastructure required.
+
+---
+
+## Phase 2: Foundational
+
+> No blocking prerequisites — `StatusDot`, `extractRGDKind`, `extractReadyStatus`,
+> and all CSS tokens already exist in the codebase. Implementation can begin immediately.
+
+---
+
+## Phase 3: User Story 1 — RGD Detail Header Shows Kind + Status (Priority: P1) 🎯 MVP
+
+**Goal**: The RGD detail page header (`/rgds/:name`) shows the RGD name, a status dot
+(green/red/gray via `StatusDot`), and a Kind badge (muted blue pill) — matching the
+information visible on the home page `RGDCard`.
+
+**Independent Test**: Navigate to any RGD detail page. Header must show:
+1. StatusDot (green if Ready=True, red if Ready=False, gray if absent)
+2. RGD name as `<h1>`
+3. Kind badge below (or omitted entirely if `spec.schema.kind` is absent)
+
+All acceptance criteria from spec.md must be met. Run `bun run typecheck` — zero errors.
+
+### FR-001 — Kind Label in Detail Header
+
+- [x] T001 [P] [US1] Add `.rgd-detail-header-row` flex rule and `.rgd-detail-kind` pill badge styles to `web/src/pages/RGDDetail.css`; adjust `.rgd-detail-name` margin-bottom from `16px` to `0`
+
+### FR-002 + FR-003 — StatusDot + Consistent Extraction in RGDDetail.tsx
+
+- [x] T002 [US1] Import `StatusDot` from `@/components/StatusDot` and import `extractRGDKind`, `extractReadyStatus` from `@/lib/format` in `web/src/pages/RGDDetail.tsx`
+- [x] T003 [US1] Extract `rgdKind` and `readyState` local variables from the already-fetched `rgd` object (after the `if (!rgd) return null` guard) in `web/src/pages/RGDDetail.tsx`
+- [x] T004 [US1] Replace the `{/* Header */}` block (lines 198–201) in `web/src/pages/RGDDetail.tsx` with the two-row layout: `.rgd-detail-header-row` wrapping `<StatusDot>` + `<h1>`, followed by conditional `<span className="rgd-detail-kind">` when `rgdKind` is truthy
+
+**Checkpoint**: Open any RGD detail page — header shows status dot, name, and Kind badge. TypeScript compiles cleanly.
+
+---
+
+## Phase 4: Polish & Cross-Cutting Concerns
+
+- [x] T005 Run `bun run typecheck` in `web/` and fix any type errors introduced by T002–T004
+- [x] T006 Verify no hardcoded `rgba()` or hex values appear in the new CSS rules added in T001 — all colors must use `var(--token-name)` references from `tokens.css`
+- [x] T007 Verify Kind badge is omitted (not blank, not `?`) when navigating to an RGD whose `spec.schema.kind` is absent or empty
+- [x] T008 Update spec comment in `RGDDetail.tsx` JSDoc block (line ~28) to reference spec `036-rgd-detail-header`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 3 (US1)**: No foundational phase to wait for — begin immediately
+- **Phase 4 (Polish)**: Depends on T001–T004 complete
+
+### Within User Story 1
+
+- **T001** (CSS) and **T002** (imports) are independent — both can be done in parallel
+- **T003** depends on T002 (imports must exist before variables are added)
+- **T004** depends on T003 (variables must exist before JSX uses them)
+- **Phase 4** tasks T005–T008 can all run after T004
+
+### Parallel Opportunities
+
+```
+T001 (CSS changes in RGDDetail.css)
+T002 (Import additions in RGDDetail.tsx)
+  ↓
+T003 (Variable extraction in RGDDetail.tsx)
+  ↓
+T004 (JSX header replacement in RGDDetail.tsx)
+  ↓
+T005, T006, T007, T008 (all polish tasks run in parallel)
+```
+
+---
+
+## Parallel Example: User Story 1
+
+```
+# Step 1 — can run in parallel (different concerns, same file is fine sequentially):
+T001: Add CSS rules to web/src/pages/RGDDetail.css
+T002: Add imports to web/src/pages/RGDDetail.tsx
+
+# Step 2 — sequential (T003 needs T002's imports, T004 needs T003's vars):
+T003 → T004
+
+# Step 3 — all polish tasks independent of each other:
+T005, T006, T007, T008
+```
+
+---
+
+## Implementation Strategy
+
+### MVP (This feature is entirely US1 — ship as one increment)
+
+1. T001 — CSS rules (can be done first, no deps)
+2. T002 — Add imports
+3. T003 — Extract variables
+4. T004 — Replace header JSX
+5. T005–T008 — Polish and verify
+6. **VALIDATE**: `bun run typecheck` passes; visual check on RGD detail page
+
+### Incremental Delivery
+
+This feature is small enough to land as a single commit:
+
+```
+feat(web): add Kind badge and status dot to RGD detail header (#130)
+```
+
+Files changed: `web/src/pages/RGDDetail.tsx`, `web/src/pages/RGDDetail.css`
+
+---
+
+## Notes
+
+- [P] tasks = different files or independent concerns, no dependencies between them
+- T001 and T002 touch different files — genuinely parallelizable
+- T003 and T004 both touch `RGDDetail.tsx` — must be sequential
+- No backend changes, no new files, no new npm dependencies
+- `extractRGDKind` returns `''` when absent — the `{rgdKind && ...}` guard handles graceful omission automatically
+- `extractReadyStatus` never returns null — `state: 'unknown'` is the safe default

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,6 +359,7 @@ Always read the spec before writing code. Always run `go vet ./...` and
 - Go 1.25 (backend — no changes) / TypeScript 5.x + React 19 + React Router v7, Vite — all already present; no new npm deps (030-error-patterns-tab)
 - TypeScript 5.x + React 19, Go 1.25 + React, React Router v7, Vite; no new npm deps (027-instance-telemetry-panel)
 - N/A — all data is in-memory React state (027-instance-telemetry-panel)
+- TypeScript 5.x + React 19 (frontend only; no backend changes) + React Router v7, existing `@/lib/format` utilities, existing `StatusDot` componen (036-rgd-detail-header)
 
 ## Recent Changes
 - 026-rgd-yaml-generator: Added Go 1.25 (backend, no changes needed) / TypeScript 5.x + React 19 + React 19, React Router v7, Vite (all already present); no new npm deps

--- a/web/src/pages/RGDDetail.css
+++ b/web/src/pages/RGDDetail.css
@@ -39,11 +39,31 @@
   flex-shrink: 0;
 }
 
+/* Header first row: StatusDot + name on one line */
+.rgd-detail-header-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
 .rgd-detail-name {
   font-size: 20px;
   font-weight: 600;
   color: var(--color-text);
-  margin-bottom: 16px;
+  margin-bottom: 0;
+}
+
+/* Kind badge — mirrors .rgd-card__kind on the home card */
+.rgd-detail-kind {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  background-color: var(--color-primary-muted);
+  color: var(--color-primary-text);
+  margin-bottom: 12px;
 }
 
 /* ── Tab bar ──────────────────────────────────────────────────────────────── */

--- a/web/src/pages/RGDDetail.tsx
+++ b/web/src/pages/RGDDetail.tsx
@@ -4,7 +4,9 @@ import { getRGD, listRGDs, listInstances } from "@/lib/api"
 import type { K8sObject, K8sList } from "@/lib/api"
 import { toYaml } from "@/lib/yaml"
 import { buildDAGGraph, detectCollapseGroups } from "@/lib/dag"
+import { extractRGDKind, extractReadyStatus } from "@/lib/format"
 import { usePageTitle } from "@/hooks/usePageTitle"
+import StatusDot from "@/components/StatusDot"
 import KroCodeBlock from "@/components/KroCodeBlock"
 import StaticChainDAG from "@/components/StaticChainDAG"
 import NodeDetailPanel from "@/components/NodeDetailPanel"
@@ -33,7 +35,8 @@ function isValidTab(t: string | null): t is TabId {
  *
  * Spec: .specify/specs/003-rgd-detail-dag/, .specify/specs/004-instance-list/,
  *       .specify/specs/017-rgd-validation-linting/, .specify/specs/018-rbac-visualizer/,
- *       .specify/specs/020-schema-doc-generator/, .specify/specs/030-error-patterns-tab/
+ *       .specify/specs/020-schema-doc-generator/, .specify/specs/030-error-patterns-tab/,
+ *       .specify/specs/036-rgd-detail-header/
  */
 export default function RGDDetail() {
   const { name } = useParams<{ name: string }>()
@@ -185,6 +188,9 @@ export default function RGDDetail() {
 
   if (!rgd) return null
 
+  const rgdKind = extractRGDKind(rgd)
+  const readyState = extractReadyStatus(rgd)
+
   return (
     <div className="rgd-detail">
       {/* Breadcrumb — shown when navigated via "View RGD →" (spec 025) */}
@@ -198,7 +204,13 @@ export default function RGDDetail() {
 
       {/* Header */}
       <div className="rgd-detail-header">
-        <h1 className="rgd-detail-name">{String(rgdName)}</h1>
+        <div className="rgd-detail-header-row">
+          <StatusDot state={readyState.state} reason={readyState.reason} message={readyState.message} />
+          <h1 className="rgd-detail-name">{String(rgdName)}</h1>
+        </div>
+        {rgdKind && (
+          <span className="rgd-detail-kind">{rgdKind}</span>
+        )}
       </div>
 
       {/* Tab bar */}


### PR DESCRIPTION
## Summary

Fixes #130.

The RGD detail page (`/rgds/:name`) header previously showed only the RGD name. Users navigating directly to a detail URL lost the Kind label and status badge visible on the home page card.

- Adds a `StatusDot` (green/red/gray) to the left of the `<h1>` name, reflecting `status.conditions[type=Ready]`
- Adds a muted blue Kind badge below the name when `spec.schema.kind` is present (omitted when absent)
- Reuses the exact same `extractRGDKind`, `extractReadyStatus`, and `StatusDot` already used by `RGDCard` — no new extraction logic, no new components, no new API calls

## Changes

- `web/src/pages/RGDDetail.tsx` — imports, two local variables, updated header JSX block
- `web/src/pages/RGDDetail.css` — `.rgd-detail-header-row` (flex row), `.rgd-detail-kind` (pill badge using `--color-primary-muted` / `--color-primary-text` tokens)

## Checklist

- [x] Kind badge omitted (not blank, not `?`) when `spec.schema.kind` is absent
- [x] StatusDot shows `unknown` (gray) when `status.conditions` is absent — graceful degradation per §XII
- [x] All CSS colors use `var(--token)` references — no hardcoded hex or `rgba()`
- [x] Page title unchanged (`<rgdName> — kro-ui`)
- [x] `bun tsc --noEmit` — 0 errors
- [x] `vitest run` — 547/547 pass