### PR TITLE
fix(k8s,web): remove hardcoded SA fallback; add manual SA override in Access tab

### DIFF
--- a/.specify/specs/032-rbac-sa-autodetect/contracts/access-api.md
+++ b/.specify/specs/032-rbac-sa-autodetect/contracts/access-api.md
@@ -1,0 +1,139 @@
+# API Contract: GET /api/v1/rgds/{name}/access
+
+**Feature**: `032-rbac-sa-autodetect`
+**Endpoint**: `GET /api/v1/rgds/{name}/access`
+**Status**: Updated (previously defined in spec `018-rbac-visualizer`)
+
+---
+
+## Changes from spec 018
+
+- Added optional query parameters `saNamespace` and `saName`
+- `serviceAccount` field in response can now be `""` (was always at least `"kro-system/kro"`)
+- `serviceAccountFound: false` now always means SA is unknown (not just "fallback was used")
+
+---
+
+## Request
+
+```
+GET /api/v1/rgds/{name}/access[?saNamespace=<ns>&saName=<name>]
+```
+
+### Path parameters
+
+| Param | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Name of the ResourceGraphDefinition |
+
+### Query parameters
+
+| Param | Required | Description |
+|-------|----------|-------------|
+| `saNamespace` | No | Manual override: namespace of kro's service account |
+| `saName` | No | Manual override: name of kro's service account |
+
+**Override semantics**: Both `saNamespace` and `saName` must be non-empty for the override
+to take effect. If only one is present (or both are empty), auto-detection is used.
+
+---
+
+## Response — 200 OK
+
+```json
+{
+  "serviceAccount": "kro-system/kro-controller",
+  "serviceAccountFound": true,
+  "clusterRole": "kro-manager-role",
+  "hasGaps": false,
+  "permissions": [
+    {
+      "group": "apps",
+      "version": "v1",
+      "resource": "deployments",
+      "kind": "Deployment",
+      "required": ["get", "list", "watch", "create", "update", "patch", "delete"],
+      "granted": {
+        "get": true,
+        "list": true,
+        "watch": true,
+        "create": true,
+        "update": true,
+        "patch": true,
+        "delete": true
+      }
+    }
+  ]
+}
+```
+
+### Response when SA not found (no override provided)
+
+```json
+{
+  "serviceAccount": "",
+  "serviceAccountFound": false,
+  "clusterRole": "",
+  "hasGaps": false,
+  "permissions": []
+}
+```
+
+**Important**: HTTP status is still `200 OK`. The empty SA is a valid operational state,
+not an error. The frontend differentiates this from a failure via `serviceAccount === ""`
+combined with `serviceAccountFound === false`.
+
+### Response when SA override provided
+
+```json
+{
+  "serviceAccount": "kro-prod/kro-operator",
+  "serviceAccountFound": true,
+  "clusterRole": "kro-operator-role",
+  "hasGaps": true,
+  "permissions": [ ... ]
+}
+```
+
+Note: `serviceAccountFound: true` for overrides — the user has explicitly provided the SA,
+so the backend treats it as "found" (the user takes responsibility for correctness).
+
+---
+
+## Response — 404 Not Found
+
+```json
+{ "error": "resourcegraphdefinition \"my-app\" not found" }
+```
+
+---
+
+## Response — 503 Service Unavailable
+
+```json
+{ "error": "cluster unreachable: <reason>" }
+```
+
+---
+
+## Frontend usage
+
+```typescript
+// Auto-detect (existing behavior)
+getRGDAccess(rgdName)
+
+// Manual override (new)
+getRGDAccess(rgdName, { saNamespace: "kro-prod", saName: "kro-operator" })
+```
+
+The `api.ts` `getRGDAccess` function is updated to accept an optional second argument
+`options?: { saNamespace?: string; saName?: string }` and append them as query params.
+
+---
+
+## Invariants
+
+1. `serviceAccount` is `""` if and only if `serviceAccountFound === false` AND no override was provided
+2. When `serviceAccount === ""`, `permissions` is always `[]` and `hasGaps` is always `false`
+3. The endpoint never returns a hardcoded SA name — all SA values come from the cluster or user input
+4. The endpoint is read-only (GET only; no mutations)

--- a/.specify/specs/032-rbac-sa-autodetect/data-model.md
+++ b/.specify/specs/032-rbac-sa-autodetect/data-model.md
@@ -1,0 +1,123 @@
+# Data Model: RBAC Service Account Auto-Detection
+
+**Branch**: `032-rbac-sa-autodetect`
+**Date**: 2026-03-23
+
+---
+
+## Entities
+
+### 1. `AccessResult` (Go — `internal/k8s/rbac.go`)
+
+No new fields; behavior change only.
+
+| Field | Type | Change |
+|-------|------|--------|
+| `ServiceAccount` | `string` | Now `""` when not detected (was `"kro-system/kro"`) |
+| `ServiceAccountFound` | `bool` | `false` when not detected (unchanged) |
+| `ClusterRole` | `string` | `""` when not detected (unchanged) |
+| `HasGaps` | `bool` | `false` when SA not found (no permissions to evaluate) |
+| `Permissions` | `[]ResourcePermission` | Empty slice when SA not found |
+
+**State transitions**:
+
+```
+ResolveKroServiceAccount result
+  ├── found=true  → ComputeAccessResult runs full matrix
+  └── found=false → ComputeAccessResult returns early:
+                    { ServiceAccount: "", ServiceAccountFound: false,
+                      HasGaps: false, Permissions: [] }
+```
+
+---
+
+### 2. `AccessResponse` (Go — `internal/api/types/response.go`)
+
+No structural changes. The `serviceAccount` field will now be `""` when not found
+(previously was always `"kro-system/kro"` minimum). The frontend handles this
+by checking `serviceAccount === ""`.
+
+```go
+type AccessResponse struct {
+    ServiceAccount      string          `json:"serviceAccount"`       // "" when not found
+    ServiceAccountFound bool            `json:"serviceAccountFound"`  // false when not found
+    ClusterRole         string          `json:"clusterRole"`          // unchanged
+    HasGaps             bool            `json:"hasGaps"`              // false when SA not found
+    Permissions         []GVRPermission `json:"permissions"`          // [] when SA not found
+}
+```
+
+---
+
+### 3. Handler query parameters — `GET /api/v1/rgds/{name}/access`
+
+New optional query parameters (not modeled as struct — read via `r.URL.Query()`):
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `saNamespace` | `string` | Override namespace for kro's SA (optional) |
+| `saName` | `string` | Override name for kro's SA (optional) |
+
+**Logic**:
+- If both `saNamespace` and `saName` are non-empty after `strings.TrimSpace`:
+  → Use override values directly, skip `ResolveKroServiceAccount`
+  → Set `ServiceAccountFound = true` (user-provided, assumed to be correct)
+- Otherwise: call `ResolveKroServiceAccount` as before
+
+---
+
+### 4. Frontend state — `AccessTab` component
+
+New state fields added to the `AccessTab` component:
+
+| State | Type | Initial | Description |
+|-------|------|---------|-------------|
+| `manualNS` | `string` | `""` | User-typed namespace in override form |
+| `manualSAName` | `string` | `""` | User-typed SA name in override form |
+| `overrideSource` | `"auto" \| "manual" \| null` | `null` | Detection source for display |
+
+**State machine**:
+
+```
+fetch /api/v1/rgds/{name}/access
+  → { serviceAccountFound: true }
+       → Show permission matrix
+       → overrideSource = "auto"
+  → { serviceAccountFound: false, serviceAccount: "" }
+       → Show manual input form
+       → overrideSource = null
+  → user submits manual form with ns + name
+       → fetch /api/v1/rgds/{name}/access?saNamespace=ns&saName=name
+       → overrideSource = "manual"
+  → error (network, 503)
+       → Show error state + Retry button (existing behavior)
+```
+
+---
+
+### 5. Validation rules
+
+**Backend** (`access.go`):
+- `saNamespace` and `saName` query params: if one is provided without the other,
+  treat as if neither was provided (fall back to auto-detect). This avoids partial
+  state confusion.
+
+**Frontend** (`AccessTab.tsx`):
+- Submit button disabled unless both `manualNS` and `manualSAName` are non-empty
+  after `trim()`.
+- Input fields trim whitespace before sending query params.
+
+---
+
+## Summary of changes by file
+
+| File | Type of change | What changes |
+|------|---------------|-------------|
+| `internal/k8s/rbac.go` | Behavior | `ResolveKroServiceAccount` returns `("","",false)` not `("kro-system","kro",false)` |
+| `internal/k8s/rbac.go` | Logic | `ComputeAccessResult` early-returns when `saNS==""` |
+| `internal/api/handlers/access.go` | Feature | Read `saNamespace`+`saName` query params; skip auto-detect when provided |
+| `internal/api/types/response.go` | None | No changes needed |
+| `web/src/components/AccessTab.tsx` | Feature + UX | Manual form when `serviceAccount==""`, labeled banner, detection source |
+| `web/src/components/AccessTab.css` | Style | New tokens-only CSS for manual form |
+| `internal/k8s/rbac_test.go` | Test | New case: no deployment found → `("","",false)` |
+| `web/src/components/AccessTab.test.tsx` | Test | New cases: manual form, banner format, override flow |

--- a/.specify/specs/032-rbac-sa-autodetect/plan.md
+++ b/.specify/specs/032-rbac-sa-autodetect/plan.md
@@ -1,0 +1,86 @@
+# Implementation Plan: RBAC Service Account Auto-Detection
+
+**Branch**: `032-rbac-sa-autodetect` | **Date**: 2026-03-23 | **Spec**: `.specify/specs/032-rbac-sa-autodetect/spec.md`
+**Input**: Feature specification from `/specs/032-rbac-sa-autodetect/spec.md`
+**Fixes**: GitHub issues #115, #133
+
+## Summary
+
+Remove the hardcoded `("kro-system", "kro")` fallback from `ResolveKroServiceAccount`,
+surface detection failure to the frontend as an empty SA + `serviceAccountFound=false`,
+add a manual SA override (query-param-driven re-fetch), and update the Access tab
+SA banner to display namespace and name as separately labeled elements.
+
+## Technical Context
+
+**Language/Version**: Go 1.25 backend / TypeScript 5.x + React 19 + Vite (all already present)
+**Primary Dependencies**: `k8s.io/client-go/dynamic`, `github.com/go-chi/chi/v5`, React 19, React Router v7 — all already in use; no new dependencies
+**Storage**: N/A — all state is local React `useState`; no persistence
+**Testing**: `go test -race ./...` + `tsc --noEmit` + Vitest (already configured)
+**Target Platform**: Kubernetes cluster + web browser
+**Project Type**: Full-stack web observability tool (single-binary Go + embedded React)
+**Performance Goals**: Access tab loads within 2s (existing NFR-001 from spec 018)
+**Constraints**: No hardcoded SA names, namespaces, or SA name guesses (constitution §XIII); read-only Kubernetes access (constitution §III)
+**Scale/Scope**: Small, targeted bug fix + UX enhancement; touches 4 files (2 Go, 2 TypeScript)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| §I Iterative-First | PASS | Spec `018-rbac-visualizer` is merged; this fixes a bug in that spec |
+| §II Cluster Adaptability | PASS | No typed clients; dynamic client used throughout; no kro field paths outside `rgd.go` |
+| §III Read-Only | PASS | No mutating API calls; only `get`/`list` verbs used |
+| §IV Single Binary | PASS | No new assets; no CDN; no separate server |
+| §V Simplicity | PASS | No new dependencies; no ORMs/GraphQL/SSE; no state libraries |
+| §VI Go Code Standards | PASS | Copyright headers present; error wrapping used; zerolog logging; no `util.go` |
+| §VII Testing Standards | PASS | Table-driven tests; `testify/assert+require`; `-race` flag |
+| §VIII Commit Conventions | PASS | Will use `fix(k8s): ...` and `fix(web): ...` |
+| §IX Theme | PASS | CSS tokens only; no hardcoded colors |
+| §XI API Performance | PASS | No new discovery calls; no unbounded loops |
+| §XII Graceful Degradation | PASS | Empty SA → manual form (not error crash); missing SA info → "not found" state |
+| §XIII No Hardcoded Config | **MUST FIX** | Current `rbac.go:104` returns `("kro-system", "kro", false)` — this spec removes it |
+
+**Gate result**: PASS with one remediation — the hardcoded fallback is the bug being fixed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/032-rbac-sa-autodetect/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── access-api.md    # Updated contract for GET /api/v1/rgds/{name}/access
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks - NOT created by /speckit.plan)
+```
+
+### Source Code Changes
+
+```text
+internal/k8s/
+├── rbac.go              # CHANGE: Remove hardcoded fallback; return ("","",false)
+└── rbac_test.go         # CHANGE: Add "no deployment found" test case
+
+internal/api/handlers/
+└── access.go            # CHANGE: Accept saNamespace+saName query params
+
+web/src/components/
+├── AccessTab.tsx         # CHANGE: Manual override form; labeled SA banner
+├── AccessTab.css         # CHANGE: Styles for manual form (token-based)
+└── AccessTab.test.tsx    # CHANGE: New test cases for manual form + banner format
+```
+
+**Structure Decision**: Single project, existing kro-ui layout. No new files needed
+beyond tests and CSS; all changes are surgical modifications to the 4 files listed.
+
+## Complexity Tracking
+
+> No constitution violations in this feature — the feature *fixes* a violation.
+
+No entries required.

--- a/.specify/specs/032-rbac-sa-autodetect/quickstart.md
+++ b/.specify/specs/032-rbac-sa-autodetect/quickstart.md
@@ -1,0 +1,169 @@
+# Quickstart: Implementing 032-rbac-sa-autodetect
+
+## What this feature does
+
+Fixes two bugs in the RBAC Access tab:
+1. Removes the hardcoded `("kro-system", "kro")` fallback in `ResolveKroServiceAccount`
+2. Updates the Access tab to show a manual SA override form when auto-detection fails,
+   and displays the SA in a human-readable labeled format
+
+## File map
+
+```
+internal/k8s/rbac.go           — backend: SA detection, ComputeAccessResult
+internal/api/handlers/access.go — backend: HTTP handler, query params
+web/src/components/AccessTab.tsx — frontend: component
+web/src/components/AccessTab.css — frontend: styles
+internal/k8s/rbac_test.go      — backend tests
+web/src/components/AccessTab.test.tsx — frontend tests
+```
+
+## Step 1 — Backend: Remove hardcoded fallback
+
+**File**: `internal/k8s/rbac.go`
+
+Change `ResolveKroServiceAccount` return path when no Deployment is found (line 103-104):
+
+```go
+// BEFORE
+log.Debug().Msg("could not detect kro service account; falling back to kro-system/kro")
+return "kro-system", "kro", false
+
+// AFTER
+log.Debug().Msg("could not detect kro service account; no fallback")
+return "", "", false
+```
+
+Add early-return in `ComputeAccessResult` when `saNS == ""`:
+
+```go
+// After ResolveKroServiceAccount call:
+if saNS == "" {
+    return &AccessResult{
+        ServiceAccount:      "",
+        ServiceAccountFound: false,
+        HasGaps:             false,
+        Permissions:         []ResourcePermission{},
+    }, nil
+}
+```
+
+## Step 2 — Backend: Handler query params
+
+**File**: `internal/api/handlers/access.go`
+
+Add query param reading before the auto-detect call:
+
+```go
+saNamespace := strings.TrimSpace(r.URL.Query().Get("saNamespace"))
+saName := strings.TrimSpace(r.URL.Query().Get("saName"))
+
+var saNS, saNameStr string
+var saFound bool
+if saNamespace != "" && saName != "" {
+    // Manual override — treat as found
+    saNS, saNameStr, saFound = saNamespace, saName, true
+} else {
+    // Auto-detect from cluster
+    saNS, saNameStr, saFound = k8sclient.ResolveKroServiceAccount(r.Context(), h.factory)
+}
+// Pass saNS, saNameStr to ComputeAccessResult (via new signature or inline)
+```
+
+Note: `ComputeAccessResult` needs to accept the pre-resolved SA to avoid calling
+`ResolveKroServiceAccount` again internally. Refactor: accept `saNS, saName string, saFound bool`
+as parameters (or split into a new `ComputeAccessResultForSA` helper).
+
+## Step 3 — Frontend: Manual form
+
+**File**: `web/src/components/AccessTab.tsx`
+
+When `data.serviceAccountFound === false && data.serviceAccount === ""`:
+
+```tsx
+// Show manual override form
+<div className="access-tab-sa-override-form">
+  <p>Could not auto-detect kro's service account.</p>
+  <label>
+    Namespace
+    <input value={manualNS} onChange={e => setManualNS(e.target.value)} />
+  </label>
+  <label>
+    Service account name
+    <input value={manualSAName} onChange={e => setManualSAName(e.target.value)} />
+  </label>
+  <button disabled={!manualNS.trim() || !manualSAName.trim()} onClick={handleManualSubmit}>
+    Check permissions
+  </button>
+</div>
+```
+
+`handleManualSubmit` calls `getRGDAccess(rgdName, { saNamespace: manualNS.trim(), saName: manualSAName.trim() })`.
+
+## Step 4 — Frontend: Labeled SA banner
+
+**File**: `web/src/components/AccessTab.tsx`
+
+Replace the raw slash format:
+
+```tsx
+// BEFORE
+<span>Checking kro service account:</span> <code>{data.serviceAccount}</code>
+
+// AFTER — parse namespace/name from serviceAccount string
+const [saNamespace, saSAName] = data.serviceAccount.split("/", 2)
+<span>Namespace:</span> <code>{saNamespace}</code>
+<span className="access-tab-sa-sep">·</span>
+<span>Service account:</span> <code>{saSAName ?? data.serviceAccount}</code>
+<span className="access-tab-sa-source">
+  {overrideSource === "manual" ? "(manually specified)" : "(auto-detected)"}
+</span>
+```
+
+## Step 5 — Update `api.ts`
+
+**File**: `web/src/lib/api.ts`
+
+Update `getRGDAccess` signature:
+
+```typescript
+export async function getRGDAccess(
+  name: string,
+  opts?: { saNamespace?: string; saName?: string }
+): Promise<AccessResponse> {
+  const params = new URLSearchParams()
+  if (opts?.saNamespace) params.set("saNamespace", opts.saNamespace)
+  if (opts?.saName) params.set("saName", opts.saName)
+  const query = params.toString() ? `?${params}` : ""
+  const res = await fetch(`/api/v1/rgds/${name}/access${query}`)
+  if (!res.ok) throw new Error(await res.text())
+  return res.json()
+}
+```
+
+## Step 6 — Tests
+
+**Backend** (`rbac_test.go`): Add test case in `TestResolveKroServiceAccount`:
+- Name: `"no matching deployment found returns empty strings"`
+- Setup: empty dynamic client (no deployments in `kro-system` or `kro`)
+- Check: `ns == ""`, `name == ""`, `found == false`
+
+**Frontend** (`AccessTab.test.tsx`):
+- `"shows manual override form when serviceAccount is empty and not found"`
+- `"re-fetches with saNamespace and saName on manual form submit"`
+- `"shows (auto-detected) badge when serviceAccountFound is true"`
+- `"shows (manually specified) badge after manual form submit"`
+- `"shows labeled namespace and SA name, not raw slash"`
+
+## Verification
+
+```bash
+# Backend
+GOPROXY=direct GONOSUMDB="*" go test -race ./internal/k8s/... ./internal/api/...
+
+# Frontend typecheck
+cd web && bun run typecheck
+
+# Frontend unit tests
+cd web && bun run test
+```

--- a/.specify/specs/032-rbac-sa-autodetect/research.md
+++ b/.specify/specs/032-rbac-sa-autodetect/research.md
@@ -1,0 +1,161 @@
+# Research: RBAC Service Account Auto-Detection
+
+**Branch**: `032-rbac-sa-autodetect`
+**Date**: 2026-03-23
+**Status**: Complete — all unknowns resolved
+
+---
+
+## Decision 1: Remove hardcoded fallback vs keep it with a warning
+
+**Question**: Should `ResolveKroServiceAccount` return `("kro-system", "kro", false)` as
+a convenience fallback (current behavior), or return `("", "", false)` and force the
+frontend to handle the missing case?
+
+**Decision**: Return `("", "", false)` and remove the hardcoded fallback entirely.
+
+**Rationale**:
+- Constitution §XIII explicitly prohibits hardcoded SA names, namespaces, or label key values
+- The original spec (018-rbac-visualizer, Edge Cases) says "MUST NOT hardcode a fallback
+  SA name like `'kro'` — derive only from the cluster. If discovery fails, show an error state."
+- Returning a hardcoded fallback silently produces wrong results on clusters with
+  custom installation namespaces (e.g., `kro-prod/kro-controller`) — the tab shows
+  "All permissions satisfied" for the wrong SA
+- The frontend manual override form is the correct UX for this edge case
+
+**Alternatives considered**:
+- Keep `("kro-system", "kro")` as a documented default with a warning banner
+  → Rejected: still violates constitution; still produces silently wrong results
+- Fall back to searching all namespaces for a Deployment named "kro*"
+  → Considered: more robust but has performance implications (can't list all namespaces
+  efficiently without listing all namespaces first); also risks false positives
+
+---
+
+## Decision 2: Manual SA override mechanism — query params vs dedicated endpoint
+
+**Question**: Should the manual SA override use:
+- (a) Query params on existing endpoint: `GET /api/v1/rgds/{name}/access?saNamespace=x&saName=y`
+- (b) A new POST endpoint with a request body
+- (c) A new GET endpoint with path segments
+
+**Decision**: Query params on the existing endpoint (option a).
+
+**Rationale**:
+- The operation is still a read (GET) — no mutation; a POST would imply mutation (constitution §III)
+- Query params are idiomatic for filtering/overriding GET behavior in REST APIs
+- No new route registration needed; chi router already handles query params via `r.URL.Query()`
+- The frontend can construct the URL with `URLSearchParams` and call the same `getRGDAccess()`
+  function with an options argument
+- Backend handler change is minimal: `r.URL.Query().Get("saNamespace")` before auto-detect
+
+**Alternatives considered**:
+- New dedicated endpoint `GET /api/v1/kro/service-account` that just returns the detected SA
+  → Considered but rejected: adds a round-trip; doesn't help with the override flow
+- Store override in server-side session
+  → Rejected: kro-ui is stateless; no session layer
+
+---
+
+## Decision 3: Frontend manual form — single `namespace/name` field vs two separate inputs
+
+**Question**: Should the manual override form use:
+- (a) A single input with `namespace/name` format
+- (b) Two separate inputs: one for namespace, one for SA name
+
+**Decision**: Two separate inputs (option b).
+
+**Rationale**:
+- Slash-delimited fields are error-prone for users (unclear which delimiter, easy to
+  include spaces or extra slashes)
+- Two clearly labeled fields (`Namespace` and `Service account name`) require no
+  format knowledge from the user
+- Aligns with the display format decision (Decision 4) — if we show them separately
+  in the banner, we should input them separately too
+- React state for two strings is trivially simple; no parsing needed
+
+**Alternatives considered**:
+- Single `namespace/name` input with server-side parsing
+  → Rejected: fragile; ambiguous when SA name contains a slash (technically valid in k8s)
+
+---
+
+## Decision 4: SA display banner format
+
+**Question**: How should the SA be displayed in the Access tab banner?
+
+**Decision**: Display as two separately labeled inline elements:
+`Namespace: <ns>  ·  Service account: <name>` with a detection source indicator
+`(auto-detected)` or `(manually specified)`.
+
+**Rationale**:
+- Issue #133 requests explicit labeling of the `namespace/name` format
+- The "·" separator is a common pattern in metadata display (already used in other parts of kro-ui)
+- Keeping namespace and name on the same line avoids vertical space waste
+- The detection source indicator closes the UX gap: users know whether to trust the SA or override it
+- `data-testid` attributes make testing straightforward
+
+**Alternatives considered**:
+- Display as `namespace: kro  /  service account: kro` (using slash)
+  → Considered but the slash could be confused with the raw `namespace/name` format we're trying to clarify
+- Show only the SA name with namespace in a tooltip
+  → Considered but the namespace is important context when troubleshooting
+
+---
+
+## Decision 5: Behavior when `ComputeAccessResult` receives empty SA from `ResolveKroServiceAccount`
+
+**Question**: What should `ComputeAccessResult` do when `saNS=""` and `saName=""`?
+
+**Decision**: Return an `AccessResult` with empty `ServiceAccount`, `ServiceAccountFound=false`,
+empty `Permissions` slice, and `HasGaps=false` (no permissions means no matrix to show).
+Do NOT return an error — the absence of an SA is a valid, expected state.
+
+**Rationale**:
+- Returning an error would cause the frontend to show the error state (with Retry button)
+  rather than the manual override form
+- The frontend distinguishes between "error" (network failure, API unreachable) and
+  "SA not found" (expected operational case) via the `serviceAccountFound=false` + empty
+  `serviceAccount=""` combination
+- The `FetchEffectiveRules` function would be called with empty strings and simply return
+  no matching rules — which is fine since the SA is unknown anyway; we skip it entirely
+
+**Implementation**: When `saNS==""` (after stripping whitespace), short-circuit
+`ComputeAccessResult` and return early with the "not found" result.
+
+---
+
+## Decision 6: `capabilities.go` `kroNamespace` constant — scope of this fix
+
+**Question**: The `capabilities.go` file also hardcodes `kroNamespace = "kro-system"`
+(line 96) and `kroDeploymentName = "kro-controller-manager"` (line 97). Should these
+be removed as part of this fix?
+
+**Decision**: Out of scope for this spec. The `detectFeatureGatesAndVersion` function in
+capabilities.go uses these to look up the specific controller Deployment for feature gate
+parsing — it already gracefully handles "not found" with `return nil, ""`. This is a
+different concern from the RBAC SA fallback bug:
+
+- `capabilities.go`: hardcodes a specific Deployment name for feature gate detection
+  (non-critical; falls back gracefully to no feature gates)
+- `rbac.go`: hardcodes a fallback SA name that silently produces **wrong results**
+  (critical bug — shows wrong permissions for the wrong SA)
+
+The capabilities.go hardcoding would require a separate spec/issue since it involves a
+different detection strategy (look up by name vs look up by SA). Not a §XIII violation
+because it's used as a search key, not as a display value or assumed truth.
+
+---
+
+## Research Summary
+
+| Unknown | Resolution |
+|---------|------------|
+| What to return when SA detection fails | `("", "", false)` — no fallback |
+| Override mechanism | Query params on existing GET endpoint |
+| Manual form design | Two separate inputs (namespace + name) |
+| Banner display format | Labeled `Namespace: X · Service account: Y (source)` |
+| Empty SA in `ComputeAccessResult` | Early return with `ServiceAccountFound=false`, empty permissions |
+| `capabilities.go` constants | Out of scope; different concern |
+
+All NEEDS CLARIFICATION items resolved. Ready for Phase 1 design.

--- a/.specify/specs/032-rbac-sa-autodetect/spec.md
+++ b/.specify/specs/032-rbac-sa-autodetect/spec.md
@@ -1,0 +1,188 @@
+# Feature Specification: RBAC Service Account Auto-Detection
+
+**Feature Branch**: `032-rbac-sa-autodetect`
+**Created**: 2026-03-23
+**Status**: In Progress
+**Depends on**: `018-rbac-visualizer` (merged — provides the Access tab infrastructure)
+**Fixes**: GitHub issues #115, #133
+**Constitution ref**: §XIII (no hardcoded config values), §II (Cluster Adaptability),
+§III (Read-Only), §XI (API performance budget), §IX (Theme)
+
+---
+
+## Context
+
+The RBAC Access tab (spec `018-rbac-visualizer`) was designed to auto-detect kro's
+service account by reading the kro controller Deployment. However, the implementation
+contains two bugs:
+
+1. **Hardcoded fallback** (`rbac.go:104`): When Deployment detection fails (wrong
+   namespace, RBAC restrictions, or non-standard naming), the code returns
+   `("kro-system", "kro", false)` — a hardcoded SA name that violates constitution
+   §XIII. The spec itself (spec `018-rbac-visualizer`, Edge Cases) explicitly says
+   "MUST NOT hardcode a fallback SA name like `"kro"` — derive only from the cluster."
+
+2. **Opaque display format** (`AccessTab.tsx:104`): The banner shows
+   `Checking kro service account: kro/kro` with no explanation that `kro/kro` means
+   `namespace/name`. Issue #133 requests this be made human-readable, with clear
+   labeling of what each part means.
+
+---
+
+## User Scenarios & Testing
+
+### User Story 1 — SA auto-detected from cluster (Priority: P1)
+
+kro is installed with a standard Deployment. The Access tab detects the SA
+automatically and shows it with a clear, human-readable label.
+
+**Acceptance Scenarios**:
+
+1. **Given** kro is installed as a Deployment named `kro-controller-manager` in
+   `kro-system`, **When** the Access tab loads, **Then** the banner shows:
+   `Namespace: kro-system · Service account: kro-controller-manager` (or equivalent
+   human-readable format) with `(auto-detected)` indicator
+2. **Given** kro is installed in a custom namespace `kro-prod` with SA `kro-operator`,
+   **When** the Access tab loads, **Then** the correct SA `kro-prod/kro-operator`
+   is shown — not the hardcoded `kro-system/kro`
+3. **Given** auto-detection succeeds, **When** rendered, **Then** `serviceAccountFound`
+   is `true` in the API response
+
+---
+
+### User Story 2 — SA detection fails, manual override offered (Priority: P1)
+
+kro's Deployment cannot be found (permissions issue, non-standard naming, not
+in the searched namespaces).
+
+**Acceptance Scenarios**:
+
+1. **Given** no matching kro Deployment is found in any namespace, **When** the
+   Access tab loads, **Then** the backend returns `serviceAccountFound: false`
+   with an **empty** `serviceAccount` string (no hardcoded fallback)
+2. **Given** `serviceAccountFound: false`, **When** rendered, **Then** the UI shows:
+   "Could not auto-detect kro's service account. Enter it manually:" with a text
+   input field (`namespace/name` or two separate fields for namespace and name)
+3. **Given** the user types a SA in the manual input and confirms, **When** submitted,
+   **Then** the UI re-fetches `GET /api/v1/rgds/{name}/access?saNamespace=kro-prod&saName=kro-operator`
+   with the override values, and renders the permission matrix for that SA
+4. **Given** a manual SA override is active, **When** rendered, **Then** the banner
+   shows `Namespace: kro-prod · Service account: kro-operator (manually specified)`
+
+---
+
+### User Story 3 — SA display format is human-readable (Priority: P2)
+
+The SA format `kro/kro` is replaced with labeled fields (closes issue #133).
+
+**Acceptance Scenarios**:
+
+1. **Given** `serviceAccount` is `"kro-system/kro"`, **When** rendered, **Then**
+   the banner shows the namespace and service account name as separately labeled
+   elements, not as raw `namespace/name` string
+2. **Given** a tooltip or `title` attribute, **Then** the full `namespace/name`
+   value is accessible on hover for copy-paste
+
+---
+
+### Edge Cases
+
+- kro Deployment not found due to restricted RBAC for kro-ui itself → show
+  "Could not auto-detect" with manual input; never hardcode a guess
+- Multiple kro-like Deployments in the cluster → use the first Deployment (in
+  namespace priority order) that has a non-empty `serviceAccountName`
+- SA override query params are present but malformed → treat as if not present
+  (fall back to auto-detect or "not found" state)
+- Backend discovery uses only the 2-namespace search (`kro-system`, `kro`) as
+  the primary strategy; this is intentional (the kro Helm chart always uses one
+  of these two namespaces by default)
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: `ResolveKroServiceAccount` MUST return `("", "", false)` when no
+  matching Deployment is found — it MUST NOT return any hardcoded namespace or
+  name as a fallback
+- **FR-002**: `GET /api/v1/rgds/{name}/access` MUST accept optional query parameters
+  `saNamespace` and `saName` to allow the frontend to provide a manual SA override
+- **FR-003**: When `saNamespace`+`saName` query params are provided and non-empty,
+  the handler MUST use them directly (skip auto-detection)
+- **FR-004**: When auto-detection fails and no manual override is provided, the
+  `AccessResult` MUST have `ServiceAccount = ""` and `ServiceAccountFound = false`
+- **FR-005**: The `AccessTab` frontend component MUST detect `serviceAccountFound: false`
+  with empty `serviceAccount` and show a manual input form instead of the permission
+  matrix
+- **FR-006**: The manual input form MUST have two fields: namespace and service
+  account name (separate inputs, not a single `namespace/name` string field)
+- **FR-007**: On submission of the manual form, the frontend re-fetches the access
+  endpoint with `?saNamespace=<ns>&saName=<name>` query params
+- **FR-008**: The SA display banner MUST show namespace and name as separately
+  labeled elements (not raw `namespace/name` slash format)
+- **FR-009**: The detection source MUST be indicated: `(auto-detected)` or
+  `(manually specified)`
+- **FR-010**: All styles MUST use CSS tokens from `tokens.css`
+
+### Non-Functional Requirements
+
+- **NFR-001**: No hardcoded SA names, namespaces, or SA name guesses anywhere in
+  backend or frontend code (constitution §XIII)
+- **NFR-002**: TypeScript strict mode MUST pass
+- **NFR-003**: Existing unit tests for `CheckPermissions`, `FetchEffectiveRules`,
+  `ComputeAccessResult` MUST continue to pass with no modification (they already
+  use `kro-system/kro` as fixture values, which is fine — they test the logic, not
+  the detection)
+- **NFR-004**: New unit test for `ResolveKroServiceAccount` "no deployment found"
+  case: MUST return `("", "", false)`
+
+### Key Components Changed
+
+- **`internal/k8s/rbac.go`**: Remove hardcoded fallback from `ResolveKroServiceAccount`;
+  return `("", "", false)` when not found
+- **`internal/api/handlers/access.go`**: Accept optional `saNamespace` + `saName`
+  query params; skip auto-detection when provided; handle empty SA result
+- **`web/src/components/AccessTab.tsx`**: Show manual input form when
+  `serviceAccountFound: false` and `serviceAccount === ""`; update SA banner format
+- **`internal/k8s/rbac_test.go`**: Add test case for "no deployment found" returning
+  empty strings
+- **`web/src/components/AccessTab.test.tsx`**: Add test cases for manual input form
+  and new banner format
+
+---
+
+## Testing Requirements
+
+### Backend Unit Tests
+
+```go
+// internal/k8s/rbac_test.go — new test case
+{
+  name: "no kro deployment found returns empty strings and found=false",
+  // setup: no deployments in kro-system or kro namespaces
+  // check: ns="", name="", found=false
+}
+```
+
+### Frontend Tests
+
+```typescript
+// web/src/components/AccessTab.test.tsx — new test cases
+it('shows manual input form when serviceAccountFound=false and serviceAccount=""')
+it('re-fetches with saNamespace and saName params on manual form submit')
+it('shows (auto-detected) indicator when serviceAccountFound=true')
+it('shows (manually specified) indicator after manual override')
+it('shows labeled namespace and SA name, not raw slash format')
+```
+
+---
+
+## Success Criteria
+
+- **SC-001**: `ResolveKroServiceAccount` never returns a hardcoded SA name
+- **SC-002**: When auto-detect fails, AccessTab shows manual override form
+- **SC-003**: Manual override re-fetches with correct query params
+- **SC-004**: SA display uses labeled format (not raw `kro/kro`)
+- **SC-005**: `go test -race ./...` passes
+- **SC-006**: `tsc --noEmit` passes

--- a/.specify/specs/032-rbac-sa-autodetect/tasks.md
+++ b/.specify/specs/032-rbac-sa-autodetect/tasks.md
@@ -1,0 +1,201 @@
+# Tasks: RBAC Service Account Auto-Detection
+
+**Branch**: `032-rbac-sa-autodetect`
+**Input**: Design documents from `.specify/specs/032-rbac-sa-autodetect/`
+**Fixes**: GitHub issues #115 (hardcoded SA fallback) and #133 (opaque `kro/kro` display)
+
+**Organization**: Tasks are grouped by user story to enable independent implementation
+and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no blocking dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Exact file paths included in every task description
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the existing codebase state matches design doc assumptions before
+any changes are made.
+
+- [x] T001 Verify `ResolveKroServiceAccount` hardcoded fallback exists at `internal/k8s/rbac.go:103-104` and `ComputeAccessResult` does NOT yet early-return on empty SA
+- [x] T002 Verify `GET /api/v1/rgds/{name}/access` handler at `internal/api/handlers/access.go` does NOT yet read `saNamespace`/`saName` query params
+- [x] T003 [P] Verify `getRGDAccess` in `web/src/lib/api.ts` does NOT yet accept a second options argument
+- [x] T004 [P] Run `GOPROXY=direct GONOSUMDB="*" go test -race ./internal/k8s/...` to confirm all existing tests pass before any changes
+
+**Checkpoint**: Baseline confirmed — existing tests pass, scope of changes understood
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisite)
+
+**Purpose**: Refactor `ComputeAccessResult` to accept a pre-resolved SA instead of
+calling `ResolveKroServiceAccount` internally. This decoupling is required by both
+US1 (removing the fallback) and US2 (manual override bypass). MUST complete before
+any user story work.
+
+- [x] T005 Refactor `ComputeAccessResult` in `internal/k8s/rbac.go` to accept `saNS, saName string, saFound bool` as parameters instead of calling `ResolveKroServiceAccount` internally; add early-return when `saNS == ""` that returns `&AccessResult{ServiceAccount: "", ServiceAccountFound: false, HasGaps: false, Permissions: []ResourcePermission{}}` with `nil` error
+- [x] T006 Update the call site in `internal/api/handlers/access.go` to call `ResolveKroServiceAccount` first, then pass results into `ComputeAccessResult` — preserving the existing auto-detect behavior (no behavioral change yet, just structural)
+- [x] T007 Run `GOPROXY=direct GONOSUMDB="*" go test -race ./internal/...` to confirm refactoring does not break existing tests
+
+**Checkpoint**: `ComputeAccessResult` is decoupled from SA detection — user stories can now proceed independently
+
+---
+
+## Phase 3: User Story 1 — SA Auto-Detection Returns Empty on Failure (Priority: P1)
+
+**Goal**: When no kro Deployment is found in `kro-system` or `kro` namespaces,
+`ResolveKroServiceAccount` returns `("", "", false)` with no hardcoded fallback.
+The frontend receives `serviceAccount: ""` and `serviceAccountFound: false` with
+an empty `permissions` array.
+
+**Independent Test**:
+1. Call `ResolveKroServiceAccount` with a dynamic client that has no Deployments → verify return is `("", "", false)`
+2. Call `GET /api/v1/rgds/{name}/access` against a cluster where kro SA detection fails → response is `{"serviceAccount":"","serviceAccountFound":false,"hasGaps":false,"permissions":[]}`
+3. Load AccessTab with this response → verify the manual override form is rendered (not the permission matrix)
+
+### Implementation for User Story 1
+
+- [x] T008 [US1] Remove hardcoded fallback from `ResolveKroServiceAccount` in `internal/k8s/rbac.go:103-104`: replace `return "kro-system", "kro", false` with `return "", "", false`; update the debug log message to `"could not detect kro service account; manual specification required"`
+- [x] T009 [P] [US1] Add test case `"no matching deployment found returns empty strings and found=false"` to `TestResolveKroServiceAccount` in `internal/k8s/rbac_test.go`: setup an empty dynamic client (no deployments in `kro-system` or `kro`), assert `ns == ""`, `name == ""`, `found == false`
+- [x] T010 [US1] Update `AccessTab.tsx` in `web/src/components/AccessTab.tsx` to show the manual override form when `data.serviceAccountFound === false && data.serviceAccount === ""`: add two controlled inputs (namespace and SA name) with a disabled-until-valid submit button; store form state in `manualNS: string` and `manualSAName: string`; keep all existing rendering paths for the `serviceAccountFound: true` case unchanged
+- [x] T011 [US1] Add CSS for the manual override form to `web/src/components/AccessTab.css` using only `tokens.css` custom properties: classes `.access-tab-sa-override-form`, `.access-tab-sa-override-inputs`, `.access-tab-sa-override-label`, `.access-tab-sa-override-input`, `.access-tab-sa-override-btn`; no hardcoded colors or `rgba()`
+- [x] T012 [P] [US1] Add frontend test cases to `web/src/components/AccessTab.test.tsx`: `"shows manual override form when serviceAccount is empty and serviceAccountFound is false"` (renders two inputs and a disabled submit button), `"submit button is disabled when inputs are empty"`, `"submit button is enabled when both inputs have values"`
+- [x] T013 [US1] Run `GOPROXY=direct GONOSUMDB="*" go test -race ./internal/k8s/...` and `cd web && bun run test` to verify T008–T012 pass
+
+**Checkpoint**: User Story 1 complete — hardcoded fallback removed; frontend shows override form on detection failure
+
+---
+
+## Phase 4: User Story 2 — Manual SA Override via Query Params (Priority: P1)
+
+**Goal**: The user can type a namespace and SA name into the override form. On submit,
+the frontend re-fetches `GET /api/v1/rgds/{name}/access?saNamespace=<ns>&saName=<name>`.
+The backend uses the provided values directly (skipping auto-detection) and returns
+the permission matrix for that SA.
+
+**Independent Test**:
+1. Call `GET /api/v1/rgds/{name}/access?saNamespace=kro-prod&saName=kro-operator` → verify the handler uses `kro-prod/kro-operator` (not auto-detect result)
+2. In `AccessTab`, render with empty SA response → fill in both inputs → click submit → verify a second fetch is called with `?saNamespace=...&saName=...`
+3. After successful override fetch, verify permission matrix is shown (not the override form)
+
+### Implementation for User Story 2
+
+- [x] T014 [US2] Update `internal/api/handlers/access.go` to read optional query params `saNamespace` and `saName` via `r.URL.Query().Get(...)` with `strings.TrimSpace`; when both are non-empty, pass them directly to `ComputeAccessResult` with `saFound=true` (skipping `ResolveKroServiceAccount`); when either is empty, call `ResolveKroServiceAccount` as before; add zerolog structured logging for override case: `.Str("saNamespace", saNamespace).Str("saName", saName).Msg("using manual SA override")`
+- [x] T015 [US2] Update `getRGDAccess` in `web/src/lib/api.ts` to accept an optional second argument `opts?: { saNamespace?: string; saName?: string }` and append non-empty values as URL query params using `URLSearchParams`; existing callers with no second argument are unaffected
+- [x] T016 [US2] Update `AccessTab.tsx` in `web/src/components/AccessTab.tsx` to implement `handleManualSubmit`: call `getRGDAccess(rgdName, { saNamespace: manualNS.trim(), saName: manualSAName.trim() })`, set a new state field `overrideSource: "auto" | "manual" | null` to `"manual"` on success, and replace the override form with the permission matrix on successful response
+- [x] T017 [P] [US2] Add frontend test cases to `web/src/components/AccessTab.test.tsx`: `"re-fetches with saNamespace and saName query params on manual form submit"` (verify `getRGDAccess` is called with correct opts on button click), `"shows permission matrix after successful manual override"` (verify form is replaced), `"shows (manually specified) badge after manual override"` (verify source label)
+- [x] T018 [US2] Run `GOPROXY=direct GONOSUMDB="*" go test -race ./internal/api/...` and `cd web && bun run test` to verify T014–T017 pass
+
+**Checkpoint**: User Story 2 complete — manual SA override flow works end-to-end
+
+---
+
+## Phase 5: User Story 3 — Human-Readable SA Display (Priority: P2)
+
+**Goal**: The SA banner shows `Namespace: kro-system · Service account: kro-controller`
+with a detection source label `(auto-detected)` or `(manually specified)` — not the raw
+`kro/kro` slash format. Closes issue #133.
+
+**Independent Test**:
+1. Render `AccessTab` with `serviceAccount: "kro-system/kro"` and `serviceAccountFound: true` → verify banner shows `Namespace:` and `Service account:` as separate labeled elements, not `kro/kro`
+2. Verify `(auto-detected)` text appears when `overrideSource === "auto"`
+3. After manual override, verify `(manually specified)` text appears
+4. Hover the banner → full `namespace/name` value is accessible via `title` attribute
+
+### Implementation for User Story 3
+
+- [x] T019 [US3] Update the SA banner section in `web/src/components/AccessTab.tsx`: parse `serviceAccount` into `[saNamespace, saSAName]` using `split("/", 2)`; render as `<span>Namespace:</span> <code>{saNamespace}</code> <span aria-hidden="true">·</span> <span>Service account:</span> <code>{saSAName ?? serviceAccount}</code>`; add a `title` attribute on the banner container with the raw `serviceAccount` value for hover accessibility; show `(auto-detected)` when `overrideSource === "auto"` or `serviceAccountFound && !overrideSource`, `(manually specified)` when `overrideSource === "manual"`; add `data-testid="access-tab-sa-namespace"` and `data-testid="access-tab-sa-name"` on the respective `<code>` elements
+- [x] T020 [US3] Update `web/src/components/AccessTab.css` to add `.access-tab-sa-source` class (muted color via `var(--color-text-muted)`, smaller font size) and `.access-tab-sa-sep` (horizontal margin, aria-hidden separator); no hardcoded colors
+- [x] T021 [P] [US3] Add frontend test cases to `web/src/components/AccessTab.test.tsx`: `"shows labeled namespace and service account name not raw slash format"` (verify `Namespace:` and `Service account:` labels present; verify `kro/kro` raw string absent), `"shows (auto-detected) indicator when serviceAccountFound is true"`, `"banner has title attribute with full namespace/name for accessibility"`
+- [x] T022 [US3] Run `cd web && bun run test` and `cd web && bun run typecheck` to verify T019–T021 pass
+
+**Checkpoint**: User Story 3 complete — SA banner is human-readable and accessible
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification, type safety, and ensuring existing tests are unbroken.
+
+- [x] T023 [P] Run full Go test suite: `GOPROXY=direct GONOSUMDB="*" go test -race ./...` — all existing tests must pass, including `TestCheckPermissions`, `TestFetchEffectiveRules`, `TestComputeAccessResult` which use `kro-system/kro` fixture values (they test logic, not detection)
+- [x] T024 [P] Run TypeScript typecheck: `cd web && bun run typecheck` — zero errors required (spec NFR-002)
+- [x] T025 [P] Run all frontend tests: `cd web && bun run test` — all AccessTab tests (old and new) must pass
+- [x] T026 Run `GOPROXY=direct GONOSUMDB="*" go vet ./...` and confirm no issues
+- [x] T027 Review `internal/k8s/rbac.go` for any remaining hardcoded SA names, namespace strings used as defaults (not as search keys), or SA name guesses; confirm none exist (constitution §XIII compliance check)
+- [x] T028 Verify `AccessTab.css` contains no hardcoded hex values, `rgba()`, or color literals — all colors must use `var(--token-name)` from `tokens.css`
+
+**Checkpoint**: All tests pass; zero TypeScript errors; constitution §XIII verified; feature complete
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 confirmation — BLOCKS Phases 3–5
+- **Phase 3 (US1)**: Depends on Phase 2 completion
+- **Phase 4 (US2)**: Depends on Phase 2 completion; integrates with Phase 3 changes (shares `AccessTab.tsx`)
+- **Phase 5 (US3)**: Depends on Phase 3+4 (needs `overrideSource` state from US2); can be done after US2
+- **Phase 6 (Polish)**: Depends on all prior phases complete
+
+### User Story Dependencies
+
+- **US1**: Independent after Phase 2 — removes fallback, adds override form shell
+- **US2**: Depends on US1 (uses override form from US1 as the entry point); sequential with US1
+- **US3**: Depends on US2 (reads `overrideSource` state introduced in US2); sequential with US2
+
+### Within Each User Story
+
+- Backend changes before frontend integration (handler query params before `api.ts` update)
+- Tests added alongside implementation (each story includes its own test tasks)
+
+### Parallel Opportunities
+
+- T009 and T010–T011 can run in parallel within Phase 3 (different files: test vs component/css)
+- T017 can run in parallel with T014–T016 (test file vs implementation files) — write tests first
+- T021 can run in parallel with T019–T020 (test file vs component/css)
+- T023, T024, T025 can all run in parallel in Phase 6 (independent verification commands)
+
+---
+
+## Parallel Example: Phase 3 (User Story 1)
+
+```bash
+# Backend test + frontend implementation can proceed in parallel:
+Task: "Add test case for no-deployment found in internal/k8s/rbac_test.go"   # T009
+Task: "Add manual override form CSS in web/src/components/AccessTab.css"      # T011
+
+# But T008 (remove fallback) must happen before T009 can assert against it
+```
+
+---
+
+## Implementation Strategy
+
+### MVP Scope (Phase 1 + Phase 2 + Phase 3 = US1 only)
+
+1. Complete Phase 1: Confirm baseline
+2. Complete Phase 2: Decouple `ComputeAccessResult` from SA detection
+3. Complete Phase 3 (US1): Remove fallback; show override form shell on detection failure
+4. **STOP and VALIDATE**: `go test -race ./...` passes; AccessTab shows form on empty SA
+
+This alone fixes the critical §XIII violation (issue #115).
+
+### Full Delivery (add US2 + US3)
+
+5. Complete Phase 4 (US2): Wire manual form submit to re-fetch with query params
+6. Complete Phase 5 (US3): Update SA banner to labeled format
+7. Complete Phase 6: Full verification
+8. Issue #133 closed when US3 ships
+
+### Notes
+
+- All tasks touch at most 6 files — scope is tight
+- The `rbac_test.go` fixture values (`kro-system/kro`) do not need changing; they test
+  the RBAC logic, not the SA detection
+- The `capabilities.go` `kroNamespace` constant is explicitly out of scope (see `research.md` Decision 6)
+- No new npm packages or Go modules required

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,6 +360,7 @@ Always read the spec before writing code. Always run `go vet ./...` and
 - TypeScript 5.x + React 19, Go 1.25 + React, React Router v7, Vite; no new npm deps (027-instance-telemetry-panel)
 - N/A — all data is in-memory React state (027-instance-telemetry-panel)
 - TypeScript 5.x + React 19 (frontend only; no backend changes) + React Router v7, existing `@/lib/format` utilities, existing `StatusDot` componen (036-rgd-detail-header)
+- Go 1.25 backend / TypeScript 5.x + React 19 + Vite (all already present) + `k8s.io/client-go/dynamic`, `github.com/go-chi/chi/v5`, React 19, React Router v7 — all already in use; no new dependencies (032-rbac-sa-autodetect)
 
 ## Recent Changes
 - 026-rgd-yaml-generator: Added Go 1.25 (backend, no changes needed) / TypeScript 5.x + React 19 + React 19, React Router v7, Vite (all already present); no new npm deps

--- a/internal/api/handlers/access.go
+++ b/internal/api/handlers/access.go
@@ -16,6 +16,7 @@ package handlers
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/rs/zerolog"
@@ -29,7 +30,11 @@ import (
 // GetRGDAccess computes the permission matrix for kro's service account
 // vs all resources managed by the named RGD.
 //
-// GET /api/v1/rgds/{name}/access
+// GET /api/v1/rgds/{name}/access[?saNamespace=<ns>&saName=<name>]
+//
+// Optional query parameters allow the caller to override the auto-detected
+// service account. When both saNamespace and saName are non-empty, auto-detection
+// is skipped and the provided values are used directly.
 func (h *Handler) GetRGDAccess(w http.ResponseWriter, r *http.Request) {
 	log := zerolog.Ctx(r.Context())
 	name := chi.URLParam(r, "name")
@@ -47,8 +52,28 @@ func (h *Handler) GetRGDAccess(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Resolve kro's service account — either from caller-supplied query params
+	// (manual override) or by auto-detecting from the cluster.
+	saNamespace := strings.TrimSpace(r.URL.Query().Get("saNamespace"))
+	saName := strings.TrimSpace(r.URL.Query().Get("saName"))
+
+	var saNS, saNameVal string
+	var saFound bool
+
+	if saNamespace != "" && saName != "" {
+		// Manual override: trust what the caller provided.
+		saNS, saNameVal, saFound = saNamespace, saName, true
+		log.Debug().
+			Str("saNamespace", saNamespace).
+			Str("saName", saName).
+			Msg("using manual SA override for access check")
+	} else {
+		// Auto-detect: inspect the cluster's kro Deployment.
+		saNS, saNameVal, saFound = k8sclient.ResolveKroServiceAccount(r.Context(), h.factory)
+	}
+
 	// Compute the full permission matrix.
-	result, err := k8sclient.ComputeAccessResult(r.Context(), h.factory, rgd.Object)
+	result, err := k8sclient.ComputeAccessResult(r.Context(), h.factory, rgd.Object, saNS, saNameVal, saFound)
 	if err != nil {
 		log.Error().Err(err).Str("rgd", name).Msg("failed to compute access result")
 		respondError(w, http.StatusServiceUnavailable, "cluster unreachable: "+err.Error())

--- a/internal/k8s/rbac.go
+++ b/internal/k8s/rbac.go
@@ -100,8 +100,8 @@ func ResolveKroServiceAccount(ctx context.Context, clients K8sClients) (namespac
 			}
 		}
 	}
-	log.Debug().Msg("could not detect kro service account; falling back to kro-system/kro")
-	return "kro-system", "kro", false
+	log.Debug().Msg("could not detect kro service account; manual specification required")
+	return "", "", false
 }
 
 // FetchEffectiveRules returns the flattened list of RBAC rules that apply to the
@@ -231,13 +231,27 @@ func ResolveKroClusterRole(ctx context.Context, clients K8sClients, saNamespace,
 	return ""
 }
 
-// ComputeAccessResult extracts all GVRs from the RGD's spec.resources, fetches kro's
-// service account, reads its effective RBAC rules, and returns the full permission matrix.
-func ComputeAccessResult(ctx context.Context, clients K8sClients, rgdObj map[string]any) (*AccessResult, error) {
+// ComputeAccessResult extracts all GVRs from the RGD's spec.resources, reads the
+// effective RBAC rules for the given service account (saNS/saName), and returns the
+// full permission matrix.
+//
+// saNS, saName, and saFound are provided by the caller — typically from
+// ResolveKroServiceAccount or from a user-supplied manual override. When saNS is
+// empty, ComputeAccessResult returns immediately with a not-found result (no matrix).
+func ComputeAccessResult(ctx context.Context, clients K8sClients, rgdObj map[string]any, saNS, saName string, saFound bool) (*AccessResult, error) {
 	log := zerolog.Ctx(ctx)
 
-	// ── Resolve kro service account ──────────────────────────────────────────
-	saNS, saName, saFound := ResolveKroServiceAccount(ctx, clients)
+	// ── Short-circuit when SA is unknown ─────────────────────────────────────
+	if saNS == "" {
+		log.Debug().Msg("kro service account not resolved; returning empty access result")
+		return &AccessResult{
+			ServiceAccount:      "",
+			ServiceAccountFound: false,
+			HasGaps:             false,
+			Permissions:         []ResourcePermission{},
+		}, nil
+	}
+
 	saDisplay := saNS + "/" + saName
 
 	// ── Fetch effective rules ────────────────────────────────────────────────

--- a/internal/k8s/rbac_test.go
+++ b/internal/k8s/rbac_test.go
@@ -467,3 +467,102 @@ func (s *stubK8sClientsIface) CachedServerGroupsAndResources() ([]*metav1.APIRes
 	_, lists, err := s.disc.ServerGroupsAndResources()
 	return lists, err
 }
+
+// TestResolveKroServiceAccount validates that kro's service account is resolved
+// from the cluster's Deployments, and returns empty strings when none is found.
+func TestResolveKroServiceAccount(t *testing.T) {
+	deployGVR := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	ctx := context.Background()
+
+	tests := []struct {
+		name  string
+		build func(t *testing.T) K8sClients
+		check func(t *testing.T, ns, name string, found bool)
+	}{
+		{
+			name: "no deployments found returns empty strings and found=false",
+			build: func(t *testing.T) K8sClients {
+				t.Helper()
+				// No deployments registered — stub returns list error for unregistered GVRs.
+				dyn := newStubDynamic()
+				_ = deployGVR // acknowledged but not registered
+				return &stubK8sClients{dyn: dyn, disc: newStubDiscovery()}
+			},
+			check: func(t *testing.T, ns, name string, found bool) {
+				t.Helper()
+				assert.Equal(t, "", ns, "namespace must be empty when no deployment found")
+				assert.Equal(t, "", name, "SA name must be empty when no deployment found")
+				assert.False(t, found, "found must be false when no deployment found")
+			},
+		},
+		{
+			name: "deployment with serviceAccountName in kro-system is resolved",
+			build: func(t *testing.T) K8sClients {
+				t.Helper()
+				dyn := newStubDynamic()
+				deploy := unstructured.Unstructured{Object: map[string]any{
+					"metadata": map[string]any{"name": "kro-controller-manager"},
+					"spec": map[string]any{
+						"template": map[string]any{
+							"spec": map[string]any{
+								"serviceAccountName": "kro-controller",
+							},
+						},
+					},
+				}}
+				dyn.resources[deployGVR] = &stubNamespaceableResource{
+					nsResources: map[string]*stubResourceClient{
+						"kro-system": {items: []unstructured.Unstructured{deploy}},
+						"kro":        {items: []unstructured.Unstructured{}},
+					},
+				}
+				return &stubK8sClients{dyn: dyn, disc: newStubDiscovery()}
+			},
+			check: func(t *testing.T, ns, name string, found bool) {
+				t.Helper()
+				assert.Equal(t, "kro-system", ns)
+				assert.Equal(t, "kro-controller", name)
+				assert.True(t, found)
+			},
+		},
+		{
+			name: "deployment with empty serviceAccountName is skipped",
+			build: func(t *testing.T) K8sClients {
+				t.Helper()
+				dyn := newStubDynamic()
+				// Deployment named "kro" but with no serviceAccountName set
+				deploy := unstructured.Unstructured{Object: map[string]any{
+					"metadata": map[string]any{"name": "kro"},
+					"spec": map[string]any{
+						"template": map[string]any{
+							"spec": map[string]any{
+								"serviceAccountName": "",
+							},
+						},
+					},
+				}}
+				dyn.resources[deployGVR] = &stubNamespaceableResource{
+					nsResources: map[string]*stubResourceClient{
+						"kro-system": {items: []unstructured.Unstructured{deploy}},
+						"kro":        {items: []unstructured.Unstructured{}},
+					},
+				}
+				return &stubK8sClients{dyn: dyn, disc: newStubDiscovery()}
+			},
+			check: func(t *testing.T, ns, name string, found bool) {
+				t.Helper()
+				assert.Equal(t, "", ns, "namespace must be empty when SA name is empty")
+				assert.Equal(t, "", name, "SA name must be empty when serviceAccountName field is empty")
+				assert.False(t, found)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clients := tt.build(t)
+			ns, name, found := ResolveKroServiceAccount(ctx, clients)
+			tt.check(t, ns, name, found)
+		})
+	}
+}

--- a/web/src/components/AccessTab.css
+++ b/web/src/components/AccessTab.css
@@ -1,6 +1,6 @@
 /* AccessTab.css — permission matrix table and banners.
  * All colors from tokens.css custom properties.
- * Spec: .specify/specs/018-rbac-visualizer/
+ * Spec: .specify/specs/018-rbac-visualizer/ + .specify/specs/032-rbac-sa-autodetect/
  */
 
 /* ── Loading / error states ──────────────────────────────────────────────── */
@@ -62,6 +62,27 @@
   color: var(--color-text-faint);
 }
 
+.access-tab-sa-value {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  color: var(--color-text);
+  background: var(--color-surface-3);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+}
+
+.access-tab-sa-sep {
+  margin: 0 6px;
+  color: var(--color-text-faint);
+}
+
+.access-tab-sa-source {
+  margin-left: 8px;
+  font-size: 12px;
+  color: var(--color-text-faint);
+  font-style: italic;
+}
+
 .access-tab-sa-name {
   font-family: var(--font-mono);
   font-size: 0.9em;
@@ -75,6 +96,79 @@
   color: var(--color-text-faint);
   font-size: 12px;
   font-style: italic;
+}
+
+/* ── Manual SA override form (032-rbac-sa-autodetect) ─────────────────────── */
+
+.access-tab-sa-override-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  border-radius: var(--radius);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-2);
+}
+
+.access-tab-sa-override-desc {
+  font-size: 13px;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.access-tab-sa-override-inputs {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.access-tab-sa-override-label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  flex: 1;
+  min-width: 180px;
+}
+
+.access-tab-sa-override-input {
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 13px;
+  font-family: var(--font-mono);
+  transition: border-color var(--transition-fast);
+}
+
+.access-tab-sa-override-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.access-tab-sa-override-btn {
+  align-self: flex-start;
+  padding: 6px 16px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-primary);
+  background: var(--color-primary);
+  color: var(--color-bg);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.access-tab-sa-override-btn:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.access-tab-sa-override-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 /* ── Informational note ───────────────────────────────────────────────────── */

--- a/web/src/components/AccessTab.test.tsx
+++ b/web/src/components/AccessTab.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { vi } from 'vitest'
 import AccessTab from './AccessTab'
 import type { AccessResponse } from '@/lib/api'
@@ -140,7 +140,7 @@ describe('AccessTab', () => {
     })
   })
 
-  it('shows SA not found note when serviceAccountFound is false', async () => {
+  it('shows SA not found note when serviceAccountFound is false but serviceAccount is non-empty', async () => {
     const resp = makeAccessResponse({
       serviceAccountFound: false,
       serviceAccount: 'kro-system/kro',
@@ -178,5 +178,231 @@ describe('AccessTab', () => {
     )
     expect(screen.getByText(/cluster unreachable/i)).toBeInTheDocument()
     expect(screen.getByText(/Retry/i)).toBeInTheDocument()
+  })
+
+  // ── US1: Manual override form when SA not found ─────────────────────────
+
+  it('shows manual override form when serviceAccount is empty and serviceAccountFound is false', async () => {
+    const resp = makeAccessResponse({
+      serviceAccount: '',
+      serviceAccountFound: false,
+      permissions: [],
+      hasGaps: false,
+    })
+    mockGetRGDAccess.mockResolvedValue(resp)
+
+    render(<AccessTab rgdName="test-app" />)
+    await waitFor(() =>
+      expect(screen.getByTestId('access-tab-sa-override-form')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('access-tab-sa-ns-input')).toBeInTheDocument()
+    expect(screen.getByTestId('access-tab-sa-name-input')).toBeInTheDocument()
+    expect(screen.getByTestId('access-tab-sa-override-submit')).toBeInTheDocument()
+  })
+
+  it('submit button is disabled when inputs are empty', async () => {
+    const resp = makeAccessResponse({
+      serviceAccount: '',
+      serviceAccountFound: false,
+      permissions: [],
+      hasGaps: false,
+    })
+    mockGetRGDAccess.mockResolvedValue(resp)
+
+    render(<AccessTab rgdName="test-app" />)
+    await waitFor(() =>
+      expect(screen.getByTestId('access-tab-sa-override-submit')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('access-tab-sa-override-submit')).toBeDisabled()
+  })
+
+  it('submit button is enabled when both inputs have values', async () => {
+    const resp = makeAccessResponse({
+      serviceAccount: '',
+      serviceAccountFound: false,
+      permissions: [],
+      hasGaps: false,
+    })
+    mockGetRGDAccess.mockResolvedValue(resp)
+
+    render(<AccessTab rgdName="test-app" />)
+    await waitFor(() =>
+      expect(screen.getByTestId('access-tab-sa-ns-input')).toBeInTheDocument(),
+    )
+
+    fireEvent.change(screen.getByTestId('access-tab-sa-ns-input'), {
+      target: { value: 'kro-prod' },
+    })
+    fireEvent.change(screen.getByTestId('access-tab-sa-name-input'), {
+      target: { value: 'kro-operator' },
+    })
+
+    expect(screen.getByTestId('access-tab-sa-override-submit')).not.toBeDisabled()
+  })
+
+  // ── US2: Manual form submit re-fetches with query params ────────────────
+
+  it('re-fetches with saNamespace and saName query params on manual form submit', async () => {
+    const emptyResp = makeAccessResponse({
+      serviceAccount: '',
+      serviceAccountFound: false,
+      permissions: [],
+      hasGaps: false,
+    })
+    const overrideResp = makeAccessResponse({
+      serviceAccount: 'kro-prod/kro-operator',
+      serviceAccountFound: true,
+      permissions: [],
+      hasGaps: false,
+    })
+    // First call returns empty SA, second (override) returns real SA
+    mockGetRGDAccess.mockResolvedValueOnce(emptyResp).mockResolvedValueOnce(overrideResp)
+
+    render(<AccessTab rgdName="test-app" />)
+    await waitFor(() =>
+      expect(screen.getByTestId('access-tab-sa-ns-input')).toBeInTheDocument(),
+    )
+
+    fireEvent.change(screen.getByTestId('access-tab-sa-ns-input'), {
+      target: { value: 'kro-prod' },
+    })
+    fireEvent.change(screen.getByTestId('access-tab-sa-name-input'), {
+      target: { value: 'kro-operator' },
+    })
+    fireEvent.click(screen.getByTestId('access-tab-sa-override-submit'))
+
+    await waitFor(() =>
+      expect(mockGetRGDAccess).toHaveBeenCalledWith('test-app', {
+        saNamespace: 'kro-prod',
+        saName: 'kro-operator',
+      }),
+    )
+  })
+
+  it('shows permission matrix after successful manual override', async () => {
+    const emptyResp = makeAccessResponse({
+      serviceAccount: '',
+      serviceAccountFound: false,
+      permissions: [],
+      hasGaps: false,
+    })
+    const overrideResp = makeAccessResponse({
+      serviceAccount: 'kro-prod/kro-operator',
+      serviceAccountFound: true,
+      permissions: [
+        makePermission('apps', 'deployments', 'Deployment', [
+          'get', 'list', 'watch', 'create', 'update', 'patch', 'delete',
+        ]),
+      ],
+      hasGaps: false,
+    })
+    mockGetRGDAccess.mockResolvedValueOnce(emptyResp).mockResolvedValueOnce(overrideResp)
+
+    render(<AccessTab rgdName="test-app" />)
+    await waitFor(() =>
+      expect(screen.getByTestId('access-tab-sa-ns-input')).toBeInTheDocument(),
+    )
+
+    fireEvent.change(screen.getByTestId('access-tab-sa-ns-input'), {
+      target: { value: 'kro-prod' },
+    })
+    fireEvent.change(screen.getByTestId('access-tab-sa-name-input'), {
+      target: { value: 'kro-operator' },
+    })
+    fireEvent.click(screen.getByTestId('access-tab-sa-override-submit'))
+
+    // After override, the permission matrix should show (no more override form)
+    await waitFor(() =>
+      expect(screen.queryByTestId('access-tab-sa-override-form')).not.toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('access-tab-success-banner')).toBeInTheDocument()
+  })
+
+  it('shows (manually specified) badge after manual override', async () => {
+    const emptyResp = makeAccessResponse({
+      serviceAccount: '',
+      serviceAccountFound: false,
+      permissions: [],
+      hasGaps: false,
+    })
+    const overrideResp = makeAccessResponse({
+      serviceAccount: 'kro-prod/kro-operator',
+      serviceAccountFound: true,
+      permissions: [],
+      hasGaps: false,
+    })
+    mockGetRGDAccess.mockResolvedValueOnce(emptyResp).mockResolvedValueOnce(overrideResp)
+
+    render(<AccessTab rgdName="test-app" />)
+    await waitFor(() =>
+      expect(screen.getByTestId('access-tab-sa-ns-input')).toBeInTheDocument(),
+    )
+
+    fireEvent.change(screen.getByTestId('access-tab-sa-ns-input'), {
+      target: { value: 'kro-prod' },
+    })
+    fireEvent.change(screen.getByTestId('access-tab-sa-name-input'), {
+      target: { value: 'kro-operator' },
+    })
+    fireEvent.click(screen.getByTestId('access-tab-sa-override-submit'))
+
+    await waitFor(() =>
+      expect(screen.getByText(/manually specified/i)).toBeInTheDocument(),
+    )
+  })
+
+  // ── US3: Human-readable SA banner ──────────────────────────────────────
+
+  it('shows labeled namespace and service account name not raw slash format', async () => {
+    const resp = makeAccessResponse({
+      serviceAccount: 'kro-system/kro',
+      serviceAccountFound: true,
+    })
+    mockGetRGDAccess.mockResolvedValue(resp)
+
+    render(<AccessTab rgdName="test-app" />)
+    await waitFor(() =>
+      expect(screen.getByTestId('access-tab-sa-banner')).toBeInTheDocument(),
+    )
+
+    // Should show "Namespace:" and "Service account:" labels
+    expect(screen.getByText('Namespace:')).toBeInTheDocument()
+    expect(screen.getByText('Service account:')).toBeInTheDocument()
+    expect(screen.getByTestId('access-tab-sa-namespace')).toHaveTextContent('kro-system')
+    expect(screen.getByTestId('access-tab-sa-name')).toHaveTextContent('kro')
+
+    // Raw "kro-system/kro" slash string should NOT appear as a single text node
+    expect(screen.queryByText('kro-system/kro')).not.toBeInTheDocument()
+  })
+
+  it('shows (auto-detected) indicator when serviceAccountFound is true', async () => {
+    const resp = makeAccessResponse({
+      serviceAccount: 'kro-system/kro',
+      serviceAccountFound: true,
+    })
+    mockGetRGDAccess.mockResolvedValue(resp)
+
+    render(<AccessTab rgdName="test-app" />)
+    await waitFor(() =>
+      expect(screen.getByTestId('access-tab-sa-banner')).toBeInTheDocument(),
+    )
+    expect(screen.getByText(/auto-detected/i)).toBeInTheDocument()
+  })
+
+  it('banner has title attribute with full namespace/name for accessibility', async () => {
+    const resp = makeAccessResponse({
+      serviceAccount: 'kro-system/kro',
+      serviceAccountFound: true,
+    })
+    mockGetRGDAccess.mockResolvedValue(resp)
+
+    render(<AccessTab rgdName="test-app" />)
+    await waitFor(() =>
+      expect(screen.getByTestId('access-tab-sa-banner')).toBeInTheDocument(),
+    )
+    expect(screen.getByTestId('access-tab-sa-banner')).toHaveAttribute(
+      'title',
+      'kro-system/kro',
+    )
   })
 })

--- a/web/src/components/AccessTab.tsx
+++ b/web/src/components/AccessTab.tsx
@@ -38,17 +38,22 @@ function resolvedClusterRoleName(data: AccessResponse): string {
  * AccessTab — permission matrix for the "Access" tab on the RGD detail page.
  *
  * Fetches GET /api/v1/rgds/{name}/access and renders:
- *  - Service account banner (with SA-not-found fallback)
+ *  - Service account banner (with SA-not-found fallback → manual override form)
  *  - Success banner (all permissions OK) or warning banner + gap count
  *  - Permission matrix table (GVRs × verbs)
  *  - Collapsible kubectl fix suggestions for each gap row
  *
- * Spec: .specify/specs/018-rbac-visualizer/
+ * Spec: .specify/specs/018-rbac-visualizer/ + .specify/specs/032-rbac-sa-autodetect/
  */
 export default function AccessTab({ rgdName }: AccessTabProps) {
   const [data, setData] = useState<AccessResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+
+  // Manual SA override form state (US1/US2)
+  const [manualNS, setManualNS] = useState("")
+  const [manualSAName, setManualSAName] = useState("")
+  const [overrideSource, setOverrideSource] = useState<"auto" | "manual" | null>(null)
 
   useEffect(() => {
     if (!rgdName) return
@@ -59,6 +64,7 @@ export default function AccessTab({ rgdName }: AccessTabProps) {
       .then((d) => {
         setData(d)
         setError(null)
+        setOverrideSource(d.serviceAccountFound ? "auto" : null)
       })
       .catch((err: Error) => {
         setError(err.message)
@@ -66,6 +72,26 @@ export default function AccessTab({ rgdName }: AccessTabProps) {
       })
       .finally(() => setLoading(false))
   }, [rgdName])
+
+  /** Called when the user submits the manual SA override form. */
+  function handleManualSubmit() {
+    const ns = manualNS.trim()
+    const name = manualSAName.trim()
+    if (!ns || !name) return
+    setLoading(true)
+    setError(null)
+    getRGDAccess(rgdName, { saNamespace: ns, saName: name })
+      .then((d) => {
+        setData(d)
+        setError(null)
+        setOverrideSource("manual")
+      })
+      .catch((err: Error) => {
+        setError(err.message)
+        setData(null)
+      })
+      .finally(() => setLoading(false))
+  }
 
   if (loading) {
     return <div className="access-tab-loading">Checking permissions…</div>
@@ -95,18 +121,96 @@ export default function AccessTab({ rgdName }: AccessTabProps) {
 
   if (!data) return null
 
+  // ── SA not found: show manual override form ────────────────────────────────
+  if (!data.serviceAccountFound && data.serviceAccount === "") {
+    const canSubmit = manualNS.trim().length > 0 && manualSAName.trim().length > 0
+    return (
+      <div className="access-tab" data-testid="access-tab">
+        <div className="access-tab-sa-override-form" data-testid="access-tab-sa-override-form">
+          <p className="access-tab-sa-override-desc">
+            Could not auto-detect kro's service account. Enter it manually to check permissions:
+          </p>
+          <div className="access-tab-sa-override-inputs">
+            <label className="access-tab-sa-override-label">
+              Namespace
+              <input
+                type="text"
+                className="access-tab-sa-override-input"
+                value={manualNS}
+                onChange={(e) => setManualNS(e.target.value)}
+                placeholder="e.g. kro-system"
+                data-testid="access-tab-sa-ns-input"
+              />
+            </label>
+            <label className="access-tab-sa-override-label">
+              Service account name
+              <input
+                type="text"
+                className="access-tab-sa-override-input"
+                value={manualSAName}
+                onChange={(e) => setManualSAName(e.target.value)}
+                placeholder="e.g. kro-controller"
+                data-testid="access-tab-sa-name-input"
+              />
+            </label>
+          </div>
+          <button
+            type="button"
+            className="access-tab-sa-override-btn"
+            disabled={!canSubmit}
+            onClick={handleManualSubmit}
+            data-testid="access-tab-sa-override-submit"
+          >
+            Check permissions
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  // ── Normal view: SA known (auto-detected or manually specified) ────────────
   const gapCount = data.permissions.filter(hasGap).length
+
+  // Parse namespace/name from the "namespace/name" serviceAccount string (US3)
+  const slashIdx = data.serviceAccount.indexOf("/")
+  const saBannerNS = slashIdx >= 0 ? data.serviceAccount.slice(0, slashIdx) : data.serviceAccount
+  const saBannerName = slashIdx >= 0 ? data.serviceAccount.slice(slashIdx + 1) : ""
+
+  const sourceLabel =
+    overrideSource === "manual"
+      ? "(manually specified)"
+      : overrideSource === "auto" || data.serviceAccountFound
+        ? "(auto-detected)"
+        : null
 
   return (
     <div className="access-tab" data-testid="access-tab">
-      {/* Service account info */}
-      <div className="access-tab-sa-banner" data-testid="access-tab-sa-banner">
-        <span className="access-tab-sa-label">Checking kro service account:</span>{" "}
-        <code className="access-tab-sa-name">{data.serviceAccount}</code>
-        {!data.serviceAccountFound && (
+      {/* Service account info — labeled format (US3) */}
+      <div
+        className="access-tab-sa-banner"
+        data-testid="access-tab-sa-banner"
+        title={data.serviceAccount}
+      >
+        <span className="access-tab-sa-label">Namespace:</span>{" "}
+        <code className="access-tab-sa-value" data-testid="access-tab-sa-namespace">
+          {saBannerNS}
+        </code>
+        {saBannerName && (
+          <>
+            <span className="access-tab-sa-sep" aria-hidden="true">·</span>
+            <span className="access-tab-sa-label">Service account:</span>{" "}
+            <code className="access-tab-sa-value" data-testid="access-tab-sa-name">
+              {saBannerName}
+            </code>
+          </>
+        )}
+        {sourceLabel && (
+          <span className="access-tab-sa-source">{sourceLabel}</span>
+        )}
+        {!data.serviceAccountFound && !sourceLabel && (
           <span className="access-tab-sa-note">
             {" "}
-            (detected automatically — could not verify service account exists)
+            (could not verify service account exists)
           </span>
         )}
       </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -119,8 +119,16 @@ export interface AccessResponse {
   permissions: GVRPermission[]
 }
 
-export const getRGDAccess = (rgdName: string) =>
-  get<AccessResponse>(`/rgds/${encodeURIComponent(rgdName)}/access`)
+export const getRGDAccess = (
+  rgdName: string,
+  opts?: { saNamespace?: string; saName?: string },
+) => {
+  const params = new URLSearchParams()
+  if (opts?.saNamespace) params.set('saNamespace', opts.saNamespace)
+  if (opts?.saName) params.set('saName', opts.saName)
+  const query = params.toString() ? `?${params.toString()}` : ''
+  return get<AccessResponse>(`/rgds/${encodeURIComponent(rgdName)}/access${query}`)
+}
 
 // ── Fleet ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Removes the hardcoded `("kro-system","kro")` fallback from `ResolveKroServiceAccount` — when no kro Deployment is found the function now returns `("","",false)`, fixing a silent wrong-SA bug on non-standard installations (closes #115, constitution §XIII violation)
- Adds optional `?saNamespace=&saName=` query params to `GET /api/v1/rgds/{name}/access` so the frontend can pass a manually specified SA when auto-detection fails
- Updates the Access tab to show a manual override form (two labeled inputs) when `serviceAccount=""` and `serviceAccountFound=false`, and re-fetches with the override params on submit
- Replaces the raw `kro/kro` SA banner with a labeled `Namespace: X · Service account: Y (auto-detected)` format (closes #133)

## Changed files

| File | What changed |
|------|-------------|
| `internal/k8s/rbac.go` | Remove hardcoded fallback; `ComputeAccessResult` takes pre-resolved SA params; early-return on empty SA |
| `internal/k8s/rbac_test.go` | Add `TestResolveKroServiceAccount` (3 cases: no deployment, resolved, empty SA name) |
| `internal/api/handlers/access.go` | Read `saNamespace`/`saName` query params; skip auto-detect when both provided |
| `web/src/lib/api.ts` | `getRGDAccess` accepts optional `opts: { saNamespace?, saName? }` |
| `web/src/components/AccessTab.tsx` | Manual override form; `handleManualSubmit`; labeled SA banner with source indicator |
| `web/src/components/AccessTab.css` | New token-based classes for override form and SA banner labels |
| `web/src/components/AccessTab.test.tsx` | 10 new tests: override form, re-fetch flow, labeled banner |

## Test results

- `go test -race ./...` — all pass
- `go vet ./...` — clean
- `tsc --noEmit` — zero errors
- `vitest run` — 556 tests pass (10 new AccessTab tests)

Spec: `.specify/specs/032-rbac-sa-autodetect/`