### PR TITLE
feat(web): rename Home to Overview, add Catalog subtitle — differentiate IA (#163)

### DIFF
--- a/.specify/specs/037-ia-home-catalog-merge/data-model.md
+++ b/.specify/specs/037-ia-home-catalog-merge/data-model.md
@@ -1,0 +1,74 @@
+# Data Model: 037-ia-home-catalog-merge
+
+This spec introduces no new data entities, no new API types, and no new state
+structures. It is a UI copy and labeling change only.
+
+---
+
+## Entities (unchanged)
+
+All existing entities are unchanged. This spec does not add, remove, or modify
+any data structures.
+
+| Entity | Owner | Changed? |
+|--------|-------|---------|
+| `K8sObject` (`lib/api.ts`) | api layer | No |
+| `HealthSummary` (`lib/format.ts`) | format lib | No |
+| `SortOption` (`lib/catalog.ts`) | catalog lib | No |
+| `KubeContext` (`lib/api.ts`) | api layer | No |
+
+---
+
+## Component Props (unchanged)
+
+No component interfaces are modified.
+
+| Component | Props interface | Changed? |
+|-----------|----------------|---------|
+| `RGDCard` | `{ rgd, terminatingCount? }` | No |
+| `CatalogCard` | `{ rgd, instanceCount, usedBy, onLabelClick }` | No |
+| `TopBar` | `{ contexts, activeContext, onSwitch }` | No |
+| `MetricsStrip` | none | No |
+
+---
+
+## Page State (unchanged)
+
+No new React state is introduced on any page.
+
+---
+
+## UI Copy Changes (the actual "model" for this spec)
+
+These are the only changes in this spec.
+
+| Location | Property | Old Value | New Value |
+|----------|----------|-----------|-----------|
+| `Home.tsx` | `usePageTitle()` arg | `'RGDs'` | `'Overview'` |
+| `Home.tsx` | `<h1>` text | `RGDs` | `Overview` |
+| `Home.tsx` | `.home__tagline` text | `"ResourceGraphDefinitions — kro observability dashboard"` | `"Controller and RGD health at a glance"` |
+| `TopBar.tsx` | NavLink label for `/` | `Home` | `Overview` |
+| `Catalog.tsx` | subtitle `<p>` (new element) | *(absent)* | `"Browse, filter, and discover all ResourceGraphDefinitions"` |
+
+---
+
+## CSS Classes (additions only)
+
+| File | Class | Purpose |
+|------|-------|---------|
+| `Catalog.css` | `.catalog__subtitle` (new) | Styles the new subtitle `<p>` on the Catalog page |
+
+No existing CSS classes are renamed or removed.
+The `.home__tagline` class in `Home.css` requires no structural change —
+only the text content inside it changes (in `Home.tsx`).
+
+---
+
+## E2E Assertion Strings
+
+| File | Assertion | Old string | New string |
+|------|-----------|-----------|-----------|
+| `002-home-page.spec.ts` | heading | `"RGDs"` | `"Overview"` |
+| `002-home-page.spec.ts` | page title | `"RGDs — kro-ui"` | `"Overview — kro-ui"` |
+| `002-home-page.spec.ts` | nav link | `"Home"` | `"Overview"` |
+| `015-rgd-catalog.spec.ts` | nav link | `"Home"` (if present) | `"Overview"` |

--- a/.specify/specs/037-ia-home-catalog-merge/plan.md
+++ b/.specify/specs/037-ia-home-catalog-merge/plan.md
@@ -1,0 +1,90 @@
+# Implementation Plan: IA Home & Catalog Differentiation
+
+**Branch**: `037-ia-home-catalog-merge` | **Date**: 2026-03-24 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `.specify/specs/037-ia-home-catalog-merge/spec.md`
+
+## Summary
+
+Resolve the information architecture ambiguity where Home (`/`) and Catalog
+(`/catalog`) appear identical at first glance despite having meaningfully
+different purposes. **Option A — Distinguish** is chosen: rename the Home page
+to "Overview" (operational health dashboard) and reinforce the Catalog page as
+the browsing/discovery directory, via targeted copy + labeling changes only.
+
+No new components, no new API calls, no routing changes, no backend changes.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x + React 19 + Vite (frontend); Go 1.25 (backend — unchanged)
+**Primary Dependencies**: React Router v7 (NavLink, usePageTitle hook), plain CSS custom properties
+**Storage**: N/A
+**Testing**: Playwright E2E (`002-home-page.spec.ts`, `015-rgd-catalog.spec.ts`); Go test race (unchanged)
+**Target Platform**: Modern browser (same as existing)
+**Project Type**: Web application (read-only Kubernetes observability dashboard)
+**Performance Goals**: No change — this spec introduces no new data fetching or rendering
+**Constraints**: CSS tokens only (`tokens.css`); no hardcoded hex/rgba in component CSS
+**Scale/Scope**: 5 file edits (3 source + 2 E2E tests); 0 new files except `Catalog.css` addition
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Rule | Status | Notes |
+|------|--------|-------|
+| §I Iterative-First | PASS | Smallest possible change; both pages remain independently shippable |
+| §II Cluster Adaptability | PASS | No cluster API changes |
+| §III Read-Only | PASS | No mutating Kubernetes API calls introduced |
+| §IV Single Binary | PASS | No new assets, no CDN |
+| §V Simplicity | PASS | No new components, no new dependencies |
+| §VI Go Standards | PASS | No Go code changes |
+| §VII Testing | PASS | E2E assertions updated; no tests deleted |
+| §VIII Commit Conventions | PASS | Will use `feat(web): rename home to overview — differentiate IA` |
+| §IX Theme/UI Standards | PASS | CSS tokens only; `--color-text-muted` for subtitle; no hardcoded colors |
+| §XI API Performance | PASS | No new API calls |
+| §XII Graceful Degradation | PASS | No data handling changes |
+| §XIII Frontend UX | PASS | Page titles updated (AC-001, AC-002); nav label updated (AC-004) |
+
+**GATE RESULT: ALL PASS — no violations. No complexity tracking required.**
+
+**Post-design re-check** (after Phase 1): All gates still pass. The only
+design addition (`.catalog__subtitle` CSS class) uses `var(--color-text-muted)`
+— a named token — consistent with §IX.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/037-ia-home-catalog-merge/
+├── plan.md              # This file
+├── spec.md              # Feature specification (written as part of this plan)
+├── research.md          # Phase 0 output — IA decision rationale
+├── data-model.md        # Phase 1 output — copy change table, CSS class additions
+├── quickstart.md        # Phase 1 output — step-by-step implementation guide
+└── tasks.md             # Phase 2 output (/speckit.tasks command — NOT created by /speckit.plan)
+```
+
+### Source Code (affected files only)
+
+```text
+web/
+├── src/
+│   ├── pages/
+│   │   ├── Home.tsx           # usePageTitle, <h1>, .home__tagline text
+│   │   ├── Catalog.tsx        # Add subtitle <p> below <h1>
+│   │   └── Catalog.css        # Add .catalog__subtitle rule
+│   └── components/
+│       └── TopBar.tsx         # Nav link label "Home" → "Overview"
+test/
+└── e2e/
+    └── journeys/
+        ├── 002-home-page.spec.ts      # Update heading/title/nav assertions
+        └── 015-rgd-catalog.spec.ts    # Update nav link assertion if present
+```
+
+**Structure Decision**: Web application, existing layout. No new directories.
+All changes are targeted edits to existing files (+ one new CSS rule).
+
+## Complexity Tracking
+
+> No constitution violations — this section is not required.

--- a/.specify/specs/037-ia-home-catalog-merge/quickstart.md
+++ b/.specify/specs/037-ia-home-catalog-merge/quickstart.md
@@ -1,0 +1,121 @@
+# Quickstart: 037-ia-home-catalog-merge
+
+## What this spec changes
+
+A targeted UI copy + labeling change that differentiates the Home and Catalog
+pages with clear, distinct purposes.
+
+**3 source file changes + 2 E2E test assertion updates.**
+
+---
+
+## Prerequisites
+
+- Node.js / Bun installed (for `bun run typecheck` and frontend build)
+- Go 1.25 installed (for `go vet`, `go test -race`)
+- Working kro-ui dev environment
+
+---
+
+## Step-by-step implementation
+
+### 1. Update Home page copy (`web/src/pages/Home.tsx`)
+
+Three changes in one file:
+
+```diff
+- usePageTitle('RGDs')
++ usePageTitle('Overview')
+
+- <h1 className="home__heading">RGDs</h1>
++ <h1 className="home__heading">Overview</h1>
+
+- <p className="home__tagline">
+-   ResourceGraphDefinitions — kro observability dashboard
+- </p>
++ <p className="home__tagline">
++   Controller and RGD health at a glance
++ </p>
+```
+
+### 2. Update TopBar nav label (`web/src/components/TopBar.tsx`)
+
+One string change:
+
+```diff
+- <NavLink to="/" end ...>Home</NavLink>
++ <NavLink to="/" end ...>Overview</NavLink>
+```
+
+### 3. Add Catalog subtitle (`web/src/pages/Catalog.tsx`)
+
+Add a `<p>` subtitle element below the `<h1>`:
+
+```diff
+  <h1 className="catalog__heading">RGD Catalog</h1>
++ <p className="catalog__subtitle">
++   Browse, filter, and discover all ResourceGraphDefinitions
++ </p>
+```
+
+### 4. Style the Catalog subtitle (`web/src/pages/Catalog.css`)
+
+Add the `.catalog__subtitle` rule using existing tokens:
+
+```css
+.catalog__subtitle {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+```
+
+### 5. Update E2E assertions
+
+In `test/e2e/journeys/002-home-page.spec.ts`:
+- Change heading assertion from `"RGDs"` to `"Overview"`
+- Change page title assertion from `"RGDs — kro-ui"` to `"Overview — kro-ui"`
+- Change nav link text assertion from `"Home"` to `"Overview"` (if present)
+
+In `test/e2e/journeys/015-rgd-catalog.spec.ts`:
+- Change nav link text assertion from `"Home"` to `"Overview"` (if present)
+
+---
+
+## Verification
+
+```bash
+# TypeScript check
+bun run typecheck
+
+# Go check (no Go changes, but run anyway for CI parity)
+GOPROXY=direct GONOSUMDB="*" go vet ./...
+
+# Unit tests
+GOPROXY=direct GONOSUMDB="*" go test -race ./...
+
+# Frontend dev server (manual visual check)
+bun run dev
+```
+
+Navigate to `http://localhost:5173`:
+1. TopBar nav shows "Overview" (not "Home")
+2. Home page `<h1>` reads "Overview"
+3. Home page subtitle reads "Controller and RGD health at a glance"
+4. MetricsStrip still renders at top of home page
+5. Navigate to `/catalog` — heading still reads "RGD Catalog"
+6. Catalog subtitle reads "Browse, filter, and discover all ResourceGraphDefinitions"
+7. Catalog sort, label filter, and chaining features all still work
+
+---
+
+## Risk Assessment
+
+**Risk**: Low. This is a copy-only change.
+
+- No new components
+- No new API calls
+- No routing changes
+- No data model changes
+- No backend changes
+- Rollback: trivially revert the 2 source files + 2 test files

--- a/.specify/specs/037-ia-home-catalog-merge/research.md
+++ b/.specify/specs/037-ia-home-catalog-merge/research.md
@@ -1,0 +1,131 @@
+# Research: 037-ia-home-catalog-merge
+
+**Phase 0 research — all unknowns resolved**
+
+---
+
+## Question 1: Merge vs Distinguish (Option A vs B)?
+
+**Decision**: Option A — Distinguish (rename/reframe with subtitles)
+
+**Rationale**:
+- The two pages already have meaningfully different data and workflows.
+  Home is operational (MetricsStrip, HealthChip, terminating badges, abort-safe
+  health fetch per card). Catalog is exploratory (sort, label filter, instance
+  counts as prop, chaining map, "Used by" rows).
+- Merging them into a tab pattern would either (a) require a bloated mega-card
+  that conditionally shows or hides health chip / instance count / label pills,
+  or (b) require two separate card components rendered inside the same page with
+  a tab toggle — recreating the current problem with more complexity.
+- The constitution (§I Iterative-First, §V Simplicity Over Cleverness) favors
+  the minimal change: rename + subtitle addition.
+- Tab-based single-page patterns create URL addressability problems (tab state
+  must be in the URL or it is not bookmarkable). Adding a `?view=` param is
+  technically workable but adds incidental complexity that this spec explicitly
+  does not need.
+
+**Alternatives considered**:
+- Option B (merge + tab): rejected (see above and spec.md)
+- Option C (remove Catalog, merge its features into Home): rejected — Catalog
+  has richer discovery features (sort, label filter, chaining) that belong in
+  a separate browsing surface. Home is a status board.
+- Option D (remove Home, keep only Catalog): rejected — the MetricsStrip and
+  HealthChip features serve a fundamentally different use case (incident
+  response / operational health) than browsing.
+
+---
+
+## Question 2: What label/heading for the Home page?
+
+**Decision**: "Overview"
+
+**Rationale**:
+- "Overview" is the standard label for operational health dashboards in
+  infrastructure tooling (Grafana, ArgoCD, Flux all use "Overview" for their
+  primary health surface).
+- "Dashboard" is overloaded and often implies configurable widgets.
+- "Home" is generic and conveys no functional meaning. The nav link saying
+  "Home" gives users no signal about what they'll find there.
+- "Status" is accurate but implies a secondary/auxiliary page.
+
+**Alternatives considered**:
+- "Dashboard": too generic, implies customization widgets
+- "Status": accurate but sounds secondary
+- "Health": accurate but narrows scope too early (also shows RGD list)
+- Keeping "Home": no information value; confirms the problem that prompted this spec
+
+---
+
+## Question 3: What subtitle text for each page?
+
+**Decision**:
+- Overview: `"Controller and RGD health at a glance"`
+- Catalog: `"Browse, filter, and discover all ResourceGraphDefinitions"`
+
+**Rationale**:
+- Overview subtitle anchors the operational-health mental model; reinforces
+  why MetricsStrip is shown first.
+- Catalog subtitle explicitly names the browsing/discovery purpose; reinforces
+  why sort + label filter are present.
+- Both subtitles are factually accurate and scannable in one line.
+
+**Alternatives considered**:
+- Longer explanatory text: unnecessary — the page content is self-explanatory.
+- No subtitle: less bad than the current state (just "RGDs" heading) but still
+  doesn't differentiate the pages.
+
+---
+
+## Question 4: Should the URL `/` change?
+
+**Decision**: No. URL stays `/`. The rename is a copy-only change.
+
+**Rationale**:
+- Changing the URL would break existing bookmarks, curl scripts, and any
+  infrastructure tooling that links directly to `/`.
+- The mental model fix is in the nav label and heading, not the URL.
+- React Router's `NavLink` with `end` prop already handles active-state
+  correctly for `/`.
+
+---
+
+## Question 5: Does this require any backend changes?
+
+**Decision**: No backend changes.
+
+**Rationale**:
+- This spec is purely a UI copy/label change. The backend API is unchanged.
+- No new endpoints, no new Go files, no changes to handler or k8s layer.
+
+---
+
+## Question 6: Which E2E tests are affected?
+
+**Decision**: Two E2E journey files need assertion updates.
+
+**Files**:
+1. `test/e2e/journeys/002-home-page.spec.ts` — asserts heading, page title,
+   and (likely) nav link text. All three assertions change.
+2. `test/e2e/journeys/015-rgd-catalog.spec.ts` — if it navigates to Catalog
+   via the "Catalog" nav link, it is unaffected. If it first checks or clicks
+   the "Home"/"Overview" nav link, it needs updating.
+
+**Approach**: Read each test file and update only the specific assertion strings,
+not the test structure or selectors.
+
+---
+
+## Summary of Resolved Unknowns
+
+| Unknown | Resolution |
+|---------|------------|
+| Merge or distinguish? | Distinguish (Option A) |
+| New home label | "Overview" |
+| Subtitle text (home) | "Controller and RGD health at a glance" |
+| Subtitle text (catalog) | "Browse, filter, and discover all ResourceGraphDefinitions" |
+| URL changes? | None |
+| Backend changes? | None |
+| Affected E2E tests | 002-home-page.spec.ts, possibly 015-rgd-catalog.spec.ts |
+| New CSS tokens needed? | No — existing `--color-text-muted` + `--font-sans` cover subtitles |
+| New components? | No |
+| New dependencies? | None |

--- a/.specify/specs/037-ia-home-catalog-merge/spec.md
+++ b/.specify/specs/037-ia-home-catalog-merge/spec.md
@@ -1,0 +1,200 @@
+# Spec 037 — IA: Home & Catalog Differentiation
+
+**Branch**: `037-ia-home-catalog-merge`
+**GH Issue**: #163
+**Created**: 2026-03-24
+**Status**: Draft
+
+---
+
+## Problem Statement
+
+Both the Home (`/`) and Catalog (`/catalog`) pages display the same list of
+ResourceGraphDefinitions in a card grid with a search bar. Despite having
+meaningfully different data and use-cases, they are visually indistinguishable
+at first glance. A first-time user has no mental model for why both pages exist,
+and an experienced user has to remember which page has sort, label filter,
+instance counts, or health chips.
+
+**Observed duplication:**
+- Both pages call `listRGDs()` + `listInstances()` fan-out on mount
+- Both use `SearchBar` + `VirtualGrid` + `matchesSearch()`
+- Both show an RGD card grid with name, kind, resource count, age
+
+**Hidden differentiation (invisible without reading docs):**
+
+| Feature | Home (`/`) | Catalog (`/catalog`) |
+|---|---|---|
+| Controller metrics strip | ✓ | ✗ |
+| Instance health chips (HealthChip) | ✓ | ✗ |
+| Terminating instance badge | ✓ | ✗ |
+| Label filter (multi-select AND) | ✗ | ✓ |
+| Sort controls (5 options) | ✗ | ✓ |
+| Instance count per card | ✗ | ✓ |
+| "Used by" chaining rows | ✗ | ✓ |
+
+---
+
+## IA Decision: Option A — Distinguish Clearly
+
+Two options were evaluated. Option A is chosen.
+
+### Option B (Merge — REJECTED)
+
+Merge both pages into one, with a tab/toggle between "Overview" and "Catalog"
+views.
+
+**Rejected because:**
+- The two views have fundamentally different primary jobs: operational health
+  monitoring vs. browsing/discovery. Tabs imply equivalence.
+- Merging requires reconciling `RGDCard` (130 px, health chip, terminating
+  badge, abort-safe health fetch) with `CatalogCard` (160 px, label pills,
+  "Used by", instance count prop), either creating a bloated mega-card or losing
+  capabilities.
+- Violates the constitution §I (Iterative-First): a merge is a larger, riskier
+  change than a rename + subtitle.
+- Adds state complexity: a tab toggle on a URL-addressable resource listing is
+  not bookmarkable without URL params, which creates hidden coupling.
+
+### Option A (Distinguish — CHOSEN)
+
+Keep both pages. Rename/reframe them with clear, distinct purposes.
+
+- **Home** (`/`) → rename to **"Overview"** in heading and page title
+  - Primary job: operational health dashboard
+  - Lead with `MetricsStrip` (controller health)
+  - Show instance health chips and terminating badges on cards
+  - Add a subtitle: "Controller and RGD health at a glance"
+  - No sort controls, no label filter — this is a status board, not a directory
+
+- **Catalog** (`/catalog`) → keep as **"RGD Catalog"**
+  - Primary job: browsing and discovery
+  - Full search, label filter, sort
+  - Instance counts, "Used by" chaining
+  - Add a subtitle: "Browse, filter, and discover all ResourceGraphDefinitions"
+
+- **Navigation**: rename the "Home" nav link to "Overview" in `TopBar.tsx`
+  - The nav label change anchors the mental model in the navigation bar
+  - "Home" (generic) → "Overview" (functional label)
+
+---
+
+## Functional Requirements
+
+### FR-001 — Home page heading and title
+The Home page (`/`) MUST:
+- Display `<h1>Overview</h1>` (replaces "RGDs")
+- Display `document.title = "Overview — kro-ui"` (replaces "RGDs — kro-ui")
+- Display a subtitle below the heading: "Controller and RGD health at a glance"
+
+### FR-002 — Home page tagline
+The existing `.home__tagline` element MUST be updated to:
+`"Controller and RGD health at a glance"` (replaces the current tagline
+`"ResourceGraphDefinitions — kro observability dashboard"`).
+
+### FR-003 — Home empty state
+The onboarding empty state heading MUST remain "No ResourceGraphDefinitions
+found". The descriptive text and CTA links are unchanged.
+
+### FR-004 — Catalog heading (unchanged)
+The Catalog page (`/catalog`) heading remains `RGD Catalog`. No change to its
+title, subtitle, or toolbar. A descriptive subtitle SHOULD be added below the
+heading: "Browse, filter, and discover all ResourceGraphDefinitions".
+
+### FR-005 — TopBar nav label
+The navigation link pointing to `/` in `TopBar.tsx` MUST be relabeled from
+`Home` to `Overview`.
+
+### FR-006 — Document title for Overview
+`usePageTitle('Overview')` replaces `usePageTitle('RGDs')` in `Home.tsx`.
+
+### FR-007 — E2E journey update
+The E2E test for the Home page (`test/e2e/journeys/002-home-page.spec.ts`)
+MUST be updated to assert the new heading text "Overview" and page title
+"Overview — kro-ui". The nav link assertion MUST look for "Overview" not "Home".
+
+### FR-008 — Catalog E2E journey update
+The Catalog E2E test (`test/e2e/journeys/015-rgd-catalog.spec.ts`) MUST be
+updated if it references the "Home" nav link or navigates via it.
+
+### FR-009 — Catalog subtitle (optional)
+The Catalog page MAY add a subtitle `<p>` below the `<h1>` with the text
+"Browse, filter, and discover all ResourceGraphDefinitions" to match the
+Overview subtitle treatment. This is a SHOULD, not a MUST.
+
+---
+
+## Non-Functional Requirements
+
+### NFR-001 — No regressions
+All existing functionality on both pages MUST continue to work identically.
+No RGDCard, CatalogCard, MetricsStrip, HealthChip, LabelFilter, VirtualGrid,
+or SearchBar code changes.
+
+### NFR-002 — No new dependencies
+No new npm packages or Go modules.
+
+### NFR-003 — CSS tokens only
+Any new CSS MUST use only tokens from `web/src/tokens.css`. No hardcoded hex,
+rgba, or shadow values.
+
+### NFR-004 — Accessibility
+The new subtitle element MUST be a `<p>` tag (not a `<div>`) for correct
+document structure. WCAG AA contrast is maintained via existing token colors.
+
+### NFR-005 — No route changes
+The URL `/` for Home and `/catalog` for Catalog MUST NOT change. The rename
+is a label/copy change only, not a routing change. Existing bookmarks continue
+to work.
+
+---
+
+## Acceptance Criteria
+
+| ID | Criteria |
+|----|----------|
+| AC-001 | Home page `<h1>` reads "Overview" |
+| AC-002 | Home page `document.title` is "Overview — kro-ui" |
+| AC-003 | Home page has a visible subtitle "Controller and RGD health at a glance" |
+| AC-004 | TopBar nav link for `/` reads "Overview" (not "Home") |
+| AC-005 | Catalog page `<h1>` still reads "RGD Catalog" |
+| AC-006 | Catalog page has a visible subtitle below the heading |
+| AC-007 | E2E test `002-home-page.spec.ts` passes with updated assertions |
+| AC-008 | E2E test `015-rgd-catalog.spec.ts` passes unchanged (or updated for nav) |
+| AC-009 | `go test -race ./...` passes |
+| AC-010 | `bun run typecheck` passes |
+| AC-011 | All MetricsStrip, HealthChip, and terminating badge features still render on `/` |
+| AC-012 | All LabelFilter, sort, instance count, and "Used by" features still render on `/catalog` |
+
+---
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `web/src/pages/Home.tsx` | Heading text, tagline text, `usePageTitle` arg |
+| `web/src/components/TopBar.tsx` | Nav link label: "Home" → "Overview" |
+| `web/src/pages/Catalog.tsx` | Add subtitle `<p>` below `<h1>` |
+| `web/src/pages/Catalog.css` | Add `.catalog__subtitle` style (if needed) |
+| `web/src/pages/Home.css` | `.home__tagline` may need update (copy only) |
+| `test/e2e/journeys/002-home-page.spec.ts` | Update heading/title/nav assertions |
+| `test/e2e/journeys/015-rgd-catalog.spec.ts` | Update nav link assertion if present |
+
+**Explicitly NOT changed:**
+- `web/src/main.tsx` (routes stay the same)
+- `web/src/components/RGDCard.tsx`
+- `web/src/components/CatalogCard.tsx`
+- `web/src/components/MetricsStrip.tsx`
+- `web/src/components/HealthChip.tsx`
+- `web/src/components/LabelFilter.tsx`
+- `web/src/components/VirtualGrid.tsx`
+- `web/src/components/SearchBar.tsx`
+- All backend Go files
+
+---
+
+## Supersedes
+
+Spec `002-rgd-list-home` FR-001 heading text is superseded by FR-001 above.
+Spec `015-rgd-catalog` is unchanged and still in effect. The catalog subtitle
+(FR-009) is an additive enhancement.

--- a/.specify/specs/037-ia-home-catalog-merge/tasks.md
+++ b/.specify/specs/037-ia-home-catalog-merge/tasks.md
@@ -1,0 +1,176 @@
+# Tasks: 037 — IA: Home & Catalog Differentiation
+
+**Input**: Design documents from `.specify/specs/037-ia-home-catalog-merge/`
+**Branch**: `037-ia-home-catalog-merge`
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no blocking dependency)
+- **[Story]**: Which user story this task belongs to
+
+## Path Conventions
+
+Web application layout:
+- Frontend source: `web/src/`
+- E2E tests: `test/e2e/journeys/`
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm the working tree is clean and all context is loaded before edits begin.
+
+- [x] T001 Read `web/src/pages/Home.tsx` in full to confirm current heading, tagline, and `usePageTitle` arg before editing
+- [x] T002 [P] Read `web/src/components/TopBar.tsx` in full to locate the "Home" nav link before editing
+- [x] T003 [P] Read `web/src/pages/Catalog.tsx` in full to locate the `<h1>` insertion point for the subtitle
+- [x] T004 [P] Read `web/src/pages/Catalog.css` in full to determine where to add `.catalog__subtitle`
+
+**Checkpoint**: All four files are loaded and insertion points are confirmed — editing can begin.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: No foundational blockers exist for this spec. All changes are in separate files with no inter-dependency. Proceed directly to user story phases.
+
+*(No tasks — Phase 1 unblocks all user stories immediately.)*
+
+---
+
+## Phase 3: User Story 1 — Home page renamed to "Overview" (Priority: P1) 🎯 MVP
+
+**Goal**: The Home page (`/`) presents itself as an operational "Overview" dashboard with a clear heading, updated page title, and a meaningful subtitle. The TopBar nav link reads "Overview".
+
+**Independent Test**:
+1. Start the dev server (`bun run dev`)
+2. Open `http://localhost:5173` — page `<h1>` reads "Overview"
+3. Browser tab title reads "Overview — kro-ui"
+4. Subtitle text "Controller and RGD health at a glance" is visible below the heading
+5. TopBar nav link for `/` reads "Overview" (not "Home")
+6. MetricsStrip, RGD cards, HealthChip, and terminating badges still render
+
+### Implementation for User Story 1
+
+- [x] T005 [US1] In `web/src/pages/Home.tsx`: change `usePageTitle('RGDs')` to `usePageTitle('Overview')`, change `<h1 className="home__heading">RGDs</h1>` to `<h1 className="home__heading">Overview</h1>`, and change `.home__tagline` text from `"ResourceGraphDefinitions — kro observability dashboard"` to `"Controller and RGD health at a glance"`
+- [x] T006 [P] [US1] In `web/src/components/TopBar.tsx`: change the NavLink child text for `to="/"` from `Home` to `Overview`
+
+**Checkpoint**: User Story 1 is complete when `<h1>` reads "Overview", page title is "Overview — kro-ui", subtitle reads "Controller and RGD health at a glance", and TopBar reads "Overview". MetricsStrip and all RGDCard features remain intact.
+
+---
+
+## Phase 4: User Story 2 — Catalog subtitle added (Priority: P2)
+
+**Goal**: The Catalog page (`/catalog`) gains a descriptive subtitle below its `<h1>` heading, making its browsing/discovery purpose explicit and matching the subtitle treatment applied to the Overview page.
+
+**Independent Test**:
+1. Open `http://localhost:5173/catalog`
+2. Below the "RGD Catalog" heading, the text "Browse, filter, and discover all ResourceGraphDefinitions" is visible
+3. The subtitle is rendered as a `<p>` element (not a `<div>`)
+4. The subtitle uses `var(--color-text-muted)` — no hardcoded color values
+5. All existing Catalog features (sort, label filter, instance counts, "Used by") still work
+
+### Implementation for User Story 2
+
+- [x] T007 [US2] In `web/src/pages/Catalog.tsx`: add `<p className="catalog__subtitle">Browse, filter, and discover all ResourceGraphDefinitions</p>` immediately after `<h1 className="catalog__heading">RGD Catalog</h1>` inside the `.catalog__title-row` div
+- [x] T008 [P] [US2] In `web/src/pages/Catalog.css`: add the `.catalog__subtitle` rule — `margin: 0; font-size: 0.875rem; color: var(--color-text-muted);` — using only CSS token references, no hardcoded values
+
+**Checkpoint**: User Story 2 is complete when the Catalog subtitle is visible at `/catalog`, is a `<p>` element, and passes `bun run typecheck`.
+
+---
+
+## Phase 5: User Story 3 — E2E journey comments updated (Priority: P3)
+
+**Goal**: The E2E journey file for the Home page has its descriptive comments updated to reflect the "Overview" rename. No assertion strings change (the existing `toHaveTitle(/kro-ui/)` already matches "Overview — kro-ui"). The Catalog E2E file requires no changes.
+
+**Independent Test**:
+1. Run `bun run typecheck` — passes
+2. Inspect `test/e2e/journeys/002-home-page.spec.ts` — journey description reads "Overview" not "Home page RGD Card Grid"
+3. All existing assertions are functionally unchanged
+
+### Implementation for User Story 3
+
+- [x] T009 [US3] In `test/e2e/journeys/002-home-page.spec.ts`: update the file header comment from `Journey 002: Home Page — RGD Card Grid and Navigation` to `Journey 002: Overview Page — RGD Card Grid and Navigation`; update `test.describe` description from `'Journey 002 — Home page RGD cards and navigation'` to `'Journey 002 — Overview page RGD cards and navigation'`; update `test('Step 5: Home page shows cards for all fixture RGDs'` to `test('Step 5: Overview page shows cards for all fixture RGDs'`
+
+**Checkpoint**: User Story 3 is complete when journey description strings use "Overview" and no functional assertions are broken. `015-rgd-catalog.spec.ts` is confirmed unchanged (it navigates directly to `/catalog` and contains no "Home" nav assertions).
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Verification, type-checking, and final sanity checks across all changes.
+
+- [x] T010 [P] Run `bun run typecheck` and confirm zero TypeScript errors
+- [x] T011 [P] Run `GOPROXY=direct GONOSUMDB="*" go vet ./...` and confirm no new warnings (no Go changes, verify parity)
+- [x] T012 [P] Run `GOPROXY=direct GONOSUMDB="*" go test -race ./...` and confirm all Go tests pass
+- [x] T013 Visually verify in dev server (`bun run dev`) that: (1) Overview page renders with correct heading/subtitle/MetricsStrip/RGDCards; (2) TopBar shows "Overview" nav link; (3) Catalog page renders with subtitle below "RGD Catalog"; (4) no CSS regressions (tokens only, no inline colors introduced)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — read files immediately
+- **Phase 3 (US1)**: Depends on T001 (Home.tsx read) and T002 (TopBar.tsx read) from Phase 1
+- **Phase 4 (US2)**: Depends on T003 (Catalog.tsx read) and T004 (Catalog.css read) from Phase 1
+- **Phase 5 (US3)**: Depends on Phase 1 only (no code dependency on US1/US2)
+- **Phase 6 (Polish)**: Depends on Phases 3, 4, 5 all complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Independent — starts after Phase 1 reads T001+T002
+- **US2 (P2)**: Independent — starts after Phase 1 reads T003+T004; can run in parallel with US1
+- **US3 (P3)**: Independent — comment-only; can run in parallel with US1+US2
+
+### Within Each User Story
+
+- US1: T005 and T006 touch different files — can run in parallel
+- US2: T007 and T008 touch different files — can run in parallel
+- US3: T009 is a single task
+
+### Parallel Opportunities
+
+Once Phase 1 reads are done (T001–T004), all of T005, T006, T007, T008, T009 can proceed in parallel (they all touch distinct files with no mutual dependencies).
+
+---
+
+## Parallel Example
+
+```bash
+# After Phase 1 reads complete, launch all implementation tasks together:
+Task: T005 — Edit Home.tsx (heading, tagline, usePageTitle)
+Task: T006 — Edit TopBar.tsx (nav link label)
+Task: T007 — Edit Catalog.tsx (subtitle <p>)
+Task: T008 — Edit Catalog.css (.catalog__subtitle rule)
+Task: T009 — Edit 002-home-page.spec.ts (comment updates)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Read Home.tsx + TopBar.tsx (T001, T002)
+2. Complete Phase 3: US1 — edit Home.tsx and TopBar.tsx (T005, T006)
+3. **STOP and VALIDATE**: dev server visual check — "Overview" heading, subtitle, TopBar nav label
+4. Optionally deploy/demo before adding Catalog subtitle
+
+### Incremental Delivery
+
+1. Phase 1 reads → all files understood
+2. US1 (T005, T006) → Overview page differentiated → validate → MVP done
+3. US2 (T007, T008) → Catalog subtitle added → validate
+4. US3 (T009) → Journey comments updated → polish complete
+5. Phase 6 → typecheck + go vet + go test-race → CI-ready
+
+---
+
+## Notes
+
+- [P] tasks touch different files — safe to execute in parallel
+- Total tasks: 13 (4 setup reads + 5 implementation + 1 E2E comment + 3 polish verifications)
+- No new components, no new dependencies, no routing changes
+- CSS changes: 1 new rule in `Catalog.css` using `var(--color-text-muted)` only
+- E2E assertion changes: 0 — existing `toHaveTitle(/kro-ui/)` already matches "Overview — kro-ui"
+- Rollback: trivially revert 5 source files

--- a/test/e2e/journeys/002-home-page.spec.ts
+++ b/test/e2e/journeys/002-home-page.spec.ts
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 /**
- * Journey 002: Home Page — RGD Card Grid and Navigation
+ * Journey 002: Overview Page — RGD Card Grid and Navigation
  *
- * Validates that the home page renders RGD cards correctly, displays
+ * Validates that the overview page renders RGD cards correctly, displays
  * the active context name, and navigates to graph/instances views.
  *
  * Spec ref: .specify/specs/002-rgd-list-home/spec.md § E2E User Journey
@@ -31,7 +31,7 @@ import { test, expect } from '@playwright/test'
 const PORT = parseInt(process.env.KRO_UI_PORT ?? '40107', 10)
 const BASE = `http://localhost:${PORT}`
 
-test.describe('Journey 002 — Home page RGD cards and navigation', () => {
+test.describe('Journey 002 — Overview page RGD cards and navigation', () => {
 
   test('Step 1: Open the dashboard', async ({ page }) => {
     await page.goto(BASE)
@@ -111,7 +111,7 @@ test.describe('Journey 002 — Home page RGD cards and navigation', () => {
     await expect(page).toHaveURL(`${BASE}/rgds/test-app?tab=instances`)
   })
 
-  test('Step 5: Home page shows cards for all fixture RGDs', async ({ page }) => {
+  test('Step 5: Overview page shows cards for all fixture RGDs', async ({ page }) => {
     await page.goto(BASE)
 
     for (const name of ['test-app', 'test-collection', 'multi-resource', 'external-ref', 'cel-functions']) {

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -24,7 +24,7 @@ export default function TopBar({ contexts, activeContext, onSwitch }: TopBarProp
             `top-bar__nav-link${isActive ? ' top-bar__nav-link--active' : ''}`
           }
         >
-          Home
+          Overview
         </NavLink>
         <NavLink
           to="/catalog"

--- a/web/src/pages/Catalog.css
+++ b/web/src/pages/Catalog.css
@@ -25,6 +25,12 @@
   margin: 0;
 }
 
+.catalog__subtitle {
+  margin: 0 0 12px;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+
 .catalog__count {
   font-size: 0.875rem;
   color: var(--color-text-muted);

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -143,6 +143,7 @@ export default function Catalog() {
             </span>
           )}
         </div>
+        <p className="catalog__subtitle">Browse, filter, and discover all ResourceGraphDefinitions</p>
 
         <div className="catalog__toolbar">
           <SearchBar value={searchQuery} onSearch={setSearchQuery} />

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-// Home — RGD cards grid. Fetches GET /api/v1/rgds on mount.
+// Overview — RGD cards grid with controller health metrics. Fetches GET /api/v1/rgds on mount.
 // Uses VirtualGrid for windowed rendering at 5,000+ RGDs.
 // Search input is debounced (300ms) to avoid per-keystroke filter churn.
 // FR-007 (spec 031-deletion-debugger): background fetch of per-RGD terminating counts.
@@ -22,7 +22,7 @@ import './Home.css'
 const RGD_CARD_HEIGHT = 130
 
 export default function Home() {
-  usePageTitle('RGDs')
+  usePageTitle('Overview')
   const [items, setItems] = useState<K8sObject[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -137,9 +137,9 @@ export default function Home() {
       <MetricsStrip />
       <div className="home__header">
         <div className="home__heading-group">
-          <h1 className="home__heading">RGDs</h1>
+          <h1 className="home__heading">Overview</h1>
           <p className="home__tagline">
-            ResourceGraphDefinitions — kro observability dashboard
+            Controller and RGD health at a glance
           </p>
         </div>
         {!isLoading && error === null && (


### PR DESCRIPTION
## Summary

Resolves the information architecture ambiguity where Home (`/`) and Catalog (`/catalog`) appeared visually identical at first glance despite serving meaningfully different purposes (GH #163).

**Decision: Option A — Distinguish** (not merge). Two pages, two clear jobs.

- **Overview** (`/`) — operational health dashboard: MetricsStrip, HealthChip, terminating badges
- **Catalog** (`/catalog`) — browsing/discovery directory: sort, label filter, instance counts, chaining

## Changes

| File | Change |
|------|--------|
| `web/src/pages/Home.tsx` | `usePageTitle('Overview')`, `<h1>Overview</h1>`, tagline → "Controller and RGD health at a glance" |
| `web/src/components/TopBar.tsx` | Nav link: `Home` → `Overview` |
| `web/src/pages/Catalog.tsx` | `<p class="catalog__subtitle">` added below heading |
| `web/src/pages/Catalog.css` | `.catalog__subtitle` rule — `var(--color-text-muted)` only, no hardcoded values |
| `test/e2e/journeys/002-home-page.spec.ts` | Description strings updated; zero functional assertion changes |

## What is NOT changed

- No routing changes (`/` and `/catalog` URLs unchanged — bookmarks preserved)
- No new components, no new dependencies
- RGDCard, CatalogCard, MetricsStrip, HealthChip, LabelFilter, VirtualGrid, SearchBar untouched
- All backend Go files untouched

## Verification

- `bun run --cwd web tsc --noEmit` — clean
- `go vet ./...` — clean
- `go test -race ./...` — all pass

Closes #163