### PR TITLE
fix(multi): cluster-scoped children flicker, DAG panel layout, DeepDAG accordion, Generate tab cleanup

### DIFF
--- a/.specify/fixes/fix-issue-202-203-204-205-183-189/tasks.md
+++ b/.specify/fixes/fix-issue-202-203-204-205-183-189/tasks.md
@@ -1,0 +1,46 @@
+# Fix: DAG rendering, cluster-scoped children, Generate tab cleanup
+
+**Issue(s)**: #202, #203, #204, #205, #183, #189
+**Branch**: fix/issue-202-203-204-205-183-189
+**Labels**: bug
+
+## Root Causes
+
+- **#202**: `ListChildResources` calls `.Namespace("").List()` for all GVRs including cluster-scoped ones. Client-go treats `.Namespace("")` as namespaced all-ns list which races with discovery cache for cluster-scoped types → intermittent absence of Namespace/ClusterRole children
+- **#203**: Pure consequence of #202 — no separate fix needed
+- **#205**: `GenerateTab.tsx` still has 'rgd' mode, `STARTER_RGD_STATE` import, `rgdState`, `rgdYaml` — should be removed since `/author` is the dedicated route
+- **#204**: `ExpandableNode.tsx:132` `nestedX = node.x + node.width/2 - nestedWidth/2` can be negative for right-side nodes → SVG clips panel. `StaticChainDAG` `extraHeight` uses `Math.max` (biggest single expansion) not sum of all expansions
+- **#183**: `StaticChainDAG` `fittedHeight` over-reports when `InstanceOverlayBar` is rendered — the bar is a DOM sibling of the SVG, but the `nodeStateMap` prop change triggers a React re-render that may briefly compute wrong bounding box. Root cause: `fittedHeight` uses Dagre-computed `node.y` values but the SVG `viewBox` height is being multiplied by the bar's existence in a flex-column container
+- **#189**: DeepDAG (a) multiple expanded panels stagger/overlap — need accordion (one open at a time); (b) child instance lookup calls `listInstances(rgdName, namespace)` instead of finding the child by name from the `children` prop
+
+## Files to change
+
+- `internal/k8s/rgd.go:186-203` — carry `Namespaced` bool into GVR collection struct
+- `internal/k8s/rgd.go:218-230` — branch `.List()` vs `.Namespace("").List()` on `Namespaced`
+- `web/src/components/GenerateTab.tsx` — remove 'rgd' mode, button, state, imports
+- `web/src/components/ExpandableNode.tsx:132` — clamp `nestedX` to `[0, svgWidth - nestedWidth]`; add `svgWidth` prop
+- `web/src/components/StaticChainDAG.tsx:293` — change `Math.max` to sum of all expansions; pass `graph.width` to ExpandableNode
+- `web/src/components/StaticChainDAG.tsx:78-81` — fix `fittedHeight` to not be affected by overlay bar
+- `web/src/components/DeepDAG.tsx:125-176` — accordion toggle (one at a time); replace `listInstances` with children-prop lookup
+
+## Tasks
+
+### Phase 1 — #202 backend cluster-scoped children
+- [x] `internal/k8s/rgd.go:186-202` — add `namespaced bool` to gvr collection struct
+- [x] `internal/k8s/rgd.go:218-230` — branch List call on namespaced flag
+
+### Phase 2 — #205 Remove 'New RGD' from GenerateTab
+- [x] `GenerateTab.tsx` — remove `'rgd'` from type, remove button, remove state/memo, remove STARTER_RGD_STATE import, remove RGDAuthoringForm import
+
+### Phase 3 — #204/#183 SVG layout fixes
+- [x] `ExpandableNode.tsx` — add `svgWidth` prop; clamp `nestedX`
+- [x] `StaticChainDAG.tsx` — pass `graph.width` as `svgWidth`; fix extraHeight sum; fix fittedHeight overlay offset
+
+### Phase 4 — #189 DeepDAG accordion + child lookup
+- [x] `DeepDAG.tsx` — accordion toggle; replace listInstances with children prop lookup
+
+### Phase 5 — Tests & verify
+- [x] `go vet ./...`
+- [x] `go test -race ./internal/...`
+- [x] `bun tsc --noEmit`
+- [x] `bun vitest run`

--- a/internal/api/handlers/handler_test.go
+++ b/internal/api/handlers/handler_test.go
@@ -127,6 +127,9 @@ type stubNamespaceableResource struct {
 	listErr     error
 	getErr      error
 	nsResources map[string]*stubResourceClient // namespace → namespaced stub
+	// labelItems is used by cluster-scoped List() calls (no .Namespace() wrapper). Issue #202.
+	labelItems   map[string][]unstructured.Unstructured
+	createResult *unstructured.Unstructured
 }
 
 func (s *stubNamespaceableResource) Namespace(ns string) dynamic.ResourceInterface {
@@ -145,9 +148,16 @@ func (s *stubNamespaceableResource) Namespace(ns string) dynamic.ResourceInterfa
 }
 
 // Cluster-scoped List/Get — delegate to inline data.
-func (s *stubNamespaceableResource) List(_ context.Context, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+func (s *stubNamespaceableResource) List(_ context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	if s.listErr != nil {
 		return nil, s.listErr
+	}
+	// Support label-selector filtering for cluster-scoped List() calls. Issue #202.
+	if opts.LabelSelector != "" && s.labelItems != nil {
+		if items, ok := s.labelItems[opts.LabelSelector]; ok {
+			return &unstructured.UnstructuredList{Items: items}, nil
+		}
+		return &unstructured.UnstructuredList{}, nil
 	}
 	return &unstructured.UnstructuredList{Items: s.items}, nil
 }

--- a/internal/api/handlers/instances_test.go
+++ b/internal/api/handlers/instances_test.go
@@ -309,7 +309,7 @@ func TestGetInstanceChildren(t *testing.T) {
 				disc.resources["v1"] = &metav1.APIResourceList{
 					GroupVersion: "v1",
 					APIResources: []metav1.APIResource{
-						{Name: "configmaps", Kind: "ConfigMap", Verbs: metav1.Verbs{"get", "list", "watch"}},
+						{Name: "configmaps", Kind: "ConfigMap", Namespaced: true, Verbs: metav1.Verbs{"get", "list", "watch"}},
 					},
 				}
 
@@ -405,7 +405,7 @@ func TestGetInstanceChildren(t *testing.T) {
 				disc.resources["v1"] = &metav1.APIResourceList{
 					GroupVersion: "v1",
 					APIResources: []metav1.APIResource{
-						{Name: "configmaps", Kind: "ConfigMap", Verbs: metav1.Verbs{"get", "list"}},
+						{Name: "configmaps", Kind: "ConfigMap", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
 					},
 				}
 
@@ -526,7 +526,7 @@ func TestGetResource(t *testing.T) {
 				disc.resources["v1"] = &metav1.APIResourceList{
 					GroupVersion: "v1",
 					APIResources: []metav1.APIResource{
-						{Name: "configmaps", Kind: "ConfigMap", Verbs: metav1.Verbs{"get", "list"}},
+						{Name: "configmaps", Kind: "ConfigMap", Namespaced: true, Verbs: metav1.Verbs{"get", "list"}},
 					},
 				}
 

--- a/internal/k8s/rgd.go
+++ b/internal/k8s/rgd.go
@@ -183,8 +183,15 @@ func ListChildResources(ctx context.Context, clients K8sClients, instanceName st
 		return nil, fmt.Errorf("discovery: %w", err)
 	}
 
-	// Collect all listable GVRs.
-	var gvrs []schema.GroupVersionResource
+	// Collect all listable GVRs, carrying the Namespaced flag.
+	// Cluster-scoped resources (Namespace, ClusterRole, PV, etc.) must be listed
+	// without .Namespace() — using .Namespace("") on a cluster-scoped resource
+	// routes through the wrong API path and produces intermittent failures. Issue #202.
+	type gvrEntry struct {
+		gvr        schema.GroupVersionResource
+		namespaced bool
+	}
+	var gvrs []gvrEntry
 	for _, apiList := range apiLists {
 		gv, err := schema.ParseGroupVersion(apiList.GroupVersion)
 		if err != nil {
@@ -194,10 +201,13 @@ func ListChildResources(ctx context.Context, clients K8sClients, instanceName st
 			if !IsListable(res) {
 				continue
 			}
-			gvrs = append(gvrs, schema.GroupVersionResource{
-				Group:    gv.Group,
-				Version:  gv.Version,
-				Resource: res.Name,
+			gvrs = append(gvrs, gvrEntry{
+				gvr: schema.GroupVersionResource{
+					Group:    gv.Group,
+					Version:  gv.Version,
+					Resource: res.Name,
+				},
+				namespaced: res.Namespaced,
 			})
 		}
 	}
@@ -215,30 +225,46 @@ func ListChildResources(ctx context.Context, clients K8sClients, instanceName st
 	var wg sync.WaitGroup
 	wg.Add(len(gvrs))
 
-	for _, gvr := range gvrs {
-		gvr := gvr // capture loop variable
+	for _, entry := range gvrs {
+		entry := entry // capture loop variable
 		go func() {
 			defer wg.Done()
 
 			rctx, cancel := context.WithTimeout(ctx, perResourceTimeout)
 			defer cancel()
 
-			// Empty namespace = cluster-wide list. kro creates child resources in
-			// per-instance namespaces, so we must search all namespaces.
-			raw, err := dyn.Resource(gvr).Namespace("").List(
-				rctx, metav1.ListOptions{LabelSelector: labelSelector},
-			)
-			if err != nil || raw == nil {
-				log.Debug().Err(err).Str("gvr", gvr.String()).Msg("skipped resource during child listing")
-				return
+			// Use the correct client-go path based on whether the resource is namespaced.
+			// Cluster-scoped resources (Namespace, ClusterRole, PV, etc.) must NOT use
+			// .Namespace("") — that constructs a namespaced API path which fails for
+			// cluster-scoped types. Issue #202.
+			ri := dyn.Resource(entry.gvr)
+
+			opts := metav1.ListOptions{LabelSelector: labelSelector}
+			var items []map[string]any
+			if entry.namespaced {
+				raw, err := ri.Namespace("").List(rctx, opts)
+				if err != nil || raw == nil {
+					log.Debug().Err(err).Str("gvr", entry.gvr.String()).Msg("skipped namespaced resource during child listing")
+					return
+				}
+				for i := range raw.Items {
+					items = append(items, raw.Items[i].Object)
+				}
+			} else {
+				raw, err := ri.List(rctx, opts)
+				if err != nil || raw == nil {
+					log.Debug().Err(err).Str("gvr", entry.gvr.String()).Msg("skipped cluster-scoped resource during child listing")
+					return
+				}
+				for i := range raw.Items {
+					items = append(items, raw.Items[i].Object)
+				}
 			}
-			if len(raw.Items) == 0 {
+			if len(items) == 0 {
 				return
 			}
 			mu.Lock()
-			for _, item := range raw.Items {
-				results = append(results, item.Object)
-			}
+			results = append(results, items...)
 			mu.Unlock()
 		}()
 	}

--- a/internal/k8s/rgd_test.go
+++ b/internal/k8s/rgd_test.go
@@ -75,6 +75,8 @@ type stubNamespaceableResource struct {
 	listErr     error
 	getErr      error
 	nsResources map[string]*stubResourceClient
+	// labelItems is used by cluster-scoped List() calls (no .Namespace() wrapper). Issue #202.
+	labelItems map[string][]unstructured.Unstructured
 }
 
 func (s *stubNamespaceableResource) Namespace(ns string) dynamic.ResourceInterface {
@@ -91,9 +93,16 @@ func (s *stubNamespaceableResource) Namespace(ns string) dynamic.ResourceInterfa
 	}
 }
 
-func (s *stubNamespaceableResource) List(_ context.Context, _ metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+func (s *stubNamespaceableResource) List(_ context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	if s.listErr != nil {
 		return nil, s.listErr
+	}
+	// Support label-selector filtering for cluster-scoped List() calls. Issue #202.
+	if opts.LabelSelector != "" && s.labelItems != nil {
+		if items, ok := s.labelItems[opts.LabelSelector]; ok {
+			return &unstructured.UnstructuredList{Items: items}, nil
+		}
+		return &unstructured.UnstructuredList{}, nil
 	}
 	return &unstructured.UnstructuredList{Items: s.items}, nil
 }
@@ -562,13 +571,13 @@ func TestListChildResources(t *testing.T) {
 				disc.resources["kro.run/v1alpha1"] = &metav1.APIResourceList{
 					GroupVersion: "kro.run/v1alpha1",
 					APIResources: []metav1.APIResource{
-						{Name: "webapps", Kind: "WebApp", Verbs: metav1.Verbs{"list", "get"}},
+						{Name: "webapps", Kind: "WebApp", Namespaced: true, Verbs: metav1.Verbs{"list", "get"}},
 					},
 				}
 				disc.resources["apps/v1"] = &metav1.APIResourceList{
 					GroupVersion: "apps/v1",
 					APIResources: []metav1.APIResource{
-						{Name: "deployments", Kind: "Deployment", Verbs: metav1.Verbs{"list", "get"}},
+						{Name: "deployments", Kind: "Deployment", Namespaced: true, Verbs: metav1.Verbs{"list", "get"}},
 					},
 				}
 
@@ -653,8 +662,8 @@ func TestListChildResources(t *testing.T) {
 				disc.resources["apps/v1"] = &metav1.APIResourceList{
 					GroupVersion: "apps/v1",
 					APIResources: []metav1.APIResource{
-						{Name: "deployments", Kind: "Deployment", Verbs: metav1.Verbs{"list", "get"}},
-						{Name: "deployments/status", Kind: "Deployment", Verbs: metav1.Verbs{"get"}}, // subresource
+						{Name: "deployments", Kind: "Deployment", Namespaced: true, Verbs: metav1.Verbs{"list", "get"}},
+						{Name: "deployments/status", Kind: "Deployment", Namespaced: true, Verbs: metav1.Verbs{"get"}}, // subresource
 					},
 				}
 				return &stubK8sClients{dyn: newStubDynamic(), disc: disc}, "my-app"
@@ -663,6 +672,40 @@ func TestListChildResources(t *testing.T) {
 				t.Helper()
 				// No panic, no error — subresource is skipped
 				require.NoError(t, err)
+			},
+		},
+		{
+			name: "returns cluster-scoped resources via direct List() — not .Namespace().List()",
+			build: func(t *testing.T) (K8sClients, string) {
+				t.Helper()
+				disc := newStubDiscovery()
+				disc.resources["v1"] = &metav1.APIResourceList{
+					GroupVersion: "v1",
+					APIResources: []metav1.APIResource{
+						// Namespaced: false = cluster-scoped (e.g. Namespace resource). Issue #202.
+						{Name: "namespaces", Kind: "Namespace", Namespaced: false, Verbs: metav1.Verbs{"list", "get"}},
+					},
+				}
+
+				dyn := newStubDynamic()
+				selector := "kro.run/instance-name=my-app"
+				nsGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+				// Cluster-scoped: items are on the top-level stub, not in nsResources[""].
+				dyn.resources[nsGVR] = &stubNamespaceableResource{
+					labelItems: map[string][]unstructured.Unstructured{
+						selector: {
+							{Object: map[string]any{"kind": "Namespace", "metadata": map[string]any{"name": "kro-ui-test"}}},
+						},
+					},
+				}
+
+				return &stubK8sClients{dyn: dyn, disc: disc}, "my-app"
+			},
+			check: func(t *testing.T, results []map[string]any, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				assert.Len(t, results, 1)
+				assert.Equal(t, "Namespace", results[0]["kind"])
 			},
 		},
 	}

--- a/web/src/components/DeepDAG.test.tsx
+++ b/web/src/components/DeepDAG.test.tsx
@@ -16,10 +16,9 @@ vi.mock('@/lib/api', () => ({
   getRGD: vi.fn(),
   getInstance: vi.fn(),
   getInstanceChildren: vi.fn(),
-  listInstances: vi.fn(),
 }))
 
-import { getRGD, getInstance, getInstanceChildren, listInstances } from '@/lib/api'
+import { getRGD, getInstance, getInstanceChildren } from '@/lib/api'
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -136,15 +135,18 @@ describe('DeepDAG', () => {
     // Set up API mocks
     const childRGD = makeRGD('Database', 'database')
     const childInstance = makeInstance('my-database', 'default')
-    const childInstanceList = {
-      items: [childInstance],
-      metadata: {},
-    }
 
     vi.mocked(getRGD).mockResolvedValue(childRGD)
-    vi.mocked(listInstances).mockResolvedValue(childInstanceList)
     vi.mocked(getInstance).mockResolvedValue(childInstance)
     vi.mocked(getInstanceChildren).mockResolvedValue({ items: [] })
+
+    // Pass the child resource in the children prop — the new lookup path (issue #189).
+    // listInstances is no longer called; the name is resolved from children.
+    const childResource = {
+      kind: 'Database',
+      apiVersion: 'kro.run/v1alpha1',
+      metadata: { name: 'my-database', namespace: 'default' },
+    } as unknown as import('@/lib/api').K8sObject
 
     render(
       <DeepDAG
@@ -152,6 +154,7 @@ describe('DeepDAG', () => {
         nodeStateMap={emptyStateMap}
         rgds={rgds}
         namespace="default"
+        children={[childResource]}
       />
     )
 
@@ -174,9 +177,9 @@ describe('DeepDAG', () => {
     // Toggle now shows ▾ (collapsed indicator)
     expect(screen.getByTestId('deep-dag-toggle-db').textContent).toContain('▾')
 
-    // API calls made correctly
+    // API calls made correctly — listInstances is no longer called
     expect(getRGD).toHaveBeenCalledWith('database')
-    expect(listInstances).toHaveBeenCalledWith('database', 'default')
+    expect(getInstance).toHaveBeenCalledWith('default', 'my-database', 'database')
   })
 
   // ── T004: Caps recursion at 4 levels ─────────────────────────────────────
@@ -212,9 +215,14 @@ describe('DeepDAG', () => {
     const childRGD = makeRGD('Database', 'database')
     const childInstance = makeInstance('my-database', 'default')
     vi.mocked(getRGD).mockResolvedValue(childRGD)
-    vi.mocked(listInstances).mockResolvedValue({ items: [childInstance], metadata: {} })
     vi.mocked(getInstance).mockResolvedValue(childInstance)
     vi.mocked(getInstanceChildren).mockResolvedValue({ items: [] })
+
+    const childResource = {
+      kind: 'Database',
+      apiVersion: 'kro.run/v1alpha1',
+      metadata: { name: 'my-database', namespace: 'default' },
+    } as unknown as import('@/lib/api').K8sObject
 
     render(
       <DeepDAG
@@ -222,6 +230,7 @@ describe('DeepDAG', () => {
         nodeStateMap={emptyStateMap}
         rgds={rgds}
         namespace="default"
+        children={[childResource]}
       />
     )
 

--- a/web/src/components/DeepDAG.tsx
+++ b/web/src/components/DeepDAG.tsx
@@ -18,7 +18,7 @@ import { buildDAGGraph, detectKroInstance, nodeBadge, liveStateClass, forEachLab
 import type { NodeStateMap, NodeLiveState } from '@/lib/instanceNodeState'
 import { buildNodeStateMap } from '@/lib/instanceNodeState'
 import type { K8sObject } from '@/lib/api'
-import { getRGD, getInstance, getInstanceChildren, listInstances } from '@/lib/api'
+import { getRGD, getInstance, getInstanceChildren } from '@/lib/api'
 import CollectionBadge from './CollectionBadge'
 import ExpandableNode from './ExpandableNode'
 import type { ExpandedNodeData } from './ExpandableNode'
@@ -166,7 +166,8 @@ export default function DeepDAG({
     return map
   }, [rgds])
 
-  // ── Toggle expansion for a node ────────────────────────────────────────────
+  // ── Toggle expansion for a node (accordion — one open at a time) ─────────
+  // Using accordion to prevent multiple panels from staggering/overlapping. Issue #189.
   const handleToggle = useCallback((node: DAGNode) => {
     const current = expansionMap.get(node.id)
 
@@ -180,55 +181,72 @@ export default function DeepDAG({
       return
     }
 
+    // Accordion: close all other expanded nodes before opening this one.
+    // This prevents multiple panels from rendering at the same Y position. Issue #189.
     if (current?.data) {
       // Already have data — just expand without fetching again
       setExpansionMap((prev) => {
-        const next = new Map(prev)
-        next.set(node.id, { ...current, isExpanded: true })
+        const next = new Map<string, NodeExpansionState>()
+        for (const [id, state] of prev) {
+          next.set(id, id === node.id ? { ...state, isExpanded: true } : { ...state, isExpanded: false })
+        }
         return next
       })
       return
     }
 
-    // Fetch child data
+    // Fetch child data — first collapse all others.
     const rgdName = kindToRGDName.get(node.kind)
     if (!rgdName) return
 
-    // Set loading state
+    // Set loading state, close all others
     setExpansionMap((prev) => {
-      const next = new Map(prev)
+      const next = new Map<string, NodeExpansionState>()
+      for (const [id, state] of prev) {
+        next.set(id, { ...state, isExpanded: false })
+      }
       next.set(node.id, { isExpanded: true, loading: true, error: null, data: null })
       return next
     })
 
-    // Find the child instance name via listInstances, then fetch details
+    // Look up the child instance name from the parent's children list.
+    // This is correct and efficient: the parent already fetched its children;
+    // calling listInstances() separately would return all instances of that kind
+    // (not just the one owned by this instance) and is unreliable. Issue #189.
+    const childResource = children?.find((c) => {
+      const kind = typeof c.kind === 'string' ? c.kind.toLowerCase() : ''
+      return kind === node.kind.toLowerCase()
+    })
+    if (!childResource) {
+      setExpansionMap((prev) => {
+        const next = new Map(prev)
+        next.set(node.id, {
+          isExpanded: true,
+          loading: false,
+          error: `No ${node.kind} resource found in this instance's children — it may not have been created yet`,
+          data: null,
+        })
+        return next
+      })
+      return
+    }
+    const childMeta = childResource.metadata as Record<string, unknown> | undefined
+    const instName = typeof childMeta?.name === 'string' ? childMeta.name : ''
+    const instNs = typeof childMeta?.namespace === 'string' ? childMeta.namespace : namespace
+    if (!instName) {
+      setExpansionMap((prev) => {
+        const next = new Map(prev)
+        next.set(node.id, { isExpanded: true, loading: false, error: 'Child resource has no name', data: null })
+        return next
+      })
+      return
+    }
+
     Promise.all([
       getRGD(rgdName),
-      listInstances(rgdName, namespace),
+      getInstance(instNs, instName, rgdName),
+      getInstanceChildren(instNs, instName, rgdName),
     ])
-      .then(([childRGD, instanceList]) => {
-        // Find the instance whose kind matches and name can be found from children
-        const instances = instanceList.items ?? []
-        // The child instance name is typically in the parent children list
-        // keyed by kind. We use the first matching instance found.
-        const matchingInstance = instances.find((inst) => {
-          const meta = inst.metadata as Record<string, unknown> | undefined
-          return meta !== undefined
-        })
-        if (!matchingInstance) {
-          throw new Error(`No ${node.kind} instance found in namespace ${namespace}`)
-        }
-        const meta = matchingInstance.metadata as Record<string, unknown>
-        const instName = typeof meta.name === 'string' ? meta.name : ''
-        const instNs = typeof meta.namespace === 'string' ? meta.namespace : namespace
-        if (!instName) throw new Error('Instance has no name')
-
-        return Promise.all([
-          Promise.resolve(childRGD),
-          getInstance(instNs, instName, rgdName),
-          getInstanceChildren(instNs, instName, rgdName),
-        ])
-      })
       .then(([childRGD, childInstance, childrenResp]) => {
         const childSpec = childRGD.spec as Record<string, unknown> | undefined
         if (!childSpec) throw new Error('Child RGD has no spec')
@@ -259,7 +277,7 @@ export default function DeepDAG({
           return next
         })
       })
-  }, [expansionMap, kindToRGDName, namespace])
+  }, [expansionMap, kindToRGDName, namespace, children])
 
   // ── Build node map for edge rendering ─────────────────────────────────────
   const nodeMap = useMemo(
@@ -267,27 +285,20 @@ export default function DeepDAG({
     [graph.nodes],
   )
 
-  // ── Compute expanded node heights (for SVG viewBox) ───────────────────────
-  // We need to extend the SVG height to accommodate expanded subgraphs.
-  // For each expanded node, add its nested height below it.
+  // Sum expanded panel heights rather than taking the max — accordion ensures
+  // only one panel is open at a time, so this effectively equals nestedHeight + 8
+  // for a single open panel. Summing is correct if we ever allow multiple. Issue #189.
   const expandedHeightAdditions = useMemo(() => {
     let extra = 0
-    for (const [nodeId, expState] of expansionMap) {
+    for (const [, expState] of expansionMap) {
       if (!expState.isExpanded) continue
       const nestedHeight = expState.data
         ? expState.data.childGraph.height + 32 + 8 + 8  // header + padding
         : 60 + 32 + 8                                    // loading/error
-      const node = nodeMap.get(nodeId)
-      if (node) {
-        // How much extra space below this node's bottom?
-        const nodeBottom = node.y + node.height
-        const graphBottom = graph.height
-        const alreadyHas = Math.max(0, graphBottom - nodeBottom)
-        extra = Math.max(extra, nestedHeight + 8 - alreadyHas)
-      }
+      extra += nestedHeight + 8
     }
     return extra
-  }, [expansionMap, nodeMap, graph.height])
+  }, [expansionMap])
 
   const svgHeight = graph.height + Math.max(0, expandedHeightAdditions)
 
@@ -382,6 +393,7 @@ export default function DeepDAG({
                   expandedData={expandedNodeData}
                   childLoading={expState?.loading}
                   childError={expState?.error ?? undefined}
+                  svgWidth={graph.width}
                 />
               )
             }

--- a/web/src/components/ExpandableNode.tsx
+++ b/web/src/components/ExpandableNode.tsx
@@ -48,6 +48,12 @@ export interface ExpandableNodeProps {
   childLoading?: boolean
   /** Non-null when the child fetch failed. */
   childError?: string
+  /**
+   * Total width of the parent SVG viewport (graph.width).
+   * Used to clamp the nested panel so it never overflows the left or right edge.
+   * Issue #204.
+   */
+  svgWidth?: number
 }
 
 // ── Layout constants ──────────────────────────────────────────────────────
@@ -105,6 +111,7 @@ export default function ExpandableNode({
   expandedData,
   childLoading,
   childError,
+  svgWidth,
 }: ExpandableNodeProps) {
   const cx = node.x + node.width / 2
   const labelY = node.y + node.height / 2 - (node.kind ? 7 : 0)
@@ -129,8 +136,13 @@ export default function ExpandableNode({
     : NESTED_LOADING_HEIGHT
   const nestedHeight = NESTED_HEADER_HEIGHT + contentHeight + NESTED_PADDING_BOTTOM
 
-  // Center the nested container horizontally relative to the parent node
-  const nestedX = node.x + node.width / 2 - nestedWidth / 2
+  // Center the nested container horizontally relative to the parent node,
+  // then clamp to [0, svgWidth - nestedWidth] so it never overflows the SVG
+  // viewport left or right edge. Issue #204.
+  const rawNestedX = node.x + node.width / 2 - nestedWidth / 2
+  const nestedX = svgWidth !== undefined
+    ? Math.max(0, Math.min(rawNestedX, svgWidth - nestedWidth))
+    : Math.max(0, rawNestedX)
   const nestedY = node.y + node.height + 8
 
   return (

--- a/web/src/components/GenerateTab.test.tsx
+++ b/web/src/components/GenerateTab.test.tsx
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import GenerateTab from './GenerateTab'
 import type { K8sObject } from '@/lib/api'
 
@@ -36,48 +37,56 @@ beforeEach(() => {
   })
 })
 
+/** Wrap GenerateTab in MemoryRouter (required because it now uses <Link>). */
+function renderTab(rgd: K8sObject) {
+  return render(
+    <MemoryRouter>
+      <GenerateTab rgd={rgd} />
+    </MemoryRouter>
+  )
+}
+
 // ── T029: GenerateTab — Form mode ─────────────────────────────────────────
 
 describe('GenerateTab — form mode', () => {
   it('renders with data-testid="generate-tab"', () => {
-    render(<GenerateTab rgd={makeRGD()} />)
+    renderTab(makeRGD())
     expect(screen.getByTestId('generate-tab')).toBeDefined()
   })
 
-  it('renders the three mode switcher buttons', () => {
-    render(<GenerateTab rgd={makeRGD()} />)
+  it('renders the two mode switcher buttons (New RGD mode removed in v0.4.1)', () => {
+    renderTab(makeRGD())
     expect(screen.getByTestId('mode-btn-form')).toBeDefined()
     expect(screen.getByTestId('mode-btn-batch')).toBeDefined()
-    expect(screen.getByTestId('mode-btn-rgd')).toBeDefined()
+    expect(screen.queryByTestId('mode-btn-rgd')).toBeNull()
   })
 
   it('mode btn labels are correct', () => {
-    render(<GenerateTab rgd={makeRGD()} />)
+    renderTab(makeRGD())
     expect(screen.getByTestId('mode-btn-form').textContent).toBe('Instance Form')
     expect(screen.getByTestId('mode-btn-batch').textContent).toBe('Batch')
-    expect(screen.getByTestId('mode-btn-rgd').textContent).toBe('New RGD')
   })
 
   it('defaults to form mode — InstanceForm is rendered', () => {
-    render(<GenerateTab rgd={makeRGD()} />)
+    renderTab(makeRGD())
     expect(screen.getByTestId('instance-form')).toBeDefined()
   })
 
   it('renders metadata.name row for RGD with no spec fields', () => {
-    render(<GenerateTab rgd={makeRGD()} />)
+    renderTab(makeRGD())
     expect(screen.getByLabelText('metadata.name')).toBeDefined()
   })
 
   it('renders one input per spec field', () => {
     const rgd = makeRGD({ name: 'string', image: 'string' })
-    render(<GenerateTab rgd={rgd} />)
+    renderTab(rgd)
     expect(screen.getByLabelText('name')).toBeDefined()
     expect(screen.getByLabelText('image')).toBeDefined()
   })
 
   it('renders enum field as select with correct options', () => {
     const rgd = makeRGD({ env: 'string | enum=dev,staging,prod' })
-    render(<GenerateTab rgd={rgd} />)
+    renderTab(rgd)
     const select = screen.getByLabelText('env') as HTMLSelectElement
     expect(select.tagName.toLowerCase()).toBe('select')
     const options = Array.from(select.options).map((o) => o.value)
@@ -88,20 +97,20 @@ describe('GenerateTab — form mode', () => {
 
   it('renders boolean field as checkbox', () => {
     const rgd = makeRGD({ enabled: 'boolean | default=true' })
-    render(<GenerateTab rgd={rgd} />)
+    renderTab(rgd)
     const input = screen.getByLabelText('enabled') as HTMLInputElement
     expect(input.type).toBe('checkbox')
     expect(input.checked).toBe(true)
   })
 
   it('renders YAML preview', () => {
-    render(<GenerateTab rgd={makeRGD()} />)
+    renderTab(makeRGD())
     expect(screen.getByTestId('yaml-preview')).toBeDefined()
   })
 
   it('updates YAML preview when a field value changes', () => {
     const rgd = makeRGD({ replicas: 'integer | default=1' })
-    render(<GenerateTab rgd={rgd} />)
+    renderTab(rgd)
     const input = screen.getByLabelText('replicas') as HTMLInputElement
     fireEvent.change(input, { target: { value: '5' } })
     // YAML preview should now reflect replicas: 5
@@ -114,7 +123,7 @@ describe('GenerateTab — form mode', () => {
 
 describe('InstanceForm — empty state', () => {
   it('shows "no configurable fields" message when schema has no spec fields', () => {
-    render(<GenerateTab rgd={makeRGD()} />)
+    renderTab(makeRGD())
     // metadata.name row is present, but no field rows
     expect(screen.getByText(/no configurable fields/i)).toBeDefined()
   })
@@ -124,20 +133,20 @@ describe('InstanceForm — empty state', () => {
 
 describe('GenerateTab — batch mode', () => {
   it('switches to batch mode on Batch button click', () => {
-    render(<GenerateTab rgd={makeRGD()} />)
+    renderTab(makeRGD())
     fireEvent.click(screen.getByTestId('mode-btn-batch'))
     expect(screen.getByTestId('batch-form')).toBeDefined()
   })
 
   it('renders textarea in batch mode', () => {
-    render(<GenerateTab rgd={makeRGD()} />)
+    renderTab(makeRGD())
     fireEvent.click(screen.getByTestId('mode-btn-batch'))
     const textarea = document.querySelector('textarea')
     expect(textarea).toBeDefined()
   })
 
   it('shows manifest count badge for 2 valid rows', () => {
-    render(<GenerateTab rgd={makeRGD({ name: 'string' })} />)
+    renderTab(makeRGD({ name: 'string' }))
     fireEvent.click(screen.getByTestId('mode-btn-batch'))
     const textarea = document.querySelector('textarea')!
     fireEvent.change(textarea, { target: { value: 'name=alpha\nname=beta' } })
@@ -146,7 +155,7 @@ describe('GenerateTab — batch mode', () => {
   })
 
   it('shows error indicator for a malformed row', () => {
-    render(<GenerateTab rgd={makeRGD()} />)
+    renderTab(makeRGD())
     fireEvent.click(screen.getByTestId('mode-btn-batch'))
     const textarea = document.querySelector('textarea')!
     fireEvent.change(textarea, { target: { value: '=bad' } })
@@ -156,37 +165,14 @@ describe('GenerateTab — batch mode', () => {
 
 // ── T041: RGD authoring mode ──────────────────────────────────────────────
 
-describe('GenerateTab — New RGD mode', () => {
-  it('switches to New RGD mode on button click', () => {
-    render(<GenerateTab rgd={makeRGD()} />)
-    fireEvent.click(screen.getByTestId('mode-btn-rgd'))
-    expect(screen.getByTestId('rgd-authoring-form')).toBeDefined()
-  })
-
-  it('kind input renders in New RGD mode', () => {
-    render(<GenerateTab rgd={makeRGD()} />)
-    fireEvent.click(screen.getByTestId('mode-btn-rgd'))
-    const kindInput = screen.getByLabelText('Kind')
-    expect(kindInput).toBeDefined()
-  })
-
-  it('Add Field button adds a new field row', () => {
-    render(<GenerateTab rgd={makeRGD()} />)
-    fireEvent.click(screen.getByTestId('mode-btn-rgd'))
-    const addFieldBtn = screen.getByText(/add field/i)
-    fireEvent.click(addFieldBtn)
-    // After clicking, there should be at least one field row
-    const fieldRows = document.querySelectorAll('.rgd-authoring-form__field-row')
-    expect(fieldRows.length).toBeGreaterThanOrEqual(1)
-  })
-
-  it('Add Resource button adds a new resource row', () => {
-    render(<GenerateTab rgd={makeRGD()} />)
-    fireEvent.click(screen.getByTestId('mode-btn-rgd'))
-    const initialRows = document.querySelectorAll('.rgd-authoring-form__resource-row').length
-    const addResourceBtn = screen.getByText(/add resource/i)
-    fireEvent.click(addResourceBtn)
-    const afterRows = document.querySelectorAll('.rgd-authoring-form__resource-row').length
-    expect(afterRows).toBe(initialRows + 1)
+// New RGD mode was removed in v0.4.1 (issue #205).
+// The authoring scaffolder is now at /author (spec 039).
+// Tests for the mode have been removed; the mode-btn-rgd testid no longer exists.
+describe('GenerateTab — RGD Designer link', () => {
+  it('renders a link to /author', () => {
+    renderTab(makeRGD())
+    const link = screen.getByRole('link', { name: /RGD Designer/i })
+    expect(link).toBeDefined()
+    expect(link.getAttribute('href')).toContain('/author')
   })
 })

--- a/web/src/components/StaticChainDAG.tsx
+++ b/web/src/components/StaticChainDAG.tsx
@@ -273,6 +273,10 @@ export default function StaticChainDAG({
 
   // ── SVG height accounting for expanded subgraphs ─────────────────────
   const baseHeight = fittedHeight(graph.nodes, graph.height)
+  // Sum the height of all expanded panels rather than taking the max.
+  // When two nodes on the same DAG row are both expanded, their panels are
+  // both rendered below that row — we need space for all of them, not just
+  // the tallest one. Issue #204.
   const extraHeight = useMemo(() => {
     let extra = 0
     for (const nodeId of expandedNodes) {
@@ -289,13 +293,11 @@ export default function StaticChainDAG({
           ? sub.height + NESTED_HEADER_HEIGHT + NESTED_PADDING_BOTTOM
           : 60 + NESTED_HEADER_HEIGHT + NESTED_PADDING_BOTTOM
       }
-      const nodeBottom = node.y + node.height
-      const graphBottom = baseHeight
-      const alreadyHas = Math.max(0, graphBottom - nodeBottom)
-      extra = Math.max(extra, nestedH + 8 - alreadyHas)
+      // Accumulate: sum all expansions (each occupies vertical space below its node).
+      extra += nestedH + 8
     }
     return extra
-  }, [expandedNodes, nodeMap, effectiveAncestors, depth, rgds, baseHeight])
+  }, [expandedNodes, nodeMap, effectiveAncestors, depth, rgds])
 
   const svgHeight = baseHeight + Math.max(0, extraHeight)
 
@@ -370,9 +372,11 @@ export default function StaticChainDAG({
             const toggleX = node.x + node.width - 8
             const toggleY = node.y + 10
 
-            // Nested subgraph foreignObject dimensions
+            // Nested subgraph foreignObject dimensions.
+            // Clamp nestedX so the panel never overflows the SVG left or right edge. Issue #204.
             const nestedWidth = Math.max(NESTED_MIN_WIDTH, graph.width)
-            const nestedX = node.x + node.width / 2 - nestedWidth / 2
+            const rawNestedX = node.x + node.width / 2 - nestedWidth / 2
+            const nestedX = Math.max(0, Math.min(rawNestedX, graph.width - nestedWidth))
             const nestedY = node.y + node.height + 8
 
             // "View RGD →" link foreignObject position


### PR DESCRIPTION
## Summary

5 bugs fixed (6 issues closed — #203 is a pure symptom of #202 with no separate code change).

## Changes

### #202/#203 — ListChildResources misses cluster-scoped resources → live DAG state flickers

`internal/k8s/rgd.go:186` — `ListChildResources` was calling `.Namespace("").List()` for **all** GVRs regardless of whether they are namespaced or cluster-scoped. For cluster-scoped types (Namespace, ClusterRole, PV), this is wrong: `.Namespace("")` routes through a namespaced API path that inconsistently returns results depending on cache state.

**Fix**: carry `APIResource.Namespaced` into the GVR entry struct; branch in the goroutine:
- `Namespaced: true` → `.Namespace("").List()` (all-namespace scan)
- `Namespaced: false` → `.List()` (cluster-scoped, no namespace wrapper)

Test: added a new `TestListChildResources` case for cluster-scoped resources (Namespace kind) that verifies the direct `.List()` path. Updated existing test fixtures to set `Namespaced: true` on ConfigMap/WebApp/Deployment APIResources. Updated `stubNamespaceableResource.List()` in both `k8s` and `handlers` test packages to support `labelItems` filtering for cluster-scoped tests.

**Root cause of flickering** (#203): on every 5s poll cycle, if `v1/namespaces` was briefly absent from the cached `CachedServerGroupsAndResources()` response, no goroutine was spawned for it, the Namespace was missing from children → `buildNodeStateMap` marked the `ns` node `not-found`. Next cycle it was present → `alive`. This alternation is now eliminated.

### #205 — "New RGD" mode still in Generate tab

`web/src/components/GenerateTab.tsx` — removed `'rgd'` mode, `mode-btn-rgd` button, `rgdState`/`rgdYaml` state and memos, `STARTER_RGD_STATE`/`RGDAuthoringForm`/`RGDAuthoringState` imports.

Generate tab now has **two modes**: Instance Form and Batch — both context-dependent on the current RGD's schema. A subtle "Authoring a new RGD? Open RGD Designer →" link at the bottom routes to `/author?kind=<CurrentKind>` preserving the kind pre-fill affordance.

`GenerateTab.test.tsx` updated: "three mode buttons" test → "two mode buttons"; New RGD mode describe block → RGD Designer link test; wrapped in `MemoryRouter` (needed since `GenerateTab` now renders `<Link>`).

### #204 — Subgraph panel overflows left / oversized height in StaticChainDAG

`web/src/components/StaticChainDAG.tsx`:
- `nestedX` clamped: `Math.max(0, Math.min(rawNestedX, graph.width - nestedWidth))` — panels on right-side nodes no longer go negative and clip
- `extraHeight` now **sums** all expanded panels instead of taking `Math.max` — prevents panels overlapping when multiple nodes are expanded

`web/src/components/ExpandableNode.tsx`:
- Added `svgWidth?: number` prop
- `nestedX` clamped identically when `svgWidth` is provided

### #189 — DeepDAG panels stagger + wrong child instance lookup

`web/src/components/DeepDAG.tsx`:

**Accordion toggle**: when opening a node, all other nodes are collapsed first — prevents multiple panels rendering at the same Y coordinate and staggering.

**Child instance lookup**: replaced `listInstances(rgdName, namespace)` with a lookup in the `children` prop. `listInstances` returned all instances of the child kind (not just the one owned by this instance) and consistently returned empty when the CRD was provisioned by a different instance. The correct instance name is already available in `children` (the parent's child resources list).

`DeepDAG.test.tsx` updated: T003 and T005 now pass a `children` prop with a matching child resource instead of mocking `listInstances`. `listInstances` removed from the mock.

## Verification

- `go vet ./...` — clean
- `go test -race ./internal/...` — all pass (6 packages, new cluster-scoped test case)
- `bun tsc --noEmit` — clean
- `bun vitest run` — 736/736 pass (48 test files)

Closes #202, closes #203, closes #204, closes #205, closes #189