### PR TITLE
fix(web): error states UX audit — translateApiError, enriched empty states, symbol legends (#187)

### DIFF
--- a/.specify/specs/041-error-states-ux-audit/contracts/ui-contracts.md
+++ b/.specify/specs/041-error-states-ux-audit/contracts/ui-contracts.md
@@ -1,0 +1,97 @@
+# UI Contracts: 041 — Error States UX Audit
+
+This spec adds no new API endpoints. All contracts are frontend-only: the render
+contract for error/empty states across components.
+
+---
+
+## Error state render contract
+
+Every component that can display an error MUST satisfy this contract:
+
+| Element | Requirement |
+|---|---|
+| Error container | `role="alert"` for errors the user must act on; `role="status"` for non-critical degraded states (e.g. `MetricsStrip`) |
+| Error message | Translated via `translateApiError()` — never raw `error.message` from `api.ts` |
+| Retry button | Present whenever re-fetching the same resource would resolve the error |
+| Navigation link | Present when the user has no path forward without leaving the current view (e.g. "← Back to Overview" on full-page errors) |
+| `data-testid` | Required on the outermost error container |
+
+---
+
+## Empty state render contract
+
+Every empty state (no data, no items) MUST satisfy:
+
+| Element | Requirement |
+|---|---|
+| Explanatory text | Explain *why* the data might be absent (TTL expiry, filter, not created yet) |
+| Actionable link | Provide at least one next step (kubectl command, tab link, doc link) where applicable |
+| `data-testid` | Optional but preferred for non-trivial empty states |
+
+---
+
+## `translateApiError` contract
+
+**Module**: `web/src/lib/errors.ts`  
+**Exported**: Yes — named export  
+**Pure function**: Yes — no side effects, no React imports  
+**Return type**: `string` — always returns a string (never `null` or `undefined`)
+
+### Invariants
+
+- If the input `message` is empty or whitespace-only, return it unchanged.
+- If no pattern matches, return the original `message` unchanged (never substitute a generic
+  "Unknown error" — the raw message may be meaningful to an advanced operator).
+- Matching is case-insensitive for HTTP status references (`Forbidden`, `forbidden`,
+  `403 Forbidden` all match pattern 3).
+- Pattern 2 (kind extraction) extracts the first double-quoted word from the error string.
+  If extraction fails, it falls back to "the requested kind".
+
+### Test contract
+
+`errors.test.ts` MUST cover:
+
+| Test group | Cases |
+|---|---|
+| Pattern 1 | Exact phrase; phrase embedded in longer string |
+| Pattern 2 | With kind extraction; without kind in string |
+| Pattern 3 | HTTP 403 prefix; lowercase "forbidden" |
+| Pattern 4 | HTTP 401 prefix; "Unauthorized" |
+| Pattern 5 | "connection refused"; "dial tcp"; HTTP 503 |
+| Pattern 6 | Exact "context deadline exceeded" |
+| Pattern 7 | "x509: certificate" |
+| No match | Unknown error string returns original unchanged |
+| Edge cases | Empty string; whitespace-only string |
+| Context | `rgdReady: false` strengthens CRD hint in pattern 1 |
+
+---
+
+## `conditionStatusLabel` contract
+
+**Module**: `web/src/lib/conditions.ts` (extends existing module)  
+**Pure function**: Yes  
+**Return type**: `string`
+
+### Invariants
+
+- For normal-polarity conditions: `"True"` → `"Healthy"`, `"False"` → `"Failed"`,
+  `"Unknown"` → `"Pending"`, anything else → return raw value.
+- For `NEGATION_POLARITY_CONDITIONS`: `"True"` → `"Failed"`, `"False"` → `"Healthy"`,
+  `"Unknown"` → `"Pending"`.
+- Must be covered by tests in the existing `conditions.test.ts`.
+
+---
+
+## `EventsPanel` prop extension contract
+
+```ts
+// No breaking change — `namespace` is optional
+interface EventsPanelProps {
+  events: K8sList | null
+  namespace?: string    // NEW — instance namespace for the "No events" kubectl hint
+}
+```
+
+Existing callers with no `namespace` prop continue to work.  
+When `namespace` is undefined, the empty-events hint omits the `-n [namespace]` clause.

--- a/.specify/specs/041-error-states-ux-audit/data-model.md
+++ b/.specify/specs/041-error-states-ux-audit/data-model.md
@@ -1,0 +1,111 @@
+# Data Model: 041 — Error States UX Audit
+
+This spec introduces no new backend types or Kubernetes resources. All changes are
+frontend-only display transformations. The "data model" describes the new shared
+TypeScript types and helper functions.
+
+---
+
+## New module: `web/src/lib/errors.ts`
+
+### `TranslateContext`
+
+```ts
+export interface TranslateContext {
+  /**
+   * When false (RGD not Ready), prefer "CRD may not be provisioned yet" wording
+   * for resource-not-found / no-kind-registered errors.
+   * Undefined is treated the same as true (no RGD-readiness info available).
+   */
+  rgdReady?: boolean
+
+  /**
+   * Hint for contextual "check the X tab" suggestions.
+   * Values: "validation" | "access" | "yaml" | "generate" | "docs"
+   * Determines which tab link is appended to the translated message.
+   * Omit when no tab-level suggestion is appropriate.
+   */
+  tab?: string
+}
+```
+
+### `translateApiError(message, context?): string`
+
+```ts
+/**
+ * Translate a raw API error string into a user-readable message.
+ *
+ * Pattern matching order (first match wins):
+ *  1. "the server could not find the requested resource"
+ *     → CRD not provisioned wording (context.rgdReady === false strengthens hint)
+ *  2. /no kind "([^"]+)" is registered/i
+ *     → "The kind '[X]' is not registered — the RGD CRD hasn't been created yet."
+ *  3. HTTP 403 / "forbidden"
+ *     → "Permission denied — kro-ui's service account lacks access."
+ *  4. HTTP 401 / "Unauthorized"
+ *     → "Not authenticated — kubeconfig credentials may have expired."
+ *  5. "connection refused" / "dial tcp" / HTTP 503
+ *     → "Cannot reach the Kubernetes API server — check cluster connectivity."
+ *  6. "context deadline exceeded"
+ *     → "Request timed out — the cluster may be under load. Try again."
+ *  7. "x509: certificate"
+ *     → "TLS certificate error — kubeconfig certificate may be invalid or expired."
+ *
+ * Returns the original message unchanged when no pattern matches.
+ */
+export function translateApiError(message: string, context?: TranslateContext): string
+```
+
+---
+
+## New helper in `web/src/lib/conditions.ts`
+
+### `conditionStatusLabel(type, status): string`
+
+```ts
+/**
+ * Translate a raw Kubernetes condition status string to a display label.
+ *
+ * For normal-polarity conditions:
+ *   "True"    → "Healthy"
+ *   "False"   → "Failed"
+ *   "Unknown" → "Pending"
+ *
+ * For negation-polarity conditions (NEGATION_POLARITY_CONDITIONS):
+ *   "True"    → "Failed"   (e.g. ReconciliationSuspended=True → reconciliation is off → bad)
+ *   "False"   → "Healthy"  (e.g. ReconciliationSuspended=False → reconciliation running → good)
+ *   "Unknown" → "Pending"
+ *
+ * Returns the raw status string when none of the above match (defensive fallback).
+ */
+export function conditionStatusLabel(type: string, status: string): string
+```
+
+---
+
+## No new entity types, no new state shapes
+
+The 32 findings in this spec are all localised to render functions:
+- `string | null` error state is already in all components
+- No new props added that change component interfaces
+- Exception: `EventsPanel` gains a new optional `namespace?: string` prop for FR-014
+  (the kubectl command in the empty-events hint needs the namespace)
+
+### `EventsPanel` prop change
+
+```ts
+// Before
+interface EventsPanelProps {
+  events: K8sList | null
+}
+
+// After
+interface EventsPanelProps {
+  events: K8sList | null
+  /** Instance namespace — used in the "No events" help text */
+  namespace?: string
+}
+```
+
+All existing callers pass no `namespace` → `undefined` → graceful degradation (omit the
+kubectl command's `-n` flag in the hint text, or omit the whole command).

--- a/.specify/specs/041-error-states-ux-audit/plan.md
+++ b/.specify/specs/041-error-states-ux-audit/plan.md
@@ -1,0 +1,117 @@
+# Implementation Plan: 041 — Error States, Empty States, and Symbol Legend UX Audit
+
+**Branch**: `041-error-states-ux-audit` | **Date**: 2026-03-25 | **Spec**: `spec.md`  
+**GH Issue**: #187
+
+---
+
+## Summary
+
+Full audit and fix of all error states, empty states, and symbol-legend gaps across the
+kro-ui frontend. The root cause is the absence of an error translation layer: `api.ts`
+forwards raw Go/Kubernetes API error strings verbatim to component render paths. The fix
+introduces `web/src/lib/errors.ts` (a pure translation utility with no dependencies) and
+threads it through every error render site. Separately, 14 empty-state messages are enriched
+with actionable guidance, and 12 symbol/legend gaps are filled.
+
+**6 HIGH + 14 MEDIUM + 12 LOW = 32 findings total. All frontend-only changes.**
+
+---
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x + React 19  
+**Primary Dependencies**: React Router v7, Vite (build only) — no new npm dependencies  
+**Storage**: N/A — read-only observability UI  
+**Testing**: Vitest (unit), existing Playwright E2E (journeys must pass unmodified)  
+**Target Platform**: Browser (Chrome/Firefox/Safari via same-origin SPA)  
+**Project Type**: Web application (SPA frontend + Go backend)  
+**Performance Goals**: No new API calls, no new polling — pure rendering/display changes  
+**Constraints**: No CSS frameworks; no state management libraries; all colours via `tokens.css`
+`var()` references; no new npm packages; no hardcoded `rgba()`/hex in component CSS  
+**Scale/Scope**: 21 component/page files modified; 2 new files (`errors.ts`, `errors.test.ts`)
+
+---
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Rule | Compliance | Notes |
+|---|---|---|
+| §I Iterative-First | ✅ PASS | Spec builds on already-merged base (all prior specs merged) |
+| §II Cluster Adaptability | ✅ PASS | No new k8s API paths; all changes in render layer |
+| §III Read-Only | ✅ PASS | No mutating calls; purely display-layer changes |
+| §IV Single Binary | ✅ PASS | No new assets; no CDN calls |
+| §V Simplicity | ✅ PASS | `errors.ts` is a pure function with zero dependencies |
+| §VI Go Standards | ✅ N/A | No Go changes |
+| §VII Testing Standards | ✅ PASS | `errors.test.ts` with table-driven tests; E2E journeys unmodified |
+| §VIII Commit Conventions | ✅ PASS | Will use `fix(web):` scope |
+| §IX Theme/UI Standards | ✅ PASS | All colours via `var()` tokens; no hardcoded hex; legend uses existing `--color-*` tokens |
+| §X Licensing | ✅ PASS | Apache 2.0 header on all new TS files |
+| §XI API Performance | ✅ PASS | No new API calls |
+| §XII Graceful Degradation | ✅ PASS | This spec *implements* graceful degradation — it is the fix |
+| §XIII Frontend UX Standards | ✅ PASS | All fixes align with or exceed the standards |
+
+**No violations. Phase 0 may proceed.**
+
+---
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/041-error-states-ux-audit/
+├── plan.md              # This file
+├── spec.md              # Feature specification (32 FRs)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+web/src/lib/
+├── errors.ts            # NEW — translateApiError() utility
+├── errors.test.ts       # NEW — unit tests (table-driven)
+├── api.ts               # UNCHANGED — error forwarding stays as-is; translation at render
+├── conditions.ts        # UNCHANGED — isHealthyCondition, rewriteConditionMessage already correct
+
+web/src/pages/
+├── RGDDetail.tsx        # FR-002, FR-003, FR-017
+├── InstanceDetail.tsx   # FR-009, FR-021
+├── Home.tsx             # FR-008
+├── Catalog.tsx          # FR-008, FR-033
+├── Fleet.tsx            # FR-008, FR-013
+└── Events.tsx           # FR-008 (+ Retry button)
+
+web/src/components/
+├── ErrorsTab.tsx        # FR-004, FR-030
+├── AccessTab.tsx        # FR-005
+├── InstanceOverlayBar.tsx   # FR-006, FR-007, FR-029
+├── LiveNodeDetailPanel.tsx  # FR-010
+├── CollectionPanel.tsx      # FR-011, FR-027, FR-028
+├── ExpandableNode.tsx       # FR-012, FR-026
+├── EventsPanel.tsx          # FR-014, FR-024
+├── SpecPanel.tsx            # FR-015
+├── StaticChainDAG.tsx       # FR-016, FR-025, FR-026
+├── FleetMatrix.tsx          # FR-018, FR-019
+├── ClusterCard.tsx          # FR-020
+├── ConditionsPanel.tsx      # FR-031
+├── MetricsStrip.tsx         # FR-032
+├── LiveDAG.tsx              # FR-022, FR-023
+└── DeepDAG.tsx              # FR-022
+```
+
+**Structure Decision**: Flat `web/src/lib/` for the new utility module (consistent with all
+existing `lib/` modules). No new subdirectories needed.
+
+---
+
+## Complexity Tracking
+
+*No constitution violations. No complexity justification needed.*

--- a/.specify/specs/041-error-states-ux-audit/quickstart.md
+++ b/.specify/specs/041-error-states-ux-audit/quickstart.md
@@ -1,0 +1,109 @@
+# Quickstart: 041 — Error States UX Audit
+
+## Prerequisites
+
+- Node.js 20+ / bun 1.x
+- Go 1.25+
+- Working kubeconfig (for E2E only)
+
+## Running the frontend dev server
+
+```bash
+# From the worktree root
+cd web
+bun install          # first time only
+bun run dev          # starts Vite dev server on :5173
+```
+
+The Go backend must be running on :40107 for API calls to proxy correctly (configured in
+`web/vite.config.ts`).
+
+## Running the Go backend
+
+```bash
+# From the worktree root
+make go CMD="run ./cmd/kro-ui/... serve"
+```
+
+## Type-checking
+
+```bash
+cd web && bun run typecheck
+```
+
+All TypeScript must pass `tsc --noEmit` with no errors.
+
+## Unit tests
+
+```bash
+cd web && bun run test        # watch mode
+cd web && bun run test --run  # single run (CI mode)
+```
+
+The new `errors.test.ts` and `conditions.test.ts` additions run in this suite.
+
+## Verifying the new `errors.ts` module
+
+```bash
+cd web && bun run test --run src/lib/errors.test.ts
+```
+
+Expected output: all table-driven test cases pass (empty string, known patterns, no-match
+passthrough, context-sensitive CRD hint).
+
+## E2E tests (requires kind cluster)
+
+```bash
+# Full E2E run
+make test-e2e
+
+# Keep cluster for iteration
+SKIP_KIND_DELETE=true make test-e2e
+```
+
+The error-state changes must not break any existing Playwright journeys. No new E2E journeys
+are required for this spec (all changes are defensive display improvements to paths the
+existing journeys don't assert on).
+
+## Verifying specific fixes visually
+
+Start the full stack and open the browser to verify:
+
+| Finding | How to trigger |
+|---|---|
+| H-1 (RGD detail load error) | Navigate to `/rgds/nonexistent-rgd` |
+| H-2 (Instances tab when RGD not Ready) | Apply an invalid RGD YAML; open Instances tab |
+| M-9 (Fleet empty kubeconfig) | Start kro-ui with an empty `~/.kube/config` |
+| M-10 (No events TTL hint) | Open an instance detail with no recent events |
+| FR-031 (ConditionsPanel labels) | Open any instance with conditions; verify "Healthy"/"Failed"/"Pending" |
+| FR-019 (FleetMatrix legend) | Open Fleet page with 2+ clusters; verify legend row |
+
+## Key files changed by this spec
+
+```
+web/src/lib/errors.ts          ← new — translateApiError()
+web/src/lib/errors.test.ts     ← new — unit tests
+web/src/lib/conditions.ts      ← +conditionStatusLabel()
+web/src/lib/conditions.test.ts ← +conditionStatusLabel tests
+web/src/pages/RGDDetail.tsx    ← H-1, H-2, M-13
+web/src/pages/InstanceDetail.tsx ← M-5, M-18
+web/src/pages/Events.tsx       ← M-1 + Retry button
+web/src/components/ErrorsTab.tsx ← H-3, L-9
+web/src/components/AccessTab.tsx ← H-4
+web/src/components/InstanceOverlayBar.tsx ← H-5, H-6, L-8
+web/src/components/LiveNodeDetailPanel.tsx ← M-6
+web/src/components/CollectionPanel.tsx ← M-7, L-6, L-7
+web/src/components/ExpandableNode.tsx ← M-8, L-5
+web/src/components/EventsPanel.tsx ← M-10, L-3
+web/src/components/SpecPanel.tsx ← M-11
+web/src/components/StaticChainDAG.tsx ← M-12, L-4, L-5
+web/src/components/FleetMatrix.tsx ← M-15, M-16
+web/src/components/ClusterCard.tsx ← M-17
+web/src/components/ConditionsPanel.tsx ← L-10
+web/src/components/MetricsStrip.tsx ← L-11
+web/src/components/Catalog.tsx ← M-1, L-12
+web/src/components/Fleet.tsx ← M-1, M-9
+web/src/components/Home.tsx ← M-1
+web/src/components/LiveDAG.tsx ← L-1, L-2
+web/src/components/DeepDAG.tsx ← L-1
+```

--- a/.specify/specs/041-error-states-ux-audit/research.md
+++ b/.specify/specs/041-error-states-ux-audit/research.md
@@ -1,0 +1,179 @@
+# Research: 041 — Error States UX Audit
+
+## 1. Error translation placement strategy
+
+### Decision
+Place the translation layer in a new `web/src/lib/errors.ts` module, called at render time
+in each component, **not** at the `api.ts` fetch layer.
+
+### Rationale
+- `api.ts` is intentionally minimal (it's a typed fetch wrapper). Inserting translation there
+  would entangle display concerns with the data layer, and would make it impossible to vary
+  the translation based on render context (e.g. "is the RGD Ready?" for H-2).
+- Calling at render time lets each component pass `context` (`rgdReady`, `tab`) to
+  `translateApiError()`, enabling context-sensitive messages (e.g. H-2's CRD-not-provisioned
+  hint only when `readyState.state === 'error'`).
+- Consistent with `conditions.ts` precedent: that module also translates raw Kubernetes
+  condition strings (`rewriteConditionMessage`) at render time, not at fetch time.
+
+### Alternatives considered
+- **Translate in `api.ts`**: Rejected — no render context available; would need a second
+  pass anyway for context-sensitive messages.
+- **Translate in each component inline (no shared module)**: Rejected — 21 sites, guaranteed
+  divergence over time (same anti-pattern the constitution §IX prohibits for `nodeTypeLabel`).
+- **Backend Go translation**: Rejected — the backend is intentionally a thin proxy; API
+  consumers other than kro-ui (curl, scripts) need raw k8s error strings.
+
+---
+
+## 2. Error pattern coverage
+
+### Decision
+Implement 7 regex/substring patterns covering the errors surfaced in issue #187.
+
+### Pattern list (final)
+
+| Priority | Pattern | Match mechanism | Translation |
+|---|---|---|---|
+| 1 | `the server could not find the requested resource` | `includes()` | CRD not provisioned + Validation tab link (when context available) |
+| 2 | `no kind "X" is registered` | regex `/no kind "([^"]+)" is registered/i` | Kind-specific not registered |
+| 3 | HTTP 403 / `forbidden` | `includes('403')` or `includes('forbidden')` (case-insensitive) | Permission denied + Access tab link |
+| 4 | HTTP 401 / `Unauthorized` | `includes('401')` or `includes('Unauthorized')` | Credentials expired |
+| 5 | `dial tcp` / `connection refused` / HTTP 503 | `includes('connection refused')` or `includes('dial tcp')` or `includes('503')` | Cannot reach API server |
+| 6 | `context deadline exceeded` | `includes('context deadline exceeded')` | Timed out, cluster under load |
+| 7 | `x509: certificate` | `includes('x509')` | TLS certificate error |
+
+### Rationale
+- `includes()` preferred over full regex for patterns with no extraction need (simpler, faster).
+- Regex used only for pattern 2 where kind extraction improves the message quality.
+- Case-insensitive matching for 401/403 human labels (`Unauthorized`, `forbidden`) since Go
+  `k8s.io/apimachinery` formats these both ways depending on the path.
+- Patterns checked in priority order: more specific patterns before generic ones.
+
+### Alternatives considered
+- **Single catch-all regex with named groups**: More complex, harder to maintain, no benefit
+  over sequential `includes()` checks.
+- **Error code enum + map**: Over-engineered for 7 patterns; `if/else if` is simpler and just
+  as readable.
+
+---
+
+## 3. Retry button patterns — inline function vs callback ref
+
+### Decision
+Keep the inline anonymous function pattern used in `AccessTab.tsx` and `RGDDetail.tsx`
+Instances tab for new Retry buttons. Do **not** refactor existing Retry buttons to callbacks.
+
+### Rationale
+- The issue is about **adding** Retry buttons to sites that are missing them (H-1, M-6, M-7,
+  M-8). Refactoring existing Retry buttons is out of scope for this spec.
+- The inline function pattern is already used in 5 places across the codebase; introducing a
+  different pattern for new Retry buttons would create inconsistency.
+- `ErrorsTab.tsx` uses a named callback (`fetchInstances`) because it's also invoked by
+  `useEffect` — that requirement doesn't apply to the new sites.
+
+### Alternatives considered
+- **Extract a `<RetryButton>` component**: Premature abstraction — the surrounding error
+  banners are all structurally different; a shared component would need too many props.
+
+---
+
+## 4. ConditionsPanel status label mapping (FR-031)
+
+### Decision
+Map `"True"` → `"Healthy"`, `"False"` → `"Failed"`, `"Unknown"` → `"Pending"` using
+`NEGATION_POLARITY_CONDITIONS` from `conditions.ts` for inverted polarity.
+
+### Rationale
+- Consistent with `ValidationTab.tsx` which already shows `"Healthy"` / `"Failed"` / `"Pending"`.
+- `NEGATION_POLARITY_CONDITIONS` is already the single source of truth for polarity; using it
+  here propagates the correct inversion automatically.
+- `"Pending"` for `"Unknown"` is consistent with the design system's `--color-status-pending`
+  semantic and better communicates the state to operators.
+
+### Alternatives considered
+- **Keep raw `"True"` / `"False"` strings**: Rejected — the issue explicitly calls this out
+  as a UX gap (L-10); raw k8s strings are inconsistent with `ValidationTab`.
+- **Map `"Unknown"` → `"Unknown"`**: Less operator-friendly than `"Pending"`.
+
+---
+
+## 5. Live-state legend in LiveDAG (FR-023)
+
+### Decision
+Add a compact row of colour-labelled dots below the LiveDAG SVG using the existing
+`--color-alive`, `--color-reconciling`, `--color-pending`, `--color-error`,
+`--color-not-found` tokens. No new tokens required.
+
+### Rationale
+- All required colours are already defined in `tokens.css` as semantic tokens.
+- The pattern follows the existing `DAGLegend` component structure — same CSS pattern.
+- Issue #167 explicitly tracks the missing live-state legend; this spec resolves it.
+
+### Alternatives considered
+- **Extend `DAGLegend` to optionally show live states**: `DAGLegend` is small and purely
+  presentational; a boolean prop to toggle live-state entries is simpler than a separate
+  component, but adds coupling. A dedicated inline legend block in `LiveDAG.tsx` keeps
+  the separation cleaner.
+
+---
+
+## 6. FleetMatrix legend (FR-019)
+
+### Decision
+Add a legend row above (or below) the matrix using inline spans with `--color-alive` (present)
+and `--color-reconciling` (degraded) dots. The absent state is shown as `—` (no dot).
+
+### Rationale
+- Existing `fleet-matrix__dot--present` and `fleet-matrix__dot--degraded` already apply
+  background-color from tokens. The legend can reuse the same CSS class with an `aria-hidden`
+  dot and adjacent text.
+- No new tokens needed.
+
+### Alternatives considered
+- **Add a `<FleetMatrixLegend />` component**: Over-engineering for 2 items in a single file.
+
+---
+
+## 7. `errors.ts` signature design
+
+### Final API
+
+```ts
+// web/src/lib/errors.ts
+
+export interface TranslateContext {
+  /** When true, prefer "CRD may not be provisioned yet" wording for resource-not-found errors */
+  rgdReady?: boolean
+  /** Tab name hint for contextual "check the X tab" suggestions */
+  tab?: string
+}
+
+/**
+ * Translates a raw API error message string into a user-readable message.
+ * Returns the original message unchanged when no known pattern matches.
+ */
+export function translateApiError(message: string, context?: TranslateContext): string
+```
+
+### Rationale
+- `TranslateContext` is optional — callers that don't have RGD-readiness info (e.g. page-level
+  errors) can omit it and get a reasonable generic message.
+- The function is pure (no side effects, no React imports) — easy to unit test.
+- Returns the raw message on no-match rather than a generic fallback, because some raw k8s
+  errors are already readable (e.g. quota exceeded, resource version conflict).
+
+---
+
+## 8. NEEDS CLARIFICATION resolutions
+
+All items were either unambiguous from the issue or resolved by codebase inspection:
+
+| Item | Resolution |
+|---|---|
+| Should `api.ts` be modified? | No — translation happens at render |
+| Is a new CSS file needed for `errors.ts`? | No — `errors.ts` is a pure TS utility |
+| What token should live-state legend dots use? | Existing `--color-alive` etc. — no new tokens |
+| Should `ConditionsPanel` use a helper from `conditions.ts`? | Yes — `NEGATION_POLARITY_CONDITIONS` for polarity; add `conditionStatusLabel()` to `conditions.ts` |
+| Does `EventsPanel` need namespace prop for M-10? | Yes — pass `namespace` prop from `InstanceDetail` (already available in render scope) |
+| Should DAGLegend be extended or a new component used for live states? | Inline legend block in `LiveDAG.tsx` (see §5) |

--- a/.specify/specs/041-error-states-ux-audit/spec.md
+++ b/.specify/specs/041-error-states-ux-audit/spec.md
@@ -1,0 +1,391 @@
+# Spec 041 — Error States, Empty States, and Symbol Legend UX Audit
+
+**GH Issue**: #187  
+**Type**: UX Enhancement + Bug Fix  
+**Scope**: Frontend only — `web/src/`  
+**Status**: In progress
+
+---
+
+## Overview
+
+kro-ui is meant not only to visualise cluster state but to help operators **fix problems**.
+Today, nearly every error path forwards a raw Go/Kubernetes API error string directly to the
+screen, and nearly every empty state gives no guidance on what to do next.
+
+This spec covers the full audit: 6 HIGH, 14 MEDIUM, and 12 LOW findings from issue #187.
+
+---
+
+## Guiding Principle
+
+Every error, empty state, and symbol in the UI must answer three questions:
+
+1. **What happened?** (translated, not a raw Go/k8s error string)
+2. **Why did it happen?** (distinguish CRD-not-provisioned from network error from RBAC gap)
+3. **What should I do?** (link to the relevant tab, kubectl command, or doc)
+
+---
+
+## Root Cause: No Error Translation Layer
+
+Almost all HIGH and MEDIUM findings share a single root cause: `web/src/lib/api.ts:9–11`
+forwards the raw `body.error` from the Go backend verbatim. The recommended fix is a new
+`web/src/lib/errors.ts` module with a `translateApiError()` function.
+
+### Error translation table
+
+| Raw error pattern | User-readable message |
+|---|---|
+| `"the server could not find the requested resource"` | "The API server doesn't recognise this resource type — the CRD may not be provisioned yet. Check the Validation tab." |
+| `"no kind \"X\" is registered"` | "The kind 'X' is not registered in this cluster — the RGD CRD hasn't been created yet." |
+| HTTP 403 / `forbidden` | "Permission denied — kro-ui's service account lacks access. Check the Access tab." |
+| HTTP 401 / `Unauthorized` | "Not authenticated — your kubeconfig credentials may have expired." |
+| `dial tcp ... connection refused` / HTTP 503 | "Cannot reach the Kubernetes API server — check cluster connectivity." |
+| `context deadline exceeded` | "Request timed out — the cluster may be under load. Try again." |
+| `x509: certificate` | "TLS certificate error — your kubeconfig certificate may be invalid or expired." |
+
+---
+
+## Functional Requirements
+
+### FR-001 — `errors.ts` translation utility (ROOT CAUSE FIX)
+
+Create `web/src/lib/errors.ts` with:
+
+```ts
+translateApiError(message: string, context?: {
+  rgdReady?: boolean   // if false, prefer CRD-not-provisioned wording
+  tab?: string         // hint for contextual suggestions (e.g. "validation")
+}): string
+```
+
+- Maps all patterns from the table above
+- Returns the raw message unchanged when no pattern matches
+- Exported and covered by unit tests in `errors.test.ts`
+
+### FR-002 — HIGH: RGD detail full-page error (H-1)
+
+**File**: `RGDDetail.tsx:318–320`
+
+Current: `<div className="rgd-detail-error">Error: {error}</div>`
+
+Fix:
+- Translate error via `translateApiError()`
+- Add a "Retry" button that re-fetches the RGD
+- Add a "← Back to Overview" link (`<Link to="/">`)
+- Wrap in `role="alert"`
+
+### FR-003 — HIGH: Instances tab raw API error (H-2)
+
+**File**: `RGDDetail.tsx:502–503`
+
+Fix:
+- If `readyState.state === 'error'` (RGD not Ready), show:
+  > "This RGD's CRD has not been provisioned yet. Instances can only be created once the RGD is
+  > Ready. Check the [Validation tab](?tab=validation) for details."
+- For other errors: `translateApiError()` + Retry button
+
+### FR-004 — HIGH: ErrorsTab API error (H-3)
+
+**File**: `ErrorsTab.tsx:226`
+
+Fix:
+- Translate: 403 → "kro-ui does not have permission to list instances in this namespace"
+- Translate: 404 / CRD-not-found → "RGD CRD not found — check the [Validation tab](?tab=validation)"
+- Other → generic translated message with Retry
+
+### FR-005 — HIGH: AccessTab API error (H-4)
+
+**File**: `AccessTab.tsx:100–119`
+
+Fix:
+- 403 → "kro-ui's own service account lacks permissions to run access checks. Check that
+  the Helm ClusterRole is installed."
+- Other → translated message with Retry
+
+### FR-006 — HIGH: InstanceOverlayBar picker error (H-5)
+
+**File**: `InstanceOverlayBar.tsx:96–108`
+
+Fix:
+- If RGD not Ready: "Could not load instance list — the RGD CRD may not be provisioned yet"
+- Network/other: "Could not load instance list — check cluster connectivity"
+- Add `role="alert"` to the error span
+
+### FR-007 — HIGH: InstanceOverlayBar overlay error (H-6)
+
+**File**: `InstanceOverlayBar.tsx:167–178`
+
+Fix:
+- 404 → "Instance not found — it may have been deleted"
+- Other → "Could not load overlay data — check cluster connectivity"
+- Add `role="alert"` to the error div
+
+### FR-008 — MEDIUM: Page-level raw error banners (M-1–M-4)
+
+**Files**: `Home.tsx:179`, `Catalog.tsx:188`, `Fleet.tsx:234`, `Events.tsx:275`
+
+Fix:
+- Wrap all `{error}` renderings in `translateApiError(error)`
+- `Events.tsx` additionally needs a Retry button (the only page missing one)
+
+### FR-009 — MEDIUM: InstanceDetail RGD spec load failure (M-5)
+
+**File**: `InstanceDetail.tsx:352–354`
+
+Fix:
+- Add `<Link to={`/rgds/${rgdName}`}>← Back to {rgdName}</Link>`
+- Translate the error message
+- Explain: "The RGD may have been deleted or renamed"
+
+### FR-010 — MEDIUM: LiveNodeDetailPanel YAML error — no Retry (M-6)
+
+**File**: `LiveNodeDetailPanel.tsx:188`
+
+Fix:
+- Add Retry button to generic error branch (matching the timeout branch at lines 179–185)
+- Translate common errors: 403 → "No permission to read this resource"; 404 → "Resource not
+  found in cluster — it may not have been created yet"
+
+### FR-011 — MEDIUM: CollectionPanel item YAML error — no Retry (M-7)
+
+**File**: `CollectionPanel.tsx:263`
+
+Fix: Same as FR-010 — add Retry button to the generic error branch
+
+### FR-012 — MEDIUM: DeepDAG child-load error (M-8)
+
+**File**: `ExpandableNode.tsx:249–256`
+
+Fix:
+- Translate "No X instance found" → "No [Kind] instance found in namespace [ns] — it may
+  not have been created yet or may be in a different namespace"
+- Add Retry button (call the existing retry mechanism)
+
+### FR-013 — MEDIUM: Fleet empty kubeconfig state (M-9)
+
+**File**: `Fleet.tsx:242–244`
+
+Fix:
+- Replace "No kubeconfig contexts found." with:
+  > "No kubeconfig contexts found. Mount a kubeconfig file and restart kro-ui, or check that
+  > your `~/.kube/config` contains at least one context."
+
+### FR-014 — MEDIUM: EventsPanel "No events." — missing TTL explanation (M-10)
+
+**File**: `EventsPanel.tsx:69`
+
+Fix:
+- Replace "No events." with:
+  > "No events found. Kubernetes events expire after ~1 hour — run
+  > `kubectl get events -n [ns]` to check for recent activity."
+- The `ns` should be the instance's namespace (prop-drilled or from context)
+
+### FR-015 — MEDIUM: SpecPanel "No spec fields." (M-11)
+
+**File**: `SpecPanel.tsx:41`
+
+Fix:
+- Replace "No spec fields." with:
+  > "No spec fields defined. Check the RGD's [Docs tab](?tab=docs) to see the schema."
+
+### FR-016 — MEDIUM: StaticChainDAG "RGD not found" (M-12)
+
+**File**: `StaticChainDAG.tsx:181`
+
+Fix:
+- Replace "RGD not found" with:
+  > "Chained RGD '[chainedName]' not found in this cluster — it may have been deleted or not yet applied."
+
+### FR-017 — MEDIUM: "No managed resources defined" on Graph tab and instance DAG (M-13–M-14)
+
+**Files**: `RGDDetail.tsx:469`, `InstanceDetail.tsx:390`
+
+Fix:
+- Replace the bare "No managed resources defined in this RGD." with:
+  > "No managed resources defined in this RGD. Open the [YAML tab](?tab=yaml) to inspect the
+  > spec, or use the [Generate tab](?tab=generate) to scaffold a new resource."
+- On the instance DAG, link to the static RGD DAG (breadcrumb back to RGD detail)
+
+### FR-018 — MEDIUM: FleetMatrix "No RGDs found" (M-15)
+
+**File**: `FleetMatrix.tsx:44–49`
+
+Fix:
+- Replace "No RGDs found across any cluster." with:
+  > "No ResourceGraphDefinitions found. Apply an RGD to any connected cluster to see it here."
+- Add a link to `/author`
+
+### FR-019 — MEDIUM: FleetMatrix color dots — no legend (M-16)
+
+**File**: `FleetMatrix.tsx` (above the table)
+
+Fix:
+- Add a compact legend row: `● Present  ● Degraded  — Absent`
+- Tokens: `--color-alive` (present), `--color-reconciling` (degraded)
+- No new tokens needed
+
+### FR-020 — MEDIUM: ClusterCard health dot — color-only healthy state (M-17)
+
+**File**: `ClusterCard.tsx:40–44`
+
+Fix:
+- Add inline text label for the healthy state (matching amber/red/grey states which already show text)
+- Ensure all health states have a text label alongside the dot
+
+### FR-021 — MEDIUM: "Refresh paused" banner — swallows underlying error (M-18)
+
+**File**: `InstanceDetail.tsx:344–348`
+
+Fix:
+- Show translated error alongside the retry countdown:
+  > "Refresh paused ([translated reason]) — retrying in 10s"
+
+### FR-022 — LOW: DAGLegend not rendered on LiveDAG and DeepDAG (L-1)
+
+**Files**: `LiveDAG.tsx`, `DeepDAG.tsx`
+
+Fix:
+- Render `<DAGLegend />` below the DAG SVG on all DAG variants, not only `StaticChainDAG`
+
+### FR-023 — LOW: Live-state legend missing on Live DAG (L-2)
+
+**File**: `LiveDAG.tsx`
+
+Fix:
+- Add a live-state legend row below the DAG with colour + label for each node state:
+  alive (green), reconciling (amber), pending (violet), error (rose), not-found (grey)
+- Uses existing `--color-*` tokens
+
+### FR-024 — LOW: EventsPanel deletion tag — no text label (L-3)
+
+**File**: `EventsPanel.tsx:80–82`
+
+Fix:
+- Add "Deletion" text alongside `⊘` glyph (the glyph remains `aria-hidden="true"`)
+
+### FR-025 — LOW: StaticChainDAG cycle indicator — SVG aria-label unreliable (L-4)
+
+**File**: `StaticChainDAG.tsx:492`
+
+Fix:
+- Add visible "(cycle)" text label next to the `⊗` glyph in the node
+
+### FR-026 — LOW: StaticChainDAG / ExpandableNode max-depth indicator (L-5)
+
+**Files**: `StaticChainDAG.tsx:479`, `ExpandableNode.tsx:208`
+
+Fix:
+- Add visible "(max depth)" text next to `⋯` glyph
+
+### FR-027 — LOW: CollectionPanel empty collection — no CEL guidance (L-6)
+
+**File**: `CollectionPanel.tsx:405–408`
+
+Fix:
+- Replace "Empty collection — 0 resources" with:
+  > "Empty collection. The forEach expression evaluated to an empty list. Check the forEach CEL expression above."
+
+### FR-028 — LOW: CollectionPanel legacy notice — no upgrade guidance (L-7)
+
+**File**: `CollectionPanel.tsx:401–404`
+
+Fix:
+- Add: "kro < 0.8.0 lacks `kro.run/node-id` labels — upgrade kro to enable collection drill-down."
+
+### FR-029 — LOW: InstanceOverlayBar empty state — no Generate tab link (L-8)
+
+**File**: `InstanceOverlayBar.tsx:109–115`
+
+Fix:
+- Change "No instances — create one with `kubectl apply`" to also include a link to `?tab=generate`
+
+### FR-030 — LOW: ErrorsTab empty state — no Generate tab link (L-9)
+
+**File**: `ErrorsTab.tsx:241`
+
+Fix:
+- Add link to `?tab=generate` alongside the `kubectl apply` instruction
+
+### FR-031 — LOW: ConditionsPanel — raw True/False/Unknown strings (L-10)
+
+**File**: `ConditionsPanel.tsx:96`
+
+Fix:
+- Map `"True"` → `"Healthy"`, `"False"` → `"Failed"`, `"Unknown"` → `"Pending"`
+- Exception: negation-polarity conditions (`NEGATION_POLARITY_CONDITIONS`) — for these,
+  `"False"` → `"Healthy"`, `"True"` → `"Failed"`
+
+### FR-032 — LOW: MetricsStrip — stale --metrics-url reference (L-11)
+
+**File**: `MetricsStrip.tsx:82`
+
+Fix:
+- Replace "start kro-ui with --metrics-url to enable" with:
+  "Controller metrics unavailable — kro controller pod not found in this cluster"
+
+### FR-033 — LOW: Catalog empty state order — filter vs onboarding (L-12)
+
+**File**: `Catalog.tsx:217`
+
+Fix:
+- Check `hasFilters` first, then `items.length === 0`:
+  - If `hasFilters && filtered.length === 0`: show "No RGDs match your filter."
+  - If `!hasFilters && items.length === 0`: show the onboarding empty state
+
+---
+
+## Non-Goals
+
+- Backend changes — all fixes are frontend-only
+- New loading skeleton components — use existing `<SkeletonCard />` or plain text (skeleton
+  consistency is a separate audit)
+- Retry logic changes beyond adding missing Retry buttons
+
+---
+
+## Acceptance Criteria
+
+1. `web/src/lib/errors.ts` exists with `translateApiError()` covered by unit tests
+2. All 6 HIGH findings resolved
+3. All 14 MEDIUM findings resolved
+4. All 12 LOW findings resolved
+5. `go vet ./...` passes
+6. `bun run typecheck` passes (TypeScript strict mode, no new `any` escapes)
+7. Existing E2E journeys pass unmodified
+
+---
+
+## File Impact Summary
+
+### New files
+
+- `web/src/lib/errors.ts` — error translation utility
+- `web/src/lib/errors.test.ts` — unit tests
+
+### Modified files
+
+| File | Findings |
+|---|---|
+| `web/src/pages/RGDDetail.tsx` | FR-002, FR-003, FR-017 |
+| `web/src/pages/InstanceDetail.tsx` | FR-009, FR-021 |
+| `web/src/pages/Home.tsx` | FR-008 |
+| `web/src/pages/Catalog.tsx` | FR-008, FR-033 |
+| `web/src/pages/Fleet.tsx` | FR-008, FR-013 |
+| `web/src/pages/Events.tsx` | FR-008 |
+| `web/src/components/ErrorsTab.tsx` | FR-004, FR-030 |
+| `web/src/components/AccessTab.tsx` | FR-005 |
+| `web/src/components/InstanceOverlayBar.tsx` | FR-006, FR-007, FR-029 |
+| `web/src/components/LiveNodeDetailPanel.tsx` | FR-010 |
+| `web/src/components/CollectionPanel.tsx` | FR-011, FR-027, FR-028 |
+| `web/src/components/ExpandableNode.tsx` | FR-012, FR-026 |
+| `web/src/components/EventsPanel.tsx` | FR-014, FR-024 |
+| `web/src/components/SpecPanel.tsx` | FR-015 |
+| `web/src/components/StaticChainDAG.tsx` | FR-016, FR-025, FR-026 |
+| `web/src/components/FleetMatrix.tsx` | FR-018, FR-019 |
+| `web/src/components/ClusterCard.tsx` | FR-020 |
+| `web/src/components/ConditionsPanel.tsx` | FR-031 |
+| `web/src/components/MetricsStrip.tsx` | FR-032 |
+| `web/src/components/LiveDAG.tsx` | FR-022, FR-023 |
+| `web/src/components/DeepDAG.tsx` | FR-022 |

--- a/.specify/specs/041-error-states-ux-audit/tasks.md
+++ b/.specify/specs/041-error-states-ux-audit/tasks.md
@@ -1,0 +1,222 @@
+# Tasks: 041 — Error States, Empty States, and Symbol Legend UX Audit
+
+**Input**: Design documents from `.specify/specs/041-error-states-ux-audit/`  
+**Branch**: `041-error-states-ux-audit`  
+**GH Issue**: #187
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1–US4)
+- Exact file paths included in every task description
+
+## User Story Map
+
+| Story | Scope | Priority |
+|-------|-------|----------|
+| US1 | Error translation layer — `errors.ts` + `conditionStatusLabel` in `conditions.ts` | P1 |
+| US2 | HIGH findings: H-1 through H-6 (user blocked, no path forward) | P2 |
+| US3 | MEDIUM findings: M-1 through M-18 (confusing but recoverable) | P3 |
+| US4 | LOW findings: L-1 through L-12 (missing labels, legends, tooltips) | P4 |
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify toolchain and confirm no stale type errors before starting.
+
+- [X] T001 Run `cd web && bun run typecheck` to confirm zero pre-existing TypeScript errors
+- [X] T002 Run `cd web && bun run test --run` to confirm all existing unit tests pass
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Create the translation utility and condition label helper that every subsequent
+phase depends on. **No US2–US4 work can start until this phase is complete.**
+
+**⚠️ CRITICAL**: All phases depend on T003 and T004.
+
+- [X] T003 Create `web/src/lib/errors.ts` with `translateApiError(message, context?)` — implement all 7 error patterns from `research.md §2` (resource-not-found, no-kind-registered, 403/forbidden, 401/Unauthorized, connection-refused/dial-tcp/503, context-deadline-exceeded, x509-certificate); add Apache 2.0 header
+- [X] T004 Add `conditionStatusLabel(type, status): string` to `web/src/lib/conditions.ts` — maps `"True"` → `"Healthy"`, `"False"` → `"Failed"`, `"Unknown"` → `"Pending"` with `NEGATION_POLARITY_CONDITIONS` inversion; add Apache 2.0 header is already present
+- [X] T005 Create `web/src/lib/errors.test.ts` with table-driven unit tests covering all 9 groups from `contracts/ui-contracts.md`: patterns 1–7, no-match passthrough, edge cases (empty/whitespace string), and context (`rgdReady: false` strengthens CRD hint); add Apache 2.0 header
+- [X] T006 Add `conditionStatusLabel` unit tests to `web/src/lib/conditions.test.ts` — table-driven: normal polarity (True/False/Unknown), negation polarity (ReconciliationSuspended), unknown input passthrough
+- [X] T007 Run `cd web && bun run test --run src/lib/errors.test.ts src/lib/conditions.test.ts` to confirm T005 and T006 pass
+
+**Checkpoint**: `errors.ts` and updated `conditions.ts` are complete and tested. All subsequent phases can now proceed.
+
+---
+
+## Phase 3: User Story 1 — HIGH findings (H-1 through H-6) (Priority: P2) 🎯 MVP
+
+**Goal**: Eliminate all 6 cases where the user is completely blocked with no path forward.
+Every HIGH error site gets translated messages, Retry buttons, and navigation links.
+
+**Independent Test**: Navigate to `/rgds/nonexistent-rgd` (H-1), open Instances tab on a
+not-Ready RGD (H-2), open Errors/Access/InstanceOverlay on a broken cluster (H-3 through H-6).
+Each shows a translated message, a Retry button, and a "Back" link where applicable.
+
+### Implementation for US1
+
+- [X] T008 [US1] Fix H-1 in `web/src/pages/RGDDetail.tsx:318–320` — replace `<div className="rgd-detail-error">Error: {error}</div>` with a block that: (a) wraps in `role="alert"`, (b) calls `translateApiError(error)`, (c) adds a Retry button that re-calls `fetchRGD`, (d) adds `<Link to="/">← Back to Overview</Link>`; add `data-testid="rgd-detail-error"` to the container
+- [X] T009 [US1] Fix H-2 in `web/src/pages/RGDDetail.tsx:500–526` — in the Instances tab error branch: (a) if `readyState.state === 'error'`, show the CRD-not-provisioned message with a link to `?tab=validation`; (b) otherwise call `translateApiError(instancesError, { rgdReady: readyState.state !== 'error' })` with Retry button; keep `data-testid="instance-error-state"`
+- [X] T010 [US1] Fix H-3 in `web/src/components/ErrorsTab.tsx:224–236` — replace `Error: {error}` with `translateApiError(error, { tab: 'validation' })`; map 403 → permission message, 404/resource-not-found → CRD hint; keep `data-testid="errors-api-error"` and existing Retry button
+- [X] T011 [US1] Fix H-4 in `web/src/components/AccessTab.tsx:100–119` — replace `Error: {error}` with context-specific translation: 403 → "kro-ui's own service account lacks permissions to run access checks. Check that the Helm ClusterRole is installed."; other → `translateApiError(error)`; keep existing Retry button; add `data-testid` to loading div at line 97
+- [X] T012 [US1] Fix H-5 in `web/src/components/InstanceOverlayBar.tsx:96–108` — replace raw `pickerError` with translated message: if RGD not Ready → "Could not load instance list — the RGD CRD may not be provisioned yet"; otherwise → "Could not load instance list — check cluster connectivity"; add `role="alert"` to the error span; add `data-testid="overlay-picker-error"`
+- [X] T013 [US1] Fix H-6 in `web/src/components/InstanceOverlayBar.tsx:167–178` — replace raw `overlayError` with: 404 / resource-not-found → "Instance not found — it may have been deleted"; other → `translateApiError(overlayError)`; add `role="alert"` to the error div; add `data-testid="overlay-data-error"`
+
+**Checkpoint**: All 6 HIGH findings resolved. Run `bun run typecheck` — must pass.
+
+---
+
+## Phase 4: User Story 2 — MEDIUM findings (M-1 through M-18) (Priority: P3)
+
+**Goal**: Resolve all 14 medium-severity UX gaps where users are confused but not fully
+blocked. Enriched empty states, missing Retry buttons, and translated page-level errors.
+
+**Independent Test**: Trigger each error path described in `quickstart.md §Verifying specific
+fixes visually`. All page-level errors show translated messages; all medium empty states show
+actionable guidance.
+
+### Implementation for US2
+
+- [X] T014 [P] [US2] Fix M-1 (Home page error) in `web/src/pages/Home.tsx:179` — wrap `{error}` in `translateApiError(error)` call; no structural change needed
+- [X] T015 [P] [US2] Fix M-2 (Catalog page error) in `web/src/pages/Catalog.tsx:188` — wrap `{error}` in `translateApiError(error)` call
+- [X] T016 [P] [US2] Fix M-3 (Fleet page error) in `web/src/pages/Fleet.tsx:234` — wrap `{error}` in `translateApiError(error)` call
+- [X] T017 [P] [US2] Fix M-4 (Events page error) in `web/src/pages/Events.tsx:275` — wrap `{error}` in `translateApiError(error)`; additionally add a Retry button that re-calls the fetch function (Events is the only page-level error currently missing a Retry button)
+- [X] T018 [P] [US2] Fix M-5 in `web/src/pages/InstanceDetail.tsx:351–355` — add `<Link to={`/rgds/${rgdName}`}>← Back to {rgdName}</Link>` to the `rgdError` block; wrap error message in `translateApiError(rgdError)`; add explanatory text "The RGD may have been deleted or renamed"; wrap in `role="alert"`
+- [X] T019 [P] [US2] Fix M-6 in `web/src/components/LiveNodeDetailPanel.tsx:188` — in the generic `error` branch (not timeout), add a Retry button calling `handleRetry`; translate error: 403 → "No permission to read this resource"; 404/resource-not-found → "Resource not found in cluster — it may not have been created yet"; other → `translateApiError(yamlState.message)`; add `role="alert"`
+- [X] T020 [P] [US2] Fix M-7 in `web/src/components/CollectionPanel.tsx:263` — same pattern as T019: add Retry button calling `handleRetry` in the generic error branch; translate via `translateApiError(viewState.message)` with 403/404 contextual overrides; add `role="alert"`
+- [X] T021 [P] [US2] Fix M-8 in `web/src/components/ExpandableNode.tsx:249–256` — translate `childError` via `translateApiError(childError)`; additionally map "No X instance found" pattern → "No [Kind] instance found in namespace [ns] — it may not have been created yet or may be in a different namespace" (extract Kind and ns from the error string using a regex); add a Retry button that triggers the existing expand/load mechanism; keep `data-testid`
+- [X] T022 [P] [US2] Fix M-9 in `web/src/pages/Fleet.tsx:242–244` — replace "No kubeconfig contexts found." paragraph with the full message from spec FR-013 including the `~/.kube/config` hint; add `data-testid="fleet-empty"` to the container
+- [X] T023 [P] [US2] Fix M-10 in `web/src/components/EventsPanel.tsx:68–69` — add optional `namespace?: string` prop to `EventsPanelProps` per `data-model.md`; replace `<div className="panel-empty">No events.</div>` with the TTL-explanation message from spec FR-014 including the kubectl command (omit `-n [ns]` clause when namespace prop is undefined); add `data-testid="events-panel-empty"` to the new empty div
+- [X] T024 [US2] Pass `namespace` prop to `<EventsPanel>` in `web/src/pages/InstanceDetail.tsx` — extract namespace from `fastData.instance.metadata.namespace` and forward it to `<EventsPanel namespace={ns} events={fastData.events} />`; depends on T023
+- [X] T025 [P] [US2] Fix M-11 in `web/src/components/SpecPanel.tsx:40–41` — replace "No spec fields." with the message from spec FR-015: "No spec fields defined. Check the RGD's Docs tab to see the schema." with a `<Link to="?tab=docs">Docs tab</Link>` (use React Router `useSearchParams` or a relative query link)
+- [X] T026 [P] [US2] Fix M-12 in `web/src/components/StaticChainDAG.tsx:181` — replace "RGD not found" with the message from spec FR-016: `Chained RGD '${chainedName}' not found in this cluster — it may have been deleted or not yet applied.`; add `role="alert"` to the container div; add `data-testid="static-chain-not-found"`
+- [X] T027 [P] [US2] Fix M-13 in `web/src/pages/RGDDetail.tsx:469` — replace "No managed resources defined in this RGD." with the message from spec FR-017 including links to `?tab=yaml` and `?tab=generate`
+- [X] T028 [P] [US2] Fix M-14 in `web/src/pages/InstanceDetail.tsx:375–377` — replace "No managed resources defined in this RGD." with the same enriched message; add a breadcrumb back to the RGD's Graph tab
+- [X] T029 [P] [US2] Fix M-15 in `web/src/components/FleetMatrix.tsx:44–49` — replace "No RGDs found across any cluster." with "No ResourceGraphDefinitions found. Apply an RGD to any connected cluster to see it here." and a `<Link to="/author">Create your first RGD →</Link>`; add `data-testid="fleet-matrix-empty"` to the container
+- [X] T030 [P] [US2] Fix M-16 in `web/src/components/FleetMatrix.tsx` — add a compact legend row above the matrix (inside the `role="region"` wrapper): `● Present  ● Degraded  — Absent`; use `--color-status-ready` for present dot and `--color-status-warning` for degraded dot in inline CSS via `var()`; mark dots `aria-hidden="true"` with adjacent text
+- [X] T031 [P] [US2] Fix M-17 in `web/src/components/ClusterCard.tsx:40–44` — the healthy state health dot currently has no text label; add a visible inline text label for `health === 'healthy'` → "Healthy" consistent with amber/red/grey states; use `healthLabel()` return value or map inline
+- [X] T032 [P] [US2] Fix M-18 in `web/src/pages/InstanceDetail.tsx:344–348` — update the `poll-error-banner` block to include the translated error reason alongside the countdown: `"Refresh paused (${translateApiError(pollError)}) — retrying in 10s"`; the `role="status"` is acceptable here (non-critical interruption)
+
+**Checkpoint**: All 14 MEDIUM findings resolved. Run `bun run typecheck` — must pass.
+
+---
+
+## Phase 5: User Story 3 — LOW findings (L-1 through L-12) (Priority: P4)
+
+**Goal**: Fill all 12 symbol/legend/label gaps so every glyph and colour has an accompanying
+text label or legend, and no UI element relies solely on colour to convey meaning.
+
+**Independent Test**: Open the RGD detail Graph tab (L-1 through L-5), open an instance detail
+(L-1, L-2, L-6), open EventsPanel (L-3), open ConditionsPanel (L-10), open MetricsStrip (L-11),
+open Catalog with active filters (L-12). All glyphs have visible text; all states have legends.
+
+### Implementation for US3
+
+- [X] T033 [P] [US3] Fix L-1 in `web/src/components/LiveDAG.tsx` — import and render `<DAGLegend />` below the SVG container (following the same pattern as `StaticChainDAG` where it already renders); the legend explains `?` (conditional), `∀` (forEach), `⬡` (external ref)
+- [X] T034 [P] [US3] Fix L-1 in `web/src/components/DeepDAG.tsx` — same as T033: import and render `<DAGLegend />` below the SVG container
+- [X] T035 [US3] Fix L-2 in `web/src/components/LiveDAG.tsx` — add a live-state legend row below `<DAGLegend />` with five entries: Alive (green `--color-alive`), Reconciling (amber `--color-reconciling`), Pending (violet `--color-pending`), Error (rose `--color-error`), Not found (grey `--color-not-found`); use `aria-hidden="true"` on colour dots with adjacent text; no new tokens needed; depends on T033
+- [X] T036 [P] [US3] Fix L-3 in `web/src/components/EventsPanel.tsx:80–82` — add "Deletion" text immediately after the `⊘` glyph span (the glyph keeps `aria-label="deletion event"` and `aria-hidden` is NOT set, so remove it or keep as-is; the adjacent text "Deletion" provides the visible label); ensure the text is styled consistently with event type tags
+- [X] T037 [P] [US3] Fix L-4 in `web/src/components/StaticChainDAG.tsx` — locate the `⊗` cycle indicator SVG element; add a visible `<text>` "(cycle)" label adjacent to the glyph; ensure the existing `aria-label` is kept for screen readers
+- [X] T038 [P] [US3] Fix L-5 in `web/src/components/StaticChainDAG.tsx` — locate the `⋯` max-depth indicator SVG `<text>` element (around line 479); add visible "(max depth)" text adjacent to the glyph; keep `data-testid="static-chain-maxdepth-*"`
+- [X] T039 [P] [US3] Fix L-5 in `web/src/components/ExpandableNode.tsx` — locate the `⋯` max-depth indicator (around line 208) and add a visible "(max depth)" text label adjacent to the glyph
+- [X] T040 [P] [US3] Fix L-6 in `web/src/components/CollectionPanel.tsx:405–408` — replace "Empty collection — 0 resources" with the message from spec FR-027: "Empty collection. The forEach expression evaluated to an empty list. Check the forEach CEL expression above."; keep `data-testid="collection-empty-state"`
+- [X] T041 [P] [US3] Fix L-7 in `web/src/components/CollectionPanel.tsx:401–404` — expand the legacy notice text to include the upgrade guidance from spec FR-028: "kro < 0.8.0 lacks `kro.run/node-id` labels — upgrade kro to enable collection drill-down."
+- [X] T042 [P] [US3] Fix L-8 in `web/src/components/InstanceOverlayBar.tsx:109–115` — add a link to `?tab=generate` in the "No instances — create one with kubectl apply" empty state; use React Router `<Link to={{ search: '?tab=generate' }}>Generate tab</Link>` or a `useNavigate` approach consistent with other tab links in the codebase
+- [X] T043 [P] [US3] Fix L-9 in `web/src/components/ErrorsTab.tsx:239–243` — add a link to `?tab=generate` in the "No instances yet. Create one with kubectl apply." empty state; same approach as T042
+- [X] T044 [P] [US3] Fix L-10 in `web/src/components/ConditionsPanel.tsx:95–96` — replace raw `{c.status}` with `{conditionStatusLabel(c.type, c.status)}` (import `conditionStatusLabel` from `@/lib/conditions`); the `statusClass(c.type, c.status)` call already handles polarity-aware colour, so only the text label changes
+- [X] T045 [P] [US3] Fix L-11 in `web/src/components/MetricsStrip.tsx:82` — replace the `connection refused`/`unreachable` branch message "start kro-ui with --metrics-url to enable" with "Controller metrics unavailable — kro controller pod not found in this cluster" (the `--metrics-url` flag was removed in v0.4.0, spec #040)
+- [X] T046 [P] [US3] Fix L-12 in `web/src/pages/Catalog.tsx` — locate the empty-state rendering condition (around line 217); ensure `hasFilters && filteredItems.length === 0` is checked before `items.length === 0` so filtered-no-results shows "No RGDs match your filter." rather than the onboarding empty state; the condition inversion is described in spec FR-033
+
+**Checkpoint**: All 12 LOW findings resolved. Run `bun run typecheck` — must pass.
+
+---
+
+## Phase 6: Polish & Verification
+
+**Purpose**: Final typecheck, full test run, and visual spot-check.
+
+- [X] T047 Run `cd web && bun run typecheck` — zero errors required
+- [X] T048 Run `cd web && bun run test --run` — all tests must pass (no regressions in existing tests)
+- [X] T049 [P] Verify H-1 fix visually: navigate to `/rgds/nonexistent-rgd`; confirm translated message, Retry button, and "← Back to Overview" link are present
+- [X] T050 [P] Verify FR-031 fix visually: open any instance with conditions; confirm "Healthy"/"Failed"/"Pending" labels replace raw "True"/"False"/"Unknown" strings
+- [X] T051 [P] Verify FR-019 fix visually: open Fleet page; confirm legend row `● Present  ● Degraded  — Absent` appears above the matrix
+- [X] T052 [P] Verify L-2 fix visually: open InstanceDetail live DAG; confirm live-state legend (Alive/Reconciling/Pending/Error/Not found) appears below the DAG
+- [X] T053 Run `go vet ./...` (backend is unchanged, but must still pass)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — run immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1; **BLOCKS all user story phases**
+- **Phase 3 (US1 — HIGH)**: Depends on Phase 2 (needs `translateApiError` from T003)
+- **Phase 4 (US2 — MEDIUM)**: Depends on Phase 2; can run in parallel with Phase 3
+- **Phase 5 (US3 — LOW)**: Depends on Phase 2; T044 additionally depends on T004 (`conditionStatusLabel`)
+- **Phase 6 (Polish)**: Depends on all previous phases
+
+### User Story Dependencies
+
+- **US1 (HIGH)**: Depends only on Phase 2 foundation
+- **US2 (MEDIUM)**: Depends only on Phase 2; T024 depends on T023
+- **US3 (LOW)**: Depends on Phase 2; T035 depends on T033; T044 depends on T004
+
+### Within Each User Story
+
+- All `[P]`-marked tasks within a story touch different files — can run in parallel
+- Tasks without `[P]` have sequencing dependencies noted in their descriptions
+
+### Parallel Opportunities
+
+```bash
+# Phase 3 (HIGH fixes) — all touch different files, run together:
+T008   # RGDDetail.tsx — H-1
+T009   # RGDDetail.tsx — H-2  (same file as T008, run sequentially)
+T010   # ErrorsTab.tsx — H-3
+T011   # AccessTab.tsx — H-4
+T012   # InstanceOverlayBar.tsx — H-5
+T013   # InstanceOverlayBar.tsx — H-6 (same file as T012, run sequentially)
+
+# Phase 4 (MEDIUM fixes) — most touch different files, batch:
+T014 T015 T016 T017 T018 T019 T020 T021 T022 T025 T026 T027 T029 T030 T031
+# Sequential only: T024 after T023, T028 after T027 (same page file)
+
+# Phase 5 (LOW fixes) — all touch different files, fully parallel:
+T033 T034 T036 T037 T038 T039 T040 T041 T042 T043 T044 T045 T046
+# Sequential only: T035 after T033 (same LiveDAG.tsx file)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (T003–T007)
+3. Complete Phase 3: HIGH findings (T008–T013)
+4. **STOP and VALIDATE**: All 6 HIGH error paths show translated messages + Retry
+5. The most operator-impactful changes ship first
+
+### Incremental Delivery
+
+1. Setup + Foundational → translation utility ready
+2. Phase 3 (HIGH) → unblocks operators in error states
+3. Phase 4 (MEDIUM) → enriches confusing paths
+4. Phase 5 (LOW) → fills legend/label gaps
+5. Phase 6 (Polish) → verify and ship
+
+---
+
+## Notes
+
+- `[P]` marks tasks that touch different files from all other parallel tasks — safe to run concurrently
+- All error messages must use `translateApiError()` from `web/src/lib/errors.ts` — never inline string comparisons
+- All colours in new CSS must use `var(--token)` — never hardcoded hex or `rgba()` literals
+- Apache 2.0 header required on new `.ts` files; existing files already have it
+- No new npm dependencies introduced by any task
+- `go vet ./...` must pass (no Go changes in this spec, but required by CI)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,6 +370,8 @@ Always read the spec before writing code. Always run `go vet ./...` and
 ## Active Technologies
 - Go 1.25 backend + TypeScript 5.x + React 19 + React Router v7 + Vite — no new npm or Go dependencies introduced since v0.2.1
 - All state is local React `useState`; no persistence layer; no state management libraries
+- TypeScript 5.x + React 19 + React Router v7, Vite (build only) — no new npm dependencies (041-error-states-ux-audit)
+- N/A — read-only observability UI (041-error-states-ux-audit)
 
 ## Recent Changes
 - v0.4.1: 9-issue bug-fix batch — breadcrumb rename (Overview), FieldTable scrollbar, OptimizationAdvisor layout, context-switch navigation, ValidationTab condition types (kro v0.4+), cluster-scoped Live YAML (Namespace/ClusterRole/PV), DAG tooltip hover persistence, DiscoverPlural discovery cache + Fleet errgroup fan-out + 5s server timeout, test coverage (access handler, 4 lib modules, 3 E2E journeys)

--- a/web/src/components/AccessTab.tsx
+++ b/web/src/components/AccessTab.tsx
@@ -3,6 +3,7 @@ import { getRGDAccess } from "@/lib/api"
 import type { AccessResponse, GVRPermission } from "@/lib/api"
 import PermissionCell from "@/components/PermissionCell"
 import RBACFixSuggestion from "@/components/RBACFixSuggestion"
+import { translateApiError } from "@/lib/errors"
 import "./AccessTab.css"
 
 interface AccessTabProps {
@@ -94,13 +95,17 @@ export default function AccessTab({ rgdName }: AccessTabProps) {
   }
 
   if (loading) {
-    return <div className="access-tab-loading">Checking permissions…</div>
+    return <div className="access-tab-loading" data-testid="access-tab-loading">Checking permissions…</div>
   }
 
   if (error) {
+    // 403 on the access tab means kro-ui's own SA can't check permissions — give specific guidance
+    const msg = (error.includes('403') || error.toLowerCase().includes('forbidden'))
+      ? "kro-ui's own service account lacks permissions to run access checks. Check that the Helm ClusterRole is installed."
+      : translateApiError(error)
     return (
-      <div className="access-tab-error" data-testid="access-tab-error">
-        <span className="access-tab-error__msg">Error: {error}</span>
+      <div className="access-tab-error" role="alert" data-testid="access-tab-error">
+        <span className="access-tab-error__msg">{msg}</span>
         <button
           type="button"
           className="access-tab-retry-btn"

--- a/web/src/components/ClusterCard.css
+++ b/web/src/components/ClusterCard.css
@@ -122,3 +122,15 @@
   font-size: 0.7rem;
   color: var(--color-text-muted);
 }
+
+/* Health dot + label wrapper (M-17) */
+.cluster-card__health {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.cluster-card__health-label {
+  font-size: 11px;
+  color: var(--color-text-muted);
+}

--- a/web/src/components/ClusterCard.test.tsx
+++ b/web/src/components/ClusterCard.test.tsx
@@ -44,7 +44,7 @@ describe('ClusterCard', () => {
     const { container } = renderCard(summary)
     const dot = container.querySelector('.cluster-card__health-dot')
     expect(dot).toHaveClass('cluster-card__health-dot--degraded')
-    expect(screen.getByText('2 degraded')).toBeInTheDocument()
+    expect(screen.getAllByText('2 degraded').length).toBeGreaterThanOrEqual(1)
   })
 
   it('shows gray health for unreachable cluster', () => {
@@ -62,7 +62,7 @@ describe('ClusterCard', () => {
     const { container } = renderCard(summary)
     const dot = container.querySelector('.cluster-card__health-dot')
     expect(dot).toHaveClass('cluster-card__health-dot--unreachable')
-    expect(screen.getByText('Unreachable')).toBeInTheDocument()
+    expect(screen.getAllByText('Unreachable').length).toBeGreaterThanOrEqual(1)
   })
 
   it('calls onSwitch with context name when clicked', () => {
@@ -94,6 +94,6 @@ describe('ClusterCard', () => {
       rgdKinds: [],
     }
     renderCard(summary)
-    expect(screen.getByText('kro not installed')).toBeInTheDocument()
+    expect(screen.getAllByText('kro not installed').length).toBeGreaterThanOrEqual(1)
   })
 })

--- a/web/src/components/ClusterCard.tsx
+++ b/web/src/components/ClusterCard.tsx
@@ -37,11 +37,15 @@ export default function ClusterCard({ summary, onSwitch }: ClusterCardProps) {
             <span className="cluster-card__cluster">{cluster}</span>
           )}
         </div>
-        <span
-          className={`cluster-card__health-dot cluster-card__health-dot--${health}`}
-          aria-label={`Health: ${health}`}
-          title={healthLabel(health, degradedInstances)}
-        />
+        <div className="cluster-card__health">
+          <span
+            className={`cluster-card__health-dot cluster-card__health-dot--${health}`}
+            aria-hidden="true"
+          />
+          <span className="cluster-card__health-label">
+            {healthLabel(health, degradedInstances)}
+          </span>
+        </div>
       </div>
 
       <div className="cluster-card__body">

--- a/web/src/components/CollectionPanel.test.tsx
+++ b/web/src/components/CollectionPanel.test.tsx
@@ -195,7 +195,7 @@ describe('CollectionPanel', () => {
     )
 
     expect(screen.getByTestId('collection-empty-state')).toBeInTheDocument()
-    expect(screen.getByTestId('collection-empty-state')).toHaveTextContent('0 resources')
+    expect(screen.getByTestId('collection-empty-state')).toHaveTextContent('forEach expression evaluated to an empty list')
   })
 
   it('calls onClose when close button is clicked', () => {
@@ -280,7 +280,7 @@ describe('CollectionPanel', () => {
     )
 
     // All children have no kro.run/node-id label → legacy notice is shown
-    expect(screen.getByText('Legacy collection — labels unavailable')).toBeInTheDocument()
+    expect(screen.getByText(/Legacy collection — labels unavailable/)).toBeInTheDocument()
   })
 
   it('shows index, name, kind, status, age columns in table', () => {

--- a/web/src/components/CollectionPanel.tsx
+++ b/web/src/components/CollectionPanel.tsx
@@ -11,6 +11,7 @@ import type { K8sObject } from '@/lib/api'
 import { getResource } from '@/lib/api'
 import { formatAge } from '@/lib/format'
 import { toYaml } from '@/lib/yaml'
+import { translateApiError } from '@/lib/errors'
 import KroCodeBlock from './KroCodeBlock'
 import './CollectionPanel.css'
 
@@ -260,7 +261,18 @@ function ItemYamlView({ item, namespace, onBack }: ItemYamlViewProps) {
           </button>
         </div>
       ) : (
-        <div className="collection-yaml-error">Error: {viewState.message}</div>
+        <div className="collection-yaml-error" role="alert">
+          <div className="collection-yaml-error-msg">
+            {translateApiError(viewState.message ?? '')}
+          </div>
+          <button
+            type="button"
+            className="collection-yaml-retry-btn"
+            onClick={handleRetry}
+          >
+            Retry
+          </button>
+        </div>
       )}
     </div>
   )
@@ -400,14 +412,14 @@ export default function CollectionPanel({
           /* Legacy: kro < 0.8.0 — no kro.run/node-id labels */
           <div className="collection-legacy-notice">
             <span className="collection-legacy-icon" aria-hidden="true">⚠</span>
-            <span>Legacy collection — labels unavailable</span>
+            <span>Legacy collection — labels unavailable. kro &lt; 0.8.0 lacks <code>kro.run/node-id</code> labels — upgrade kro to enable collection drill-down.</span>
           </div>
         ) : items.length === 0 ? (
           <div
             data-testid="collection-empty-state"
             className="collection-empty-state"
           >
-            Empty collection — 0 resources
+            Empty collection. The forEach expression evaluated to an empty list. Check the forEach CEL expression above.
           </div>
         ) : (
           <div className="collection-table-wrapper">

--- a/web/src/components/ConditionsPanel.tsx
+++ b/web/src/components/ConditionsPanel.tsx
@@ -10,7 +10,7 @@
 // isHealthyCondition() lives in @/lib/conditions and is reused here and in ErrorsTab.
 
 import type { K8sObject } from '@/lib/api'
-import { isHealthyCondition } from '@/lib/conditions'
+import { isHealthyCondition, conditionStatusLabel } from '@/lib/conditions'
 import './ConditionsPanel.css'
 
 interface ConditionsPanelProps {
@@ -93,7 +93,7 @@ export default function ConditionsPanel({ instance }: ConditionsPanelProps) {
             <div className="condition-header">
               <span className="condition-type">{c.type}</span>
               <span className={`condition-status ${statusClass(c.type, c.status)}`}>
-                {c.status}
+                {conditionStatusLabel(c.type, c.status)}
               </span>
               {c.reason && c.reason !== '' && (
                 <span className="condition-reason">{c.reason}</span>

--- a/web/src/components/DeepDAG.css
+++ b/web/src/components/DeepDAG.css
@@ -100,3 +100,31 @@
   text-anchor: middle;
   pointer-events: none;
 }
+
+/* Deep DAG nested error — message + retry (M-8) */
+.deep-dag-nested-error {
+  flex-direction: column;
+  gap: 8px;
+  height: auto;
+  min-height: 60px;
+}
+
+.deep-dag-nested-error-msg {
+  color: var(--color-status-error);
+  font-size: 12px;
+}
+
+.deep-dag-nested-retry-btn {
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 3px 10px;
+  font-size: 11px;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+
+.deep-dag-nested-retry-btn:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary-text);
+}

--- a/web/src/components/DeepDAG.tsx
+++ b/web/src/components/DeepDAG.tsx
@@ -23,6 +23,7 @@ import CollectionBadge from './CollectionBadge'
 import ExpandableNode from './ExpandableNode'
 import type { ExpandedNodeData } from './ExpandableNode'
 import DAGTooltip from './DAGTooltip'
+import DAGLegend from './DAGLegend'
 import type { DAGTooltipTarget } from './DAGTooltip'
 import './LiveDAG.css'
 import './DeepDAG.css'
@@ -517,6 +518,7 @@ export default function DeepDAG({
         onTooltipMouseEnter={cancelTooltipHide}
         onTooltipMouseLeave={scheduleTooltipHide}
       />
+      <DAGLegend />
     </div>
   )
 }

--- a/web/src/components/ErrorsTab.tsx
+++ b/web/src/components/ErrorsTab.tsx
@@ -16,6 +16,7 @@ import { Link } from 'react-router-dom'
 import { listInstances } from '@/lib/api'
 import type { K8sObject } from '@/lib/api'
 import { rewriteConditionMessage, isHealthyCondition } from '@/lib/conditions'
+import { translateApiError } from '@/lib/errors'
 import './ErrorsTab.css'
 
 // ── Internal types ────────────────────────────────────────────────────────
@@ -223,7 +224,9 @@ export default function ErrorsTab({ rgdName, namespace }: ErrorsTabProps) {
       {/* API error */}
       {!loading && error && (
         <div className="errors-tab__api-error" role="alert" data-testid="errors-api-error">
-          <span className="errors-tab__api-error-msg">Error: {error}</span>
+          <span className="errors-tab__api-error-msg">
+            {translateApiError(error, { tab: 'validation' })}
+          </span>
           <button
             type="button"
             className="errors-tab__retry-btn"
@@ -238,7 +241,8 @@ export default function ErrorsTab({ rgdName, namespace }: ErrorsTabProps) {
       {/* No instances yet */}
       {!loading && !error && instances !== null && instances.length === 0 && (
         <div className="errors-tab__empty" data-testid="errors-empty">
-          No instances yet. Create one with <code>kubectl apply</code>.
+          No instances yet. Create one with <code>kubectl apply</code> or use the{' '}
+          <Link to={{ search: '?tab=generate' }}>Generate tab</Link>.
         </div>
       )}
 

--- a/web/src/components/EventsPanel.tsx
+++ b/web/src/components/EventsPanel.tsx
@@ -10,6 +10,8 @@ import './EventsPanel.css'
 
 interface EventsPanelProps {
   events: K8sList | null
+  /** Instance namespace — used in the "No events" help text's kubectl command. */
+  namespace?: string
 }
 
 interface K8sEvent {
@@ -57,18 +59,25 @@ function typeClass(type: string | undefined): string {
  *
  * Spec: .specify/specs/005-instance-detail-live/ US3 acceptance 3-4
  */
-export default function EventsPanel({ events }: EventsPanelProps) {
+export default function EventsPanel({ events, namespace }: EventsPanelProps) {
   const items: K8sEvent[] = events?.items
     ? [...events.items as K8sEvent[]].sort(
         (a, b) => getEventTimestamp(b) - getEventTimestamp(a),
       )
     : []
 
+  const kubectlCmd = namespace
+    ? `kubectl get events -n ${namespace}`
+    : 'kubectl get events'
+
   return (
     <div data-testid="events-panel" className="events-panel">
       <div className="panel-heading">Events</div>
       {items.length === 0 ? (
-        <div className="panel-empty">No events.</div>
+        <div className="panel-empty" data-testid="events-panel-empty">
+          No events found. Kubernetes events expire after ~1 hour —{' '}
+          run <code>{kubectlCmd}</code> to check for recent activity.
+        </div>
       ) : (
         <div className="events-list">
           {items.map((ev, i) => {
@@ -80,7 +89,10 @@ export default function EventsPanel({ events }: EventsPanelProps) {
               <div key={key} className={`event-row${isDeletion ? ' event-row--deletion' : ''}`}>
                 <div className="event-header">
                   {isDeletion && (
-                    <span className="event-deletion-tag" aria-label="deletion event">⊘</span>
+                    <span className="event-deletion-tag" aria-label="deletion event">
+                      <span aria-hidden="true">⊘</span>
+                      {' '}Deletion
+                    </span>
                   )}
                   {ev.type && (
                     <span className={`event-type ${typeClass(ev.type)}`}>

--- a/web/src/components/ExpandableNode.tsx
+++ b/web/src/components/ExpandableNode.tsx
@@ -11,6 +11,7 @@
 import type { ReactNode } from 'react'
 import type { DAGNode } from '@/lib/dag'
 import type { NodeLiveState } from '@/lib/instanceNodeState'
+import { translateApiError } from '@/lib/errors'
 import './DeepDAG.css'
 
 // ── Nested subgraph data ────────────────────────────────────────────────────
@@ -213,7 +214,7 @@ export default function ExpandableNode({
           data-testid={`deep-dag-maxdepth-${node.id}`}
           aria-label="Max depth reached"
         >
-          ⋯
+          ⋯ (max depth)
         </text>
       )}
 
@@ -252,7 +253,20 @@ export default function ExpandableNode({
                 data-testid={`deep-dag-error-${node.id}`}
                 role="alert"
               >
-                {childError}
+                <div className="deep-dag-nested-error-msg">
+                  {translateApiError(childError)}
+                </div>
+                <button
+                  type="button"
+                  className="deep-dag-nested-retry-btn"
+                  onClick={() => {
+                    // Re-trigger load by toggling off then on
+                    onToggle()
+                    setTimeout(() => onToggle(), 0)
+                  }}
+                >
+                  Retry
+                </button>
               </div>
             )}
 

--- a/web/src/components/FleetMatrix.css
+++ b/web/src/components/FleetMatrix.css
@@ -100,3 +100,21 @@
   font-size: 14px;
   line-height: 1;
 }
+
+/* Fleet matrix legend (M-16, L-19) */
+.fleet-matrix__legend {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 8px 0;
+  font-size: 11px;
+  color: var(--color-text-muted);
+  border-bottom: 1px solid var(--color-border-subtle);
+  margin-bottom: 4px;
+}
+
+.fleet-matrix__legend-entry {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}

--- a/web/src/components/FleetMatrix.tsx
+++ b/web/src/components/FleetMatrix.tsx
@@ -1,5 +1,6 @@
 import type { ClusterSummary } from '@/lib/api'
 import { abbreviateContext } from '@/lib/format'
+import { Link } from 'react-router-dom'
 import './FleetMatrix.css'
 
 // RGDPresence represents a single cell in the matrix.
@@ -43,14 +44,32 @@ export default function FleetMatrix({ clusters, rgdsByContext }: FleetMatrixProp
 
   if (kinds.length === 0) {
     return (
-      <div className="fleet-matrix fleet-matrix--empty">
-        <span className="fleet-matrix__empty-text">No RGDs found across any cluster.</span>
+      <div className="fleet-matrix fleet-matrix--empty" data-testid="fleet-matrix-empty">
+        <span className="fleet-matrix__empty-text">
+          No ResourceGraphDefinitions found. Apply an RGD to any connected cluster to see it here.
+        </span>
+        {' '}
+        <Link to="/author">Create your first RGD →</Link>
       </div>
     )
   }
 
   return (
     <div className="fleet-matrix" role="region" aria-label="RGD presence matrix">
+      <div className="fleet-matrix__legend" aria-label="Matrix legend">
+        <span className="fleet-matrix__legend-entry">
+          <span className="fleet-matrix__dot fleet-matrix__dot--present" aria-hidden="true" />
+          Present
+        </span>
+        <span className="fleet-matrix__legend-entry">
+          <span className="fleet-matrix__dot fleet-matrix__dot--degraded" aria-hidden="true" />
+          Degraded
+        </span>
+        <span className="fleet-matrix__legend-entry">
+          <span className="fleet-matrix__absent-dash" aria-hidden="true">–</span>
+          Absent
+        </span>
+      </div>
       <div className="fleet-matrix__scroll">
         <table className="fleet-matrix__table">
           <thead>

--- a/web/src/components/InstanceOverlayBar.tsx
+++ b/web/src/components/InstanceOverlayBar.tsx
@@ -19,6 +19,7 @@ import { Link } from 'react-router-dom'
 import type { K8sObject } from '@/lib/api'
 import { extractInstanceHealth } from '@/lib/format'
 import type { InstanceHealthState } from '@/lib/format'
+import { translateApiError } from '@/lib/errors'
 import './InstanceOverlayBar.css'
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -38,6 +39,11 @@ export interface InstanceOverlayBarProps {
   pickerLoading: boolean
   /** Non-null when picker fetch failed. */
   pickerError: string | null
+  /**
+   * Whether the RGD is in a Ready state. When false, picker errors will hint
+   * that the CRD may not be provisioned yet instead of a generic connectivity error.
+   */
+  rgdReady?: boolean
   /** Currently selected overlay key "<namespace>/<name>", or null for "No overlay". */
   selected: string | null
   /** Raw instance K8sObject for the selected overlay — drives the summary bar. */
@@ -77,6 +83,7 @@ export default function InstanceOverlayBar({
   items,
   pickerLoading,
   pickerError,
+  rgdReady,
   selected,
   overlayInstance,
   overlayLoading,
@@ -94,9 +101,12 @@ export default function InstanceOverlayBar({
       <span className="instance-overlay-bar__loading">Loading instances…</span>
     )
   } else if (pickerError) {
+    const pickerMsg = rgdReady === false
+      ? 'Could not load instance list — the RGD CRD may not be provisioned yet'
+      : 'Could not load instance list — check cluster connectivity'
     pickerContent = (
-      <span className="instance-overlay-bar__error">
-        <span>Could not load instances: {pickerError}</span>
+      <span className="instance-overlay-bar__error" role="alert" data-testid="overlay-picker-error">
+        <span>{pickerMsg}</span>
         <button
           type="button"
           className="instance-overlay-bar__retry-btn"
@@ -111,6 +121,10 @@ export default function InstanceOverlayBar({
       <span className="instance-overlay-bar__empty">
         No instances — create one with{' '}
         <code className="instance-overlay-bar__code">kubectl apply</code>
+        {' '}or use the{' '}
+        <Link to={{ search: '?tab=generate' }} className="instance-overlay-bar__generate-link">
+          Generate tab
+        </Link>
       </span>
     )
   } else {
@@ -165,9 +179,16 @@ export default function InstanceOverlayBar({
         </div>
       )
     } else if (overlayError) {
+      const overlayMsg = (overlayError.includes('404') || overlayError.toLowerCase().includes('not found'))
+        ? 'Instance not found — it may have been deleted'
+        : translateApiError(overlayError)
       summaryContent = (
-        <div className="instance-overlay-bar__overlay-status instance-overlay-bar__overlay-status--error">
-          <span>Overlay failed: {overlayError}</span>
+        <div
+          className="instance-overlay-bar__overlay-status instance-overlay-bar__overlay-status--error"
+          role="alert"
+          data-testid="overlay-data-error"
+        >
+          <span>{overlayMsg}</span>
           <button
             type="button"
             className="instance-overlay-bar__retry-btn"

--- a/web/src/components/LiveDAG.css
+++ b/web/src/components/LiveDAG.css
@@ -204,3 +204,32 @@
 .dag-tooltip__state--error       { color: var(--color-error); }
 .dag-tooltip__state--pending     { color: var(--color-pending); }
 .dag-tooltip__state--notfound    { color: var(--color-text-faint); }
+
+/* Live-state legend (L-2, issue #167) */
+.live-dag-state-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  padding: 4px 0 0;
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
+
+.live-dag-state-legend__entry {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.live-dag-state-legend__dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.live-dag-state-legend__dot--alive       { background: var(--color-alive); }
+.live-dag-state-legend__dot--reconciling { background: var(--color-reconciling); }
+.live-dag-state-legend__dot--pending     { background: var(--color-pending); }
+.live-dag-state-legend__dot--error       { background: var(--color-error); }
+.live-dag-state-legend__dot--notfound    { background: var(--color-not-found); }

--- a/web/src/components/LiveDAG.tsx
+++ b/web/src/components/LiveDAG.tsx
@@ -15,6 +15,7 @@ import type { NodeStateMap, NodeLiveState } from '@/lib/instanceNodeState'
 import type { K8sObject } from '@/lib/api'
 import CollectionBadge from './CollectionBadge'
 import DAGTooltip from './DAGTooltip'
+import DAGLegend from './DAGLegend'
 import type { DAGTooltipTarget } from './DAGTooltip'
 import './LiveDAG.css'
 
@@ -306,6 +307,33 @@ export default function LiveDAG({
         onTooltipMouseEnter={cancelTooltipHide}
         onTooltipMouseLeave={scheduleTooltipHide}
       />
+
+      {/* Node-type badge legend (L-1) */}
+      <DAGLegend />
+
+      {/* Live-state legend (L-2, issue #167) */}
+      <div className="live-dag-state-legend" aria-label="Live node state legend">
+        <span className="live-dag-state-legend__entry">
+          <span className="live-dag-state-legend__dot live-dag-state-legend__dot--alive" aria-hidden="true" />
+          Alive
+        </span>
+        <span className="live-dag-state-legend__entry">
+          <span className="live-dag-state-legend__dot live-dag-state-legend__dot--reconciling" aria-hidden="true" />
+          Reconciling
+        </span>
+        <span className="live-dag-state-legend__entry">
+          <span className="live-dag-state-legend__dot live-dag-state-legend__dot--pending" aria-hidden="true" />
+          Pending
+        </span>
+        <span className="live-dag-state-legend__entry">
+          <span className="live-dag-state-legend__dot live-dag-state-legend__dot--error" aria-hidden="true" />
+          Error
+        </span>
+        <span className="live-dag-state-legend__entry">
+          <span className="live-dag-state-legend__dot live-dag-state-legend__dot--notfound" aria-hidden="true" />
+          Not found
+        </span>
+      </div>
     </div>
   )
 }

--- a/web/src/components/LiveNodeDetailPanel.tsx
+++ b/web/src/components/LiveNodeDetailPanel.tsx
@@ -18,6 +18,7 @@ import type { K8sObject } from '@/lib/api'
 import { getResource } from '@/lib/api'
 import { toYaml } from '@/lib/yaml'
 import { isTerminating, getDeletionTimestamp, getFinalizers, formatRelativeTime } from '@/lib/k8s'
+import { translateApiError } from '@/lib/errors'
 import KroCodeBlock from './KroCodeBlock'
 import FinalizersPanel from './FinalizersPanel'
 import './LiveNodeDetailPanel.css'
@@ -185,7 +186,18 @@ function YamlSection({ nodeId, resourceInfo, onRawObj }: YamlSectionProps) {
           </button>
         </div>
       ) : (
-        <div className="node-yaml-error">Error: {yamlState.message}</div>
+        <div className="node-yaml-error" role="alert">
+          <div className="node-yaml-error-msg">
+            {translateApiError(yamlState.message ?? '')}
+          </div>
+          <button
+            type="button"
+            className="node-yaml-retry-btn"
+            onClick={handleRetry}
+          >
+            Retry
+          </button>
+        </div>
       )}
     </div>
   )

--- a/web/src/components/MetricsStrip.test.tsx
+++ b/web/src/components/MetricsStrip.test.tsx
@@ -83,9 +83,9 @@ describe('MetricsStrip', () => {
     const { container } = render(<MetricsStrip />)
 
     // The degraded message now includes actionable context (issue #97).
-    // "connection refused" → default branch → "--metrics-url" hint.
+    // "connection refused" → "kro controller pod not found in this cluster" (L-11 fix).
     expect(screen.getByText(/Controller metrics unavailable/)).toBeInTheDocument()
-    expect(screen.getByText(/--metrics-url/)).toBeInTheDocument()
+    expect(screen.getByText(/kro controller pod not found/)).toBeInTheDocument()
     expect(container.querySelectorAll('.metrics-strip__cell').length).toBe(0)
   })
 

--- a/web/src/components/MetricsStrip.tsx
+++ b/web/src/components/MetricsStrip.tsx
@@ -80,8 +80,8 @@ export default function MetricsStrip() {
       // Endpoint reachable but kro isn't exposing /metrics on that port yet
       detail = 'metrics endpoint returned 503 — check that kro is exposing /metrics'
     } else if (errMsg.toLowerCase().includes('connection refused') || errMsg.toLowerCase().includes('unreachable')) {
-      // Network/DNS failure — likely --metrics-url not set or wrong address
-      detail = 'start kro-ui with --metrics-url to enable'
+      // Network/DNS failure — kro controller pod not found or not reachable
+      detail = 'kro controller pod not found in this cluster'
     } else {
       detail = 'metrics endpoint unavailable'
     }

--- a/web/src/components/SpecPanel.tsx
+++ b/web/src/components/SpecPanel.tsx
@@ -5,6 +5,7 @@
 // Issue #122: empty-string values render as em-dash (§XII graceful degradation).
 
 import type { K8sObject } from '@/lib/api'
+import { Link } from 'react-router-dom'
 import './SpecPanel.css'
 
 interface SpecPanelProps {
@@ -38,7 +39,11 @@ export default function SpecPanel({ instance }: SpecPanelProps) {
     <div data-testid="spec-panel" className="spec-panel">
       <div className="panel-heading">Spec</div>
       {fields.length === 0 ? (
-        <div className="panel-empty">No spec fields.</div>
+        <div className="panel-empty">
+          No spec fields defined. Check the RGD&apos;s{' '}
+          <Link to="?tab=docs">Docs tab</Link>{' '}
+          to see the schema.
+        </div>
       ) : (
         <table className="spec-table">
           <tbody>

--- a/web/src/components/StaticChainDAG.tsx
+++ b/web/src/components/StaticChainDAG.tsx
@@ -178,7 +178,9 @@ function NestedSubgraph({
         <div className="static-chain-nested-header">
           <span className="static-chain-nested-header-kind">{node.kind}</span>
         </div>
-        <div className="static-chain-not-found">RGD not found</div>
+        <div className="static-chain-not-found" role="alert" data-testid="static-chain-not-found">
+          Chained RGD &apos;{chainedName}&apos; not found in this cluster — it may have been deleted or not yet applied.
+        </div>
       </div>
     )
   }
@@ -500,7 +502,7 @@ export default function StaticChainDAG({
                     data-testid={`static-chain-maxdepth-${node.id}`}
                     aria-label="Max depth reached"
                   >
-                    ⋯
+                    ⋯ (max depth)
                   </text>
                 )}
 
@@ -513,7 +515,7 @@ export default function StaticChainDAG({
                     data-testid={`static-chain-cycle-${node.id}`}
                     aria-label="Cycle detected"
                   >
-                    ⊗
+                    ⊗ (cycle)
                   </text>
                 )}
 

--- a/web/src/lib/conditions.test.ts
+++ b/web/src/lib/conditions.test.ts
@@ -18,7 +18,7 @@
 // Issue: https://github.com/pnz1990/kro-ui/issues/171
 
 import { describe, it, expect } from 'vitest'
-import { isHealthyCondition, NEGATION_POLARITY_CONDITIONS } from './conditions'
+import { isHealthyCondition, NEGATION_POLARITY_CONDITIONS, conditionStatusLabel } from './conditions'
 
 describe('NEGATION_POLARITY_CONDITIONS', () => {
   it('contains ReconciliationSuspended', () => {
@@ -77,5 +77,49 @@ describe('isHealthyCondition', () => {
 
   it('returns false for an empty status string', () => {
     expect(isHealthyCondition('Ready', '')).toBe(false)
+  })
+})
+
+describe('conditionStatusLabel', () => {
+  // ── Normal-polarity conditions ─────────────────────────────────────────
+
+  it('maps True → Healthy for normal-polarity condition', () => {
+    expect(conditionStatusLabel('Ready', 'True')).toBe('Healthy')
+  })
+
+  it('maps False → Failed for normal-polarity condition', () => {
+    expect(conditionStatusLabel('Ready', 'False')).toBe('Failed')
+  })
+
+  it('maps Unknown → Pending for normal-polarity condition', () => {
+    expect(conditionStatusLabel('Ready', 'Unknown')).toBe('Pending')
+  })
+
+  it('maps True → Healthy for another normal-polarity condition (GraphVerified)', () => {
+    expect(conditionStatusLabel('GraphVerified', 'True')).toBe('Healthy')
+  })
+
+  // ── Negation-polarity conditions ───────────────────────────────────────
+
+  it('maps False → Healthy for ReconciliationSuspended (negation polarity)', () => {
+    expect(conditionStatusLabel('ReconciliationSuspended', 'False')).toBe('Healthy')
+  })
+
+  it('maps True → Failed for ReconciliationSuspended (negation polarity)', () => {
+    expect(conditionStatusLabel('ReconciliationSuspended', 'True')).toBe('Failed')
+  })
+
+  it('maps Unknown → Pending for ReconciliationSuspended (negation polarity)', () => {
+    expect(conditionStatusLabel('ReconciliationSuspended', 'Unknown')).toBe('Pending')
+  })
+
+  // ── Unknown input passthrough ──────────────────────────────────────────
+
+  it('returns raw status string when status is not True/False/Unknown', () => {
+    expect(conditionStatusLabel('Ready', 'SomeOtherValue')).toBe('SomeOtherValue')
+  })
+
+  it('returns empty string unchanged', () => {
+    expect(conditionStatusLabel('Ready', '')).toBe('')
   })
 })

--- a/web/src/lib/conditions.ts
+++ b/web/src/lib/conditions.ts
@@ -111,3 +111,32 @@ export function rewriteConditionMessage(reason: string | undefined, message: str
 
   return null // no known pattern — show raw
 }
+
+/**
+ * conditionStatusLabel — translates a raw Kubernetes condition status string
+ * ("True" | "False" | "Unknown") to a user-readable display label.
+ *
+ * For normal-polarity conditions:
+ *   "True"    → "Healthy"
+ *   "False"   → "Failed"
+ *   "Unknown" → "Pending"
+ *
+ * For negation-polarity conditions (NEGATION_POLARITY_CONDITIONS):
+ *   "True"    → "Failed"   (e.g. ReconciliationSuspended=True → reconciliation off → bad)
+ *   "False"   → "Healthy"  (e.g. ReconciliationSuspended=False → reconciliation running → good)
+ *   "Unknown" → "Pending"
+ *
+ * Returns the raw status string as-is for any other input (defensive fallback).
+ *
+ * Spec: .specify/specs/041-error-states-ux-audit/spec.md FR-031 (L-10)
+ * Issue: #187
+ */
+export function conditionStatusLabel(type: string, status: string): string {
+  const inverted = NEGATION_POLARITY_CONDITIONS.has(type)
+  switch (status) {
+    case 'True':    return inverted ? 'Failed'  : 'Healthy'
+    case 'False':   return inverted ? 'Healthy' : 'Failed'
+    case 'Unknown': return 'Pending'
+    default:        return status
+  }
+}

--- a/web/src/lib/errors.test.ts
+++ b/web/src/lib/errors.test.ts
@@ -1,0 +1,200 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest'
+import { translateApiError } from './errors'
+
+describe('translateApiError', () => {
+  // ── Pattern 1: resource not found ───────────────────────────────────────
+  describe('pattern 1 — server could not find the requested resource', () => {
+    it('translates exact phrase', () => {
+      const result = translateApiError('the server could not find the requested resource')
+      expect(result).toContain('CRD may not be provisioned')
+      expect(result).not.toContain('the server could not find')
+    })
+
+    it('translates phrase embedded in a longer string', () => {
+      const result = translateApiError(
+        'Get "https://127.0.0.1:6443/apis/kro.run/v1alpha1/widgets": the server could not find the requested resource'
+      )
+      expect(result).toContain('CRD may not be provisioned')
+    })
+
+    it('strengthens message when rgdReady is false', () => {
+      const result = translateApiError(
+        'the server could not find the requested resource',
+        { rgdReady: false }
+      )
+      expect(result).toContain("RGD's CRD has not been provisioned yet")
+      expect(result).toContain("Validation tab")
+    })
+
+    it('uses generic wording when rgdReady is undefined', () => {
+      const result = translateApiError('the server could not find the requested resource')
+      expect(result).toContain("API server doesn't recognise")
+    })
+
+    it('uses generic wording when rgdReady is true', () => {
+      const result = translateApiError(
+        'the server could not find the requested resource',
+        { rgdReady: true }
+      )
+      expect(result).toContain("API server doesn't recognise")
+    })
+  })
+
+  // ── Pattern 2: no kind registered ───────────────────────────────────────
+  describe('pattern 2 — no kind registered', () => {
+    it('extracts kind name from error string', () => {
+      const result = translateApiError('no kind "Widget" is registered')
+      expect(result).toContain("'Widget'")
+      expect(result).not.toContain('"Widget"')
+    })
+
+    it('is case-insensitive', () => {
+      const result = translateApiError('No Kind "Widget" Is Registered')
+      expect(result).toContain("'Widget'")
+    })
+
+    it('strengthens message when rgdReady is false', () => {
+      const result = translateApiError('no kind "Widget" is registered', { rgdReady: false })
+      expect(result).toContain("CRD hasn't been created yet")
+      expect(result).toContain("Validation tab")
+    })
+
+    it('handles error string without extractable kind', () => {
+      // If the regex fails to extract, message still translates (no crash)
+      const result = translateApiError('no kind is registered')
+      // pattern 2 regex won't match (no quotes) — falls through to no-match passthrough
+      expect(result).toBe('no kind is registered')
+    })
+  })
+
+  // ── Pattern 3: HTTP 403 / forbidden ─────────────────────────────────────
+  describe('pattern 3 — 403 / forbidden', () => {
+    it('matches "HTTP 403" prefix', () => {
+      const result = translateApiError('HTTP 403')
+      expect(result).toContain('Permission denied')
+      expect(result).toContain('Access tab')
+    })
+
+    it('matches lowercase "forbidden"', () => {
+      const result = translateApiError('forbidden: User "system:serviceaccount:kro/kro" cannot list')
+      expect(result).toContain('Permission denied')
+    })
+
+    it('matches mixed-case "Forbidden"', () => {
+      const result = translateApiError('403 Forbidden')
+      expect(result).toContain('Permission denied')
+    })
+  })
+
+  // ── Pattern 4: HTTP 401 / Unauthorized ──────────────────────────────────
+  describe('pattern 4 — 401 / Unauthorized', () => {
+    it('matches "HTTP 401"', () => {
+      const result = translateApiError('HTTP 401')
+      expect(result).toContain('Not authenticated')
+      expect(result).toContain('credentials')
+    })
+
+    it('matches "Unauthorized"', () => {
+      const result = translateApiError('Unauthorized')
+      expect(result).toContain('Not authenticated')
+    })
+
+    it('matches lowercase "unauthorized"', () => {
+      const result = translateApiError('unauthorized: token has expired')
+      expect(result).toContain('Not authenticated')
+    })
+  })
+
+  // ── Pattern 5: connection refused / dial tcp / 503 ───────────────────────
+  describe('pattern 5 — API server unreachable', () => {
+    it('matches "connection refused"', () => {
+      const result = translateApiError('dial tcp 127.0.0.1:6443: connect: connection refused')
+      expect(result).toContain('Cannot reach the Kubernetes API server')
+    })
+
+    it('matches "dial tcp" prefix', () => {
+      const result = translateApiError('dial tcp: lookup kubernetes.default: no such host')
+      expect(result).toContain('Cannot reach the Kubernetes API server')
+    })
+
+    it('matches HTTP 503', () => {
+      const result = translateApiError('HTTP 503')
+      expect(result).toContain('Cannot reach the Kubernetes API server')
+    })
+  })
+
+  // ── Pattern 6: context deadline exceeded ─────────────────────────────────
+  describe('pattern 6 — timeout', () => {
+    it('matches "context deadline exceeded"', () => {
+      const result = translateApiError('context deadline exceeded')
+      expect(result).toContain('timed out')
+    })
+
+    it('matches phrase embedded in longer string', () => {
+      const result = translateApiError(
+        'Get "https://127.0.0.1:6443/api/v1/namespaces": context deadline exceeded (Client.Timeout exceeded)'
+      )
+      expect(result).toContain('timed out')
+    })
+  })
+
+  // ── Pattern 7: TLS / x509 ────────────────────────────────────────────────
+  describe('pattern 7 — TLS certificate error', () => {
+    it('matches "x509: certificate"', () => {
+      const result = translateApiError('x509: certificate signed by unknown authority')
+      expect(result).toContain('TLS certificate error')
+    })
+
+    it('matches "x509" anywhere in string', () => {
+      const result = translateApiError('tls: failed to verify certificate: x509: expired cert')
+      expect(result).toContain('TLS certificate error')
+    })
+  })
+
+  // ── No-match passthrough ──────────────────────────────────────────────────
+  describe('no-match passthrough', () => {
+    it('returns original message when no pattern matches', () => {
+      const msg = 'resource quota exceeded'
+      expect(translateApiError(msg)).toBe(msg)
+    })
+
+    it('returns original for an unknown HTTP status', () => {
+      const msg = 'HTTP 409 Conflict'
+      expect(translateApiError(msg)).toBe(msg)
+    })
+  })
+
+  // ── Edge cases ────────────────────────────────────────────────────────────
+  describe('edge cases', () => {
+    it('returns empty string unchanged', () => {
+      expect(translateApiError('')).toBe('')
+    })
+
+    it('returns whitespace-only string unchanged', () => {
+      expect(translateApiError('   ')).toBe('   ')
+    })
+
+    it('handles context object with only tab hint (no rgdReady)', () => {
+      const result = translateApiError(
+        'the server could not find the requested resource',
+        { tab: 'validation' }
+      )
+      // rgdReady is undefined → generic wording
+      expect(result).toContain("API server doesn't recognise")
+    })
+  })
+})

--- a/web/src/lib/errors.ts
+++ b/web/src/lib/errors.ts
@@ -1,0 +1,108 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// errors.ts — API error translation utility.
+//
+// Translates raw Go/Kubernetes API error strings into user-readable messages.
+// Called at render time (not in api.ts) so that components can pass context
+// (e.g. whether the RGD is Ready) to produce contextual messages.
+//
+// Spec: .specify/specs/041-error-states-ux-audit/spec.md FR-001
+// Issue: #187
+
+/**
+ * Context hints for translateApiError.
+ * All fields are optional — omit when the context is not available.
+ */
+export interface TranslateContext {
+  /**
+   * When false (RGD not Ready), prefer "CRD may not be provisioned yet" wording
+   * for resource-not-found / no-kind-registered errors.
+   * Undefined is treated the same as true (no RGD-readiness info available).
+   */
+  rgdReady?: boolean
+
+  /**
+   * Tab hint for contextual "check the X tab" suggestions.
+   * Values: "validation" | "access" | "yaml" | "generate" | "docs"
+   */
+  tab?: string
+}
+
+/**
+ * Translate a raw API error string into a user-readable message.
+ *
+ * Pattern matching order (first match wins):
+ *  1. "the server could not find the requested resource"  → CRD not provisioned
+ *  2. /no kind "X" is registered/i                       → Kind not registered
+ *  3. HTTP 403 / "forbidden"                             → Permission denied
+ *  4. HTTP 401 / "Unauthorized"                          → Not authenticated
+ *  5. "connection refused" / "dial tcp" / HTTP 503        → API server unreachable
+ *  6. "context deadline exceeded"                         → Request timed out
+ *  7. "x509: certificate"                                 → TLS certificate error
+ *
+ * Returns the original message unchanged when no pattern matches.
+ * Returns the original message unchanged when input is empty or whitespace-only.
+ */
+export function translateApiError(message: string, context?: TranslateContext): string {
+  if (!message || !message.trim()) return message
+
+  const m = message.toLowerCase()
+
+  // Pattern 1: resource not found / CRD not provisioned
+  if (m.includes('the server could not find the requested resource')) {
+    if (context?.rgdReady === false) {
+      return "The RGD's CRD has not been provisioned yet — instances can only be created once the RGD is Ready. Check the Validation tab."
+    }
+    return "The API server doesn't recognise this resource type — the CRD may not be provisioned yet. Check the Validation tab."
+  }
+
+  // Pattern 2: no kind registered (extract kind name)
+  const noKindMatch = message.match(/no kind "([^"]+)" is registered/i)
+  if (noKindMatch) {
+    const kind = noKindMatch[1]
+    if (context?.rgdReady === false) {
+      return `The kind '${kind}' is not registered — the RGD CRD hasn't been created yet. Check the Validation tab.`
+    }
+    return `The kind '${kind}' is not registered in this cluster — the RGD CRD hasn't been created yet.`
+  }
+
+  // Pattern 3: HTTP 403 / forbidden
+  if (m.includes('403') || m.includes('forbidden')) {
+    return "Permission denied — kro-ui's service account lacks access. Check the Access tab."
+  }
+
+  // Pattern 4: HTTP 401 / Unauthorized
+  if (m.includes('401') || m.includes('unauthorized')) {
+    return "Not authenticated — your kubeconfig credentials may have expired."
+  }
+
+  // Pattern 5: connection refused / dial tcp / HTTP 503
+  if (m.includes('connection refused') || m.includes('dial tcp') || m.includes('503')) {
+    return "Cannot reach the Kubernetes API server — check cluster connectivity."
+  }
+
+  // Pattern 6: context deadline exceeded
+  if (m.includes('context deadline exceeded')) {
+    return "Request timed out — the cluster may be under load. Try again."
+  }
+
+  // Pattern 7: TLS certificate error
+  if (m.includes('x509')) {
+    return "TLS certificate error — your kubeconfig certificate may be invalid or expired."
+  }
+
+  // No known pattern — return original so advanced operators see the raw message
+  return message
+}

--- a/web/src/pages/Catalog.test.tsx
+++ b/web/src/pages/Catalog.test.tsx
@@ -306,7 +306,7 @@ describe('Catalog', () => {
     renderCatalog()
 
     await waitFor(() => {
-      expect(screen.getByText('connection refused')).toBeInTheDocument()
+      expect(screen.getByText(/Cannot reach the Kubernetes API server/)).toBeInTheDocument()
     })
 
     expect(screen.getByText('Retry')).toBeInTheDocument()

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/lib/catalog'
 import type { SortOption } from '@/lib/catalog'
 import { useDebounce } from '@/hooks/useDebounce'
+import { translateApiError } from '@/lib/errors'
 import CatalogCard from '@/components/CatalogCard'
 import SearchBar from '@/components/SearchBar'
 import LabelFilter from '@/components/LabelFilter'
@@ -185,7 +186,7 @@ export default function Catalog() {
 
       {!isLoading && error !== null && (
         <div className="catalog__error" role="alert">
-          <p className="catalog__error-message">{error}</p>
+          <p className="catalog__error-message">{translateApiError(error)}</p>
           <button className="catalog__retry-btn" onClick={fetchRGDs}>
             Retry
           </button>
@@ -214,7 +215,14 @@ export default function Catalog() {
           }}
           emptyState={
             <div className="catalog__empty" data-testid="catalog-empty">
-              {items.length === 0 ? (
+              {hasFilters ? (
+                <>
+                  <p>No RGDs match your search.</p>
+                  <button className="catalog__clear-filters-btn" onClick={clearFilters}>
+                    Clear filters
+                  </button>
+                </>
+              ) : items.length === 0 ? (
                 <>
                   <p>No ResourceGraphDefinitions found in this cluster.</p>
                   <p className="catalog__empty-hint">
@@ -227,14 +235,7 @@ export default function Catalog() {
                   </p>
                 </>
               ) : (
-                <>
-                  <p>No RGDs match your search.</p>
-                  {hasFilters && (
-                    <button className="catalog__clear-filters-btn" onClick={clearFilters}>
-                      Clear filters
-                    </button>
-                  )}
-                </>
+                <p>No RGDs match your search.</p>
               )}
             </div>
           }

--- a/web/src/pages/Events.tsx
+++ b/web/src/pages/Events.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/lib/events'
 import type { KubeEvent } from '@/lib/events'
 import { usePageTitle } from '@/hooks/usePageTitle'
+import { translateApiError } from '@/lib/errors'
 import EventRow from '@/components/EventRow'
 import EventGroup from '@/components/EventGroup'
 import AnomalyBanner from '@/components/AnomalyBanner'
@@ -277,7 +278,10 @@ export default function Events() {
       {/* ── Error state ── */}
       {error && (
         <div className="events-page__error" role="alert" data-testid="events-error">
-          Failed to fetch events: {error}
+          <span>{translateApiError(error)}</span>
+          <button type="button" className="events-page__retry-btn" onClick={fetchAndMerge}>
+            Retry
+          </button>
         </div>
       )}
 

--- a/web/src/pages/Fleet.tsx
+++ b/web/src/pages/Fleet.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/lib/api'
 import type { ClusterSummary, ControllerMetrics } from '@/lib/api'
 import { usePageTitle } from '@/hooks/usePageTitle'
+import { translateApiError } from '@/lib/errors'
 import ClusterCard from '@/components/ClusterCard'
 import FleetMatrix from '@/components/FleetMatrix'
 import SkeletonCard from '@/components/SkeletonCard'
@@ -231,7 +232,7 @@ export default function Fleet() {
 
       {!isLoading && error !== null && (
         <div className="fleet__error" role="alert">
-          <p className="fleet__error-message">{error}</p>
+          <p className="fleet__error-message">{translateApiError(error)}</p>
           <button className="fleet__retry-btn" onClick={fetchFleet}>
             Retry
           </button>
@@ -239,8 +240,8 @@ export default function Fleet() {
       )}
 
       {!isLoading && error === null && deduped.length === 0 && (
-        <div className="fleet__empty">
-          <p>No kubeconfig contexts found.</p>
+        <div className="fleet__empty" data-testid="fleet-empty">
+          <p>No kubeconfig contexts found. Mount a kubeconfig file and restart kro-ui, or check that your <code>~/.kube/config</code> contains at least one context.</p>
         </div>
       )}
 

--- a/web/src/pages/Home.test.tsx
+++ b/web/src/pages/Home.test.tsx
@@ -83,7 +83,7 @@ describe('Home', () => {
     mockedListRGDs.mockRejectedValue(new Error('connection refused'))
     renderHome()
     await waitFor(() => {
-      expect(screen.getByText('connection refused')).toBeInTheDocument()
+      expect(screen.getByText(/Cannot reach the Kubernetes API server/)).toBeInTheDocument()
     })
     expect(screen.getByText('Retry')).toBeInTheDocument()
   })

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -12,6 +12,7 @@ import { matchesSearch } from '@/lib/catalog'
 import { isTerminating } from '@/lib/k8s'
 import { usePageTitle } from '@/hooks/usePageTitle'
 import { useDebounce } from '@/hooks/useDebounce'
+import { translateApiError } from '@/lib/errors'
 import MetricsStrip from '@/components/MetricsStrip'
 import RGDCard from '@/components/RGDCard'
 import SearchBar from '@/components/SearchBar'
@@ -176,7 +177,7 @@ export default function Home() {
 
       {!isLoading && error !== null && (
         <div className="home__error" role="alert">
-          <p className="home__error-message">{error}</p>
+          <p className="home__error-message">{translateApiError(error)}</p>
           <button className="home__retry-btn" onClick={fetchRGDs}>
             Retry
           </button>

--- a/web/src/pages/InstanceDetail.tsx
+++ b/web/src/pages/InstanceDetail.tsx
@@ -32,6 +32,7 @@ import { resolveChildResourceInfo } from '@/lib/resolveResourceName'
 import { extractInstanceHealth } from '@/lib/format'
 import { usePolling } from '@/hooks/usePolling'
 import { isTerminating, getDeletionTimestamp, getFinalizers } from '@/lib/k8s'
+import { translateApiError } from '@/lib/errors'
 import DeepDAG from '@/components/DeepDAG'
 import LiveNodeDetailPanel from '@/components/LiveNodeDetailPanel'
 import CollectionPanel from '@/components/CollectionPanel'
@@ -343,14 +344,19 @@ export default function InstanceDetail() {
       {/* Poll error (non-404) */}
       {pollError && !instanceGone && !pollLoading && (
         <div className="poll-error-banner" role="status">
-          Refresh paused — retrying in 10s
+          Refresh paused ({translateApiError(pollError)}) — retrying in 10s
         </div>
       )}
 
       {/* RGD error */}
       {rgdError && (
         <div className="instance-detail-error" role="alert">
-          Could not load RGD spec: {rgdError}
+          <p>{translateApiError(rgdError)} The RGD may have been deleted or renamed.</p>
+          {rgdName && (
+            <Link to={`/rgds/${rgdName}`} className="instance-detail-error__back-link">
+              ← Back to {rgdName}
+            </Link>
+          )}
         </div>
       )}
 
@@ -388,7 +394,13 @@ export default function InstanceDetail() {
                 />
               ) : (
                 <div className="instance-detail-dag-empty">
-                  No managed resources defined in this RGD.
+                  No managed resources defined in this RGD.{' '}
+                  {rgdName && (
+                    <Link to={`/rgds/${rgdName}`}>
+                      View the RGD&apos;s Graph tab
+                    </Link>
+                  )}{' '}
+                  to inspect the spec.
                 </div>
               )}
             </div>
@@ -401,7 +413,7 @@ export default function InstanceDetail() {
                 finalizers={getFinalizers(fastData.instance)}
                 defaultExpanded={isTerminating(fastData.instance)}
               />
-              <EventsPanel events={fastData.events} />
+              <EventsPanel events={fastData.events} namespace={namespace} />
             </div>
           </div>
         </>

--- a/web/src/pages/RGDDetail.css
+++ b/web/src/pages/RGDDetail.css
@@ -213,5 +213,58 @@
 
 .rgd-detail-error {
   padding: 32px;
-  color: var(--color-error);
+  color: var(--color-text);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.rgd-detail-error__msg {
+  color: var(--color-status-error);
+  font-size: 14px;
+}
+
+.rgd-detail-error__actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.rgd-detail-error__retry-btn {
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 6px 14px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.rgd-detail-error__retry-btn:hover {
+  background: var(--color-primary-hover);
+}
+
+.rgd-detail-error__back-link {
+  font-size: 13px;
+  color: var(--color-primary-text);
+}
+
+.rgd-graph-empty__tab-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--color-primary-text);
+  cursor: pointer;
+  font-size: inherit;
+  text-decoration: underline;
+}
+
+.rgd-instances-error__tab-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--color-primary-text);
+  cursor: pointer;
+  font-size: inherit;
+  text-decoration: underline;
 }

--- a/web/src/pages/RGDDetail.tsx
+++ b/web/src/pages/RGDDetail.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react"
 import { useParams, useSearchParams, useLocation, Link } from "react-router-dom"
 import { getRGD, listRGDs, listInstances, getInstance, getInstanceChildren } from "@/lib/api"
 import type { K8sObject, K8sList } from "@/lib/api"
+import { translateApiError } from "@/lib/errors"
 import { toYaml } from "@/lib/yaml"
 import { buildDAGGraph, detectCollapseGroups } from "@/lib/dag"
 import { extractRGDKind, extractReadyStatus } from "@/lib/format"
@@ -316,7 +317,37 @@ export default function RGDDetail() {
   }
 
   if (error) {
-    return <div className="rgd-detail-error">Error: {error}</div>
+    const retryLoad = () => {
+      if (!name) return
+      setLoading(true)
+      setError(null)
+      Promise.all([
+        getRGD(name),
+        listRGDs().catch(() => ({ metadata: {}, items: [] as K8sObject[] })),
+      ])
+        .then(([data, allRgds]) => {
+          setRgd(data)
+          setRgds(allRgds.items ?? [])
+          setRgdLastFetched(new Date())
+          setError(null)
+        })
+        .catch((err: Error) => {
+          setError(err.message)
+          setRgd(null)
+        })
+        .finally(() => setLoading(false))
+    }
+    return (
+      <div className="rgd-detail-error" role="alert" data-testid="rgd-detail-error">
+        <p className="rgd-detail-error__msg">{translateApiError(error)}</p>
+        <div className="rgd-detail-error__actions">
+          <button type="button" className="rgd-detail-error__retry-btn" onClick={retryLoad}>
+            Retry
+          </button>
+          <Link to="/" className="rgd-detail-error__back-link">← Back to Overview</Link>
+        </div>
+      </div>
+    )
   }
 
   if (!rgd) return null
@@ -448,6 +479,7 @@ export default function RGDDetail() {
                 items={pickerItems}
                 pickerLoading={pickerLoading}
                 pickerError={pickerError}
+                rgdReady={readyState.state !== 'error'}
                 selected={overlayKey}
                 overlayInstance={overlayInstance}
                 overlayLoading={overlayLoading}
@@ -467,7 +499,12 @@ export default function RGDDetail() {
                 />
               ) : (
                 <div className="rgd-graph-empty">
-                  No managed resources defined
+                  No managed resources defined in this RGD.{' '}
+                  Open the{' '}
+                  <button type="button" className="rgd-graph-empty__tab-link" onClick={() => setTab('yaml')}>YAML tab</button>
+                  {' '}to inspect the spec, or use the{' '}
+                  <button type="button" className="rgd-graph-empty__tab-link" onClick={() => setTab('generate')}>Generate tab</button>
+                  {' '}to scaffold a new resource.
                 </div>
               )}
               <OptimizationAdvisor
@@ -499,9 +536,23 @@ export default function RGDDetail() {
             )}
 
             {!instancesLoading && instancesError && (
-              <div className="rgd-instances-error" data-testid="instance-error-state">
+              <div className="rgd-instances-error" data-testid="instance-error-state" role="alert">
                 <span className="rgd-instances-error__msg">
-                  Error: {instancesError}
+                  {readyState.state === 'error'
+                    ? <>
+                        This RGD&apos;s CRD has not been provisioned yet. Instances can only be
+                        created once the RGD is Ready.{' '}
+                        <button
+                          type="button"
+                          className="rgd-instances-error__tab-link"
+                          onClick={() => setTab('validation')}
+                        >
+                          Check the Validation tab
+                        </button>{' '}
+                        for details.
+                      </>
+                    : translateApiError(instancesError)
+                  }
                 </span>
                 <button
                   type="button"


### PR DESCRIPTION
## Summary

Resolves all 32 findings from issue #187 — the full error states / empty states / symbol legend UX audit.

- **6 HIGH** findings: users blocked with no path forward → all now show translated messages, Retry buttons, and navigation links
- **14 MEDIUM** findings: confusing but recoverable → enriched with actionable guidance
- **12 LOW** findings: missing legend entries, glyphs without text labels, stale copy → all addressed

## Root cause fix

New `web/src/lib/errors.ts` introduces `translateApiError(message, context?)` — a pure function with 7 error patterns that maps raw Go/Kubernetes API error strings to user-readable messages. Called at render time (not in `api.ts`) so components can pass context (e.g. RGD readiness) for contextual messages.

New `conditionStatusLabel(type, status)` in `conditions.ts` maps `"True"/"False"/"Unknown"` → `"Healthy"/"Failed"/"Pending"` with negation-polarity awareness (`ReconciliationSuspended`).

## Key changes

| Area | What changed |
|---|---|
| `web/src/lib/errors.ts` (new) | `translateApiError()` — 7 patterns, 36 unit tests |
| `web/src/lib/conditions.ts` | `conditionStatusLabel()` — Healthy/Failed/Pending labels |
| `RGDDetail.tsx` | H-1: full-page error → Retry + Back link; H-2: CRD-not-provisioned hint; M-13: enriched graph empty state |
| `InstanceDetail.tsx` | M-5: RGD load error → Back link; M-18: poll-error banner shows translated reason; M-14: enriched DAG empty state |
| `ErrorsTab / AccessTab` | H-3, H-4: translated errors with context-specific 403 messages |
| `InstanceOverlayBar` | H-5, H-6: picker/overlay errors translated; L-8: Generate tab link in empty state |
| `Home / Catalog / Fleet / Events` | M-1–M-4: page errors translated; Events gains Retry; Fleet M-9 empty state enriched |
| `LiveNodeDetailPanel / CollectionPanel` | M-6, M-7: generic error branches gain Retry button |
| `ExpandableNode` | M-8: child error translated + Retry |
| `FleetMatrix` | M-15: empty state enriched; M-16: Present/Degraded/Absent legend added |
| `ClusterCard` | M-17: health dot now shows text label for all health states |
| `ConditionsPanel` | L-10: True/False/Unknown → Healthy/Failed/Pending |
| `LiveDAG / DeepDAG` | L-1: DAGLegend rendered; L-2: live-state legend (Alive/Reconciling/Pending/Error/Not found) |
| `EventsPanel` | M-10: "No events" → TTL explanation + kubectl hint; L-3: ⊘ gains "Deletion" text |
| `StaticChainDAG` | M-12: not-found enriched; L-4: ⊗ shows "(cycle)"; L-5: ⋯ shows "(max depth)" |
| `MetricsStrip` | L-11: removes stale `--metrics-url` reference |
| `Catalog` | L-12: hasFilters checked before items.length=0 |
| `SpecPanel` | M-11: Docs tab link in empty state |

## Test coverage

- 775 tests pass (was 739 — +36 new tests for `errors.ts` and `conditionStatusLabel`)
- All 8 tests that asserted old raw error strings updated to assert translated messages
- `bun run typecheck` clean
- `go vet ./...` clean

Closes #187