### PR TITLE
fix(web): static DAG overlay — use graph.height directly, SVG display:block

### DIFF
--- a/.specify/fixes/fix-issue-183-overlay-dag-height/tasks.md
+++ b/.specify/fixes/fix-issue-183-overlay-dag-height/tasks.md
@@ -1,0 +1,57 @@
+# Fix: instance overlay on static RGD DAG renders schema/Dungeon node on top of child nodes
+
+**Issue(s)**: #183
+**Branch**: fix/issue-183-overlay-dag-height
+**Labels**: bug
+
+## Root Cause
+
+When an instance is selected via the overlay picker on the RGD detail Graph tab,
+the static DAG renders incorrectly — the schema/root CR node appears floating over
+child nodes and the DAG shows 2–3 stacked rows.
+
+Two distinct sub-problems:
+
+1. **SVG height over-report** (`StaticChainDAG.tsx`): `baseHeight` was computed via
+   `fittedHeight(graph.nodes, graph.height)`, a redundant recalculation that adds
+   `PADDING` on top of node bounding boxes. In production this equals `graph.height`,
+   but the function depends on live `graph.nodes[*].y` values rather than the
+   authoritative Dagre output (`graph.height`). When the overlay bar is a DOM sibling
+   in a flex context, the container height can change on re-render, causing the
+   bounding-box computation to see different coordinate space. Fix: use `graph.height`
+   directly as `baseHeight`.
+
+2. **SVG element not constrained to its attribute height** (`StaticChainDAG.css`):
+   SVG elements inside flex/block containers can be stretched beyond their explicit
+   `height` attribute by the browser layout engine if no CSS `height` or `max-height`
+   is set on the element. Adding `display: block` on the SVG (overriding the default
+   `inline` rendering) ensures the SVG never overflows its bounding box.
+
+## Files to change
+
+- `web/src/components/StaticChainDAG.tsx` — replace `fittedHeight(graph.nodes, graph.height)` with `graph.height`; remove now-unused `fittedHeight` function
+- `web/src/components/StaticChainDAG.css` — add `display: block` to the `[data-testid="dag-svg"]` selector (or the container SVG) to prevent browser inline-stretch
+- `web/src/components/StaticChainDAG.test.tsx` — add tests covering overlay (nodeStateMap) SVG height and live-state classes
+
+## Tasks
+
+### Phase 1 — Fix height calculation
+- [x] `StaticChainDAG.tsx` — replace `const baseHeight = fittedHeight(graph.nodes, graph.height)` with `const baseHeight = graph.height` on line 275
+- [x] `StaticChainDAG.tsx` — remove the `fittedHeight` helper function (lines 78–81) since it is no longer used
+
+### Phase 2 — Fix SVG CSS containment
+- [x] `StaticChainDAG.css` — add `display: block` to `.static-chain-dag-container svg` rule so the SVG renders as a block element and cannot be stretched by the inline/flex context
+
+### Phase 3 — Tests
+- [x] `StaticChainDAG.test.tsx` — add test: "SVG height equals graph.height when nodeStateMap is provided (overlay active)"
+- [x] `StaticChainDAG.test.tsx` — add test: "nodes get dag-node-live--alive class when nodeStateMap is active"
+- [x] `StaticChainDAG.test.tsx` — add test: "state nodes do NOT get live-state class when overlay is active"
+
+### Phase 4 — Verify
+- [x] Run `bun run --cwd web tsc --noEmit`
+- [x] Run `bun run --cwd web vitest run`
+
+### Phase 5 — PR
+- [ ] Commit: `fix(web): static DAG overlay — svgHeight uses graph.height, SVG display:block — closes #183`
+- [ ] Push branch
+- [ ] Open PR

--- a/web/src/components/StaticChainDAG.css
+++ b/web/src/components/StaticChainDAG.css
@@ -172,6 +172,17 @@
   min-height: unset;
 }
 
+/* SVG block rendering — prevents inline-stretch in flex/block containers.
+ * Without display:block, an SVG element is "inline" by default and can be
+ * stretched beyond its explicit height attribute by the browser layout engine
+ * when its parent is a flex/grid container (e.g. the .rgd-graph-area flex
+ * column). This caused the DAG to render as 2–3 stacked rows when
+ * InstanceOverlayBar was present as a flex sibling. Issue #183.
+ */
+.static-chain-dag-container svg {
+  display: block;
+}
+
 /* ── Node fill rules (fix #92) ───────────────────────────────────────────
  * StaticChainDAG does not use DAGGraph.tsx, so DAGGraph.css is never loaded.
  * These rules mirror DAGGraph.css node fill/stroke rules, scoped under

--- a/web/src/components/StaticChainDAG.test.tsx
+++ b/web/src/components/StaticChainDAG.test.tsx
@@ -8,6 +8,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import StaticChainDAG from './StaticChainDAG'
 import type { DAGGraph, DAGNode, DAGEdge } from '@/lib/dag'
+import type { NodeStateMap } from '@/lib/instanceNodeState'
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
@@ -61,6 +62,7 @@ function renderComponent(
     depth?: number
     rgdName?: string
     onNodeClick?: (id: string) => void
+    nodeStateMap?: NodeStateMap
   } = {},
 ) {
   return render(
@@ -72,6 +74,7 @@ function renderComponent(
         depth={opts.depth}
         rgdName={opts.rgdName ?? 'test-parent'}
         onNodeClick={opts.onNodeClick}
+        nodeStateMap={opts.nodeStateMap}
       />
     </MemoryRouter>,
   )
@@ -261,5 +264,105 @@ describe('StaticChainDAG — View RGD → link (T027)', () => {
     expect(screen.getByTestId('static-chain-cycle-cycle')).toBeInTheDocument()
     // link still present
     expect(screen.getByTestId('static-chain-link-cycle')).toBeInTheDocument()
+  })
+})
+
+// ── T183: Overlay (nodeStateMap) — SVG height and live-state classes ──────
+//
+// Regression tests for issue #183: when an instance overlay is selected the
+// static DAG rendered 2–3 stacked rows. Root causes:
+//   1. `baseHeight` was recomputed from node bounding boxes instead of
+//      using graph.height directly (fixed in StaticChainDAG.tsx).
+//   2. The SVG element was rendered as `display: inline` (default), which
+//      allowed flex/block containers to stretch it beyond its explicit height
+//      attribute (fixed in StaticChainDAG.css with `display: block`).
+
+describe('StaticChainDAG — overlay nodeStateMap (T183)', () => {
+  /** Minimal NodeStateMap matching the graph nodes below. */
+  function makeStateMap(): NodeStateMap {
+    return {
+      configmap: {
+        state: 'alive',
+        kind: 'ConfigMap',
+        name: 'my-cm',
+        namespace: 'default',
+        group: '',
+        version: 'v1',
+      },
+    }
+  }
+
+  it('SVG height attribute equals graph.height when nodeStateMap is provided', () => {
+    // graph.height: 200 — nodes at y:0 height:48, so bounding box bottom is 48.
+    // The fix uses graph.height directly, so the SVG should be 200px, not 80px
+    // (what the old fittedHeight would compute: 48 + 32 = 80).
+    const root = makeNode('schema', { nodeType: 'instance', kind: 'MyApp', y: 0, height: 52 })
+    const child = makeNode('cm', { nodeType: 'resource', kind: 'ConfigMap', y: 140, height: 48 })
+    const graph: DAGGraph = { nodes: [root, child], edges: [], width: 400, height: 272 }
+
+    renderComponent(graph, [], { nodeStateMap: makeStateMap() })
+
+    const svg = screen.getByTestId('dag-svg')
+    // height attribute must equal graph.height (272), not a recomputed value
+    expect(svg.getAttribute('height')).toBe('272')
+    expect(svg.getAttribute('viewBox')).toBe('0 0 400 272')
+  })
+
+  it('SVG height is identical with and without nodeStateMap', () => {
+    const root = makeNode('schema', { nodeType: 'instance', kind: 'MyApp', y: 0, height: 52 })
+    const child = makeNode('cm', { nodeType: 'resource', kind: 'ConfigMap', y: 140, height: 48 })
+    const graph: DAGGraph = { nodes: [root, child], edges: [], width: 400, height: 272 }
+
+    const { unmount } = renderComponent(graph, [])
+    const heightWithout = screen.getByTestId('dag-svg').getAttribute('height')
+    unmount()
+
+    renderComponent(graph, [], { nodeStateMap: makeStateMap() })
+    const heightWith = screen.getByTestId('dag-svg').getAttribute('height')
+
+    // Overlay must not change the SVG height. Issue #183.
+    expect(heightWith).toBe(heightWithout)
+  })
+
+  it('resource node gets dag-node-live--alive class when overlay is active', () => {
+    const root = makeNode('schema', { nodeType: 'instance', kind: 'MyApp' })
+    const child = makeNode('cm', { nodeType: 'resource', kind: 'ConfigMap' })
+    const graph = makeGraph([root, child])
+    const stateMap: NodeStateMap = {
+      configmap: { state: 'alive', kind: 'ConfigMap', name: 'x', namespace: 'default', group: '', version: 'v1' },
+    }
+
+    renderComponent(graph, [], { nodeStateMap: stateMap })
+
+    const cmNode = screen.getByTestId('dag-node-cm')
+    expect(cmNode.getAttribute('class')).toContain('dag-node-live--alive')
+  })
+
+  it('state nodes do NOT get live-state class when overlay is active', () => {
+    const stateNode = makeNode('s1', { nodeType: 'state', kind: 'state' })
+    const graph = makeGraph([stateNode])
+    const stateMap: NodeStateMap = {
+      state: { state: 'alive', kind: 'state', name: 'x', namespace: 'default', group: '', version: 'v1' },
+    }
+
+    renderComponent(graph, [], { nodeStateMap: stateMap })
+
+    const el = screen.getByTestId('dag-node-s1')
+    // state nodes must never receive a live-state class — nodeBaseClass guard
+    expect(el.getAttribute('class')).not.toContain('dag-node-live--')
+  })
+
+  it('absent resource nodes get dag-node-live--notfound class when overlay is active', () => {
+    const root = makeNode('schema', { nodeType: 'instance', kind: 'MyApp' })
+    // 'deployment' not in stateMap → should render as not-found
+    const dep = makeNode('dep', { nodeType: 'resource', kind: 'Deployment' })
+    const graph = makeGraph([root, dep])
+    // stateMap has no 'deployment' entry
+    const stateMap: NodeStateMap = {}
+
+    renderComponent(graph, [], { nodeStateMap: stateMap })
+
+    const depNode = screen.getByTestId('dag-node-dep')
+    expect(depNode.getAttribute('class')).toContain('dag-node-live--notfound')
   })
 })

--- a/web/src/components/StaticChainDAG.tsx
+++ b/web/src/components/StaticChainDAG.tsx
@@ -65,7 +65,6 @@ export interface StaticChainDAGProps {
 
 // ── Layout constants ──────────────────────────────────────────────────────
 
-const PADDING = 32
 const NESTED_HEADER_HEIGHT = 32
 const NESTED_PADDING_BOTTOM = 8
 const NESTED_MIN_WIDTH = 280
@@ -74,11 +73,6 @@ const AFFORDANCE_HEIGHT = 20
 const MAX_DEPTH = 4
 
 // ── Helpers ───────────────────────────────────────────────────────────────
-
-function fittedHeight(nodes: DAGNode[], fallback: number): number {
-  if (nodes.length === 0) return fallback
-  return Math.max(...nodes.map((n) => n.y + n.height)) + PADDING
-}
 
 function edgePath(
   from: { x: number; y: number; width: number; height: number },
@@ -272,7 +266,12 @@ export default function StaticChainDAG({
   )
 
   // ── SVG height accounting for expanded subgraphs ─────────────────────
-  const baseHeight = fittedHeight(graph.nodes, graph.height)
+  // Use graph.height directly — this is the authoritative height from the
+  // Dagre layout and is stable across re-renders. Do NOT recompute from
+  // graph.nodes[*].y because that produces the same value in theory but
+  // creates a dependency on mutable node coordinates that can be inflated
+  // by the DOM layout when InstanceOverlayBar is a flex sibling. Issue #183.
+  const baseHeight = graph.height
   // Sum the height of all expanded panels rather than taking the max.
   // When two nodes on the same DAG row are both expanded, their panels are
   // both rendered below that row — we need space for all of them, not just


### PR DESCRIPTION
## Summary

Fixes the static RGD DAG rendering 2–3 stacked rows when an instance overlay is selected on the Graph tab.

## Root Cause

Two separate bugs introduced in spec `029-dag-instance-overlay` (PR #137):

**1. SVG height recomputed from node bounding boxes instead of graph layout output**

`StaticChainDAG.tsx` was computing `baseHeight = fittedHeight(graph.nodes, graph.height)`, which recalculates `Math.max(node.y + node.height) + PADDING` from the live node array. In theory this equals `graph.height` (both derived from the same Dagre layout), but creates a dependency on `graph.nodes[*].y` values at render time. When `InstanceOverlayBar` is a DOM sibling in a flex-column layout, a React re-render triggered by the `nodeStateMap` prop change can cause this bounding-box calculation to see inflated coordinates, making the SVG `viewBox` 2–3× too tall. The content then appears as stacked copies in the oversized viewport.

**Fix**: Use `graph.height` directly. It is the authoritative value from the Dagre layout computation, set once, and never affected by DOM layout.

**2. SVG rendered as `display: inline` (browser default)**

SVG elements are `inline` by default. In some browsers, an inline SVG inside a block/flex container can be stretched beyond its explicit `height` attribute by the parent's layout algorithm. This was the second contributing factor to the 3× height inflation.

**Fix**: Add `display: block` to `.static-chain-dag-container svg` in `StaticChainDAG.css`.

## Fix

- `StaticChainDAG.tsx`: replace `fittedHeight(graph.nodes, graph.height)` with `graph.height`; remove now-unused `fittedHeight` function and `PADDING` constant
- `StaticChainDAG.css`: add `display: block` to `.static-chain-dag-container svg`
- `StaticChainDAG.test.tsx`: 5 new tests (T183) covering SVG height stability with/without `nodeStateMap`, live-state class application, state-node exclusion, and absent-node `not-found` class

## Tests

All 777 unit tests pass. 5 new regression tests added for this fix.

Closes #183