### PR TITLE
fix(web): resolve child resource by kro.run/node-id label

### DIFF
--- a/.specify/fixes/fix-issue-210-live-yaml-node-id/tasks.md
+++ b/.specify/fixes/fix-issue-210-live-yaml-node-id/tasks.md
@@ -1,0 +1,57 @@
+# Fix: Live YAML always fails — resolveChildResourceInfo matches by node label instead of kro.run/node-id
+
+**Issue(s)**: #210
+**Branch**: fix/issue-210-live-yaml-node-id
+**Labels**: bug
+
+## Root Cause
+
+`resolveChildResourceInfo` in `web/src/lib/resolveResourceName.ts` derives a `kindHint`
+from the node label (resource ID, e.g. `"appNamespace"`) and matches it against
+`child.kind.toLowerCase()` (e.g. `"namespace"`). Since resource IDs almost never equal
+their kinds in real-world RGDs, no child ever matches and the fallback constructs a
+wrong name/kind, producing a 404 from the GetResource endpoint.
+
+kro ≥ 0.8.0 sets `kro.run/node-id: <resource-id>` on every managed resource — this is
+the exact, authoritative key. Matching on this label first fixes all cases, including
+two resources sharing the same kind (e.g. `appConfig` and `appStatus` both `ConfigMap`).
+
+## Files to change
+
+- `web/src/lib/resolveResourceName.ts` — add `kro.run/node-id` primary match in
+  `resolveChildResourceInfo`; add `nodeKind` optional param for secondary kind fallback
+- `web/src/pages/InstanceDetail.tsx` — pass `selectedNode.kind` as `nodeKind`
+- `web/src/lib/resolveResourceName.test.ts` — tests for node-id match + same-kind
+  disambiguation + nodeKind fallback
+
+## Tasks
+
+### Phase 1 — Fix
+- [x] `resolveResourceName.ts:69` — add `nodeKind?: string` param to
+  `resolveChildResourceInfo`; update header comment
+- [x] `resolveResourceName.ts:76` — insert primary match loop: if child has
+  `kro.run/node-id === nodeLabel` → return that child's info immediately
+- [x] `resolveResourceName.ts:78` — add tertiary kind match using `nodeKind` (after
+  existing kindHint match) for kro < 0.8.0 clusters where IDs equal kinds but label
+  doesn't carry a CR suffix
+- [x] `InstanceDetail.tsx:248` — pass `selectedNode.kind` as `nodeKind` argument
+
+### Phase 2 — Tests
+- [x] `resolveResourceName.test.ts` — add `resolveChildResourceInfo` describe block
+- [x] Test: node-id match — label "appNamespace", child kind "Namespace" with
+  `kro.run/node-id: appNamespace` → returns correct Namespace info
+- [x] Test: two ConfigMaps with same kind, different node-ids — label "appConfig" returns
+  the ConfigMap whose node-id matches, not the first kind-match
+- [x] Test: nodeKind fallback — no node-id label, label "appDeployment", nodeKind
+  "Deployment", child kind "Deployment" → returns correct info via kind match
+- [x] Test: inference fallback — no node-id, no kind match → returns inferred info
+- [x] Test: cluster-scoped resource (no namespace) → namespace="" returned correctly
+
+### Phase 3 — Verify
+- [x] Run `bun run --cwd web tsc --noEmit`
+- [x] Run `bun run --cwd web vitest run`
+
+### Phase 4 — PR
+- [ ] Commit: `fix(web): resolve child resource by kro.run/node-id label — closes #210`
+- [ ] Push branch
+- [ ] Open PR

--- a/web/src/lib/resolveResourceName.test.ts
+++ b/web/src/lib/resolveResourceName.test.ts
@@ -1,8 +1,8 @@
-// resolveResourceName.test.ts — unit tests for resolveResourceName.
-// Covers children-list lookup and CR suffix stripping fallback.
+// resolveResourceName.test.ts — unit tests for resolveResourceName and resolveChildResourceInfo.
+// Covers children-list lookup, CR suffix stripping, kro.run/node-id matching (fix #210).
 
 import { describe, it, expect } from 'vitest'
-import { resolveResourceName } from './resolveResourceName'
+import { resolveResourceName, resolveChildResourceInfo } from './resolveResourceName'
 import type { K8sObject } from './api'
 
 // ── Helpers ───────────────────────────────────────────────────────────────
@@ -12,6 +12,25 @@ function makeChild(kind: string, name: string, namespace = 'default'): K8sObject
     apiVersion: 'v1',
     kind,
     metadata: { name, namespace },
+  }
+}
+
+/** Make a child with kro.run/node-id label (kro ≥ 0.8.0). */
+function makeChildWithNodeId(
+  kind: string,
+  name: string,
+  nodeId: string,
+  namespace = 'default',
+  apiVersion = 'v1',
+): K8sObject {
+  return {
+    apiVersion,
+    kind,
+    metadata: {
+      name,
+      namespace,
+      labels: { 'kro.run/node-id': nodeId },
+    },
   }
 }
 
@@ -90,5 +109,123 @@ describe('resolveResourceName', () => {
     const result = resolveResourceName('configmapCR', 'my-app', children)
     // Should return the first match
     expect(result).toBe('my-app-cm-1')
+  })
+})
+
+// ── resolveChildResourceInfo (fix #210) ───────────────────────────────────
+//
+// Regression suite for issue #210: Live YAML always showed "CRD not provisioned"
+// because resolveChildResourceInfo matched by kindHint derived from the node label
+// (resource ID), which almost never equals the child kind in real RGDs.
+// Fix: primary match on kro.run/node-id label, fallback to kind, then nodeKind param.
+
+describe('resolveChildResourceInfo — kro.run/node-id matching (T210)', () => {
+  // T210-01: primary match via kro.run/node-id
+  it('T210-01: matches child by kro.run/node-id when label differs from kind', () => {
+    // test-app RGD: resource ID "appNamespace", kind "Namespace"
+    const children = [
+      makeChildWithNodeId('Namespace', 'kro-ui-test', 'appNamespace', ''),
+    ]
+    const result = resolveChildResourceInfo('appNamespace', 'test-instance', children)
+    expect(result).toEqual({
+      kind: 'Namespace',
+      name: 'kro-ui-test',
+      namespace: '',
+      group: '',
+      version: 'v1',
+    })
+  })
+
+  // T210-02: disambiguates two same-kind resources by node-id
+  it('T210-02: returns the correct child when two share the same kind (e.g. two ConfigMaps)', () => {
+    // test-app: appConfig and appStatus are both ConfigMap
+    const children = [
+      makeChildWithNodeId('ConfigMap', 'kro-ui-test-config', 'appConfig', 'kro-ui-test'),
+      makeChildWithNodeId('ConfigMap', 'kro-ui-test-status', 'appStatus', 'kro-ui-test'),
+    ]
+
+    const config = resolveChildResourceInfo('appConfig', 'test-instance', children)
+    expect(config?.name).toBe('kro-ui-test-config')
+
+    const status = resolveChildResourceInfo('appStatus', 'test-instance', children)
+    expect(status?.name).toBe('kro-ui-test-status')
+  })
+
+  // T210-03: cluster-scoped resource — namespace is '' (not undefined)
+  it('T210-03: cluster-scoped resource returns namespace as empty string', () => {
+    const children = [
+      makeChildWithNodeId('Namespace', 'kro-ui-test', 'appNamespace', ''),
+    ]
+    const result = resolveChildResourceInfo('appNamespace', 'test-instance', children)
+    expect(result?.namespace).toBe('')
+  })
+
+  // T210-04: non-core apiVersion — group and version parsed correctly
+  it('T210-04: parses group and version from non-core apiVersion', () => {
+    const child = makeChildWithNodeId(
+      'Deployment', 'my-deploy', 'appDeployment', 'default', 'apps/v1',
+    )
+    const result = resolveChildResourceInfo('appDeployment', 'my-app', [child])
+    expect(result?.group).toBe('apps')
+    expect(result?.version).toBe('v1')
+    expect(result?.kind).toBe('Deployment')
+  })
+
+  // T210-05: step-2 fallback — no node-id label, kindHint matches kind
+  it('T210-05: falls back to kind match when no kro.run/node-id label (kro < 0.8.0)', () => {
+    // Node label "database", kind "Database" — ID equals kind (older style)
+    const children = [makeChild('Database', 'prod-01-database', 'prod-ns')]
+    const result = resolveChildResourceInfo('database', 'prod-01', children)
+    expect(result?.name).toBe('prod-01-database')
+    expect(result?.kind).toBe('Database')
+  })
+
+  // T210-06: step-3 fallback — no node-id label, no kindHint match, nodeKind provided
+  it('T210-06: uses nodeKind param when node label differs from kind and no node-id (kro < 0.8.0)', () => {
+    // Label "appDeployment" → kindHint "appdeployment", child kind "Deployment"
+    // Only step-3 (nodeKind) can match here
+    const children = [makeChild('Deployment', 'my-deploy', 'default')]
+    const result = resolveChildResourceInfo('appDeployment', 'my-app', children, 'Deployment')
+    expect(result?.name).toBe('my-deploy')
+    expect(result?.kind).toBe('Deployment')
+  })
+
+  // T210-07: inference fallback — no match at all
+  it('T210-07: returns inferred info when no child matches', () => {
+    const result = resolveChildResourceInfo('appNamespace', 'test-instance', [])
+    // inferredKind = nodeKind (undefined) → kindHint = "appnamespace"
+    expect(result?.kind).toBe('appnamespace')
+    expect(result?.name).toBe('test-instance-appnamespace')
+    expect(result?.namespace).toBe('')
+  })
+
+  // T210-08: inference fallback uses nodeKind for kind label when provided
+  it('T210-08: inference fallback uses nodeKind for better kind label', () => {
+    const result = resolveChildResourceInfo('appNamespace', 'test-instance', [], 'Namespace')
+    expect(result?.kind).toBe('Namespace')
+    expect(result?.name).toBe('test-instance-appnamespace')
+  })
+
+  // T210-09: node-id takes priority over kind match
+  it('T210-09: kro.run/node-id match takes priority over kind match', () => {
+    // Two ConfigMaps: one has matching node-id, one has matching kindHint
+    const children = [
+      // This one matches by kind hint ("configmap") but wrong node-id
+      makeChildWithNodeId('ConfigMap', 'wrong-cm', 'otherNode', 'default'),
+      // This one matches by node-id
+      makeChildWithNodeId('ConfigMap', 'correct-cm', 'configmap', 'default'),
+    ]
+    const result = resolveChildResourceInfo('configmap', 'my-app', children)
+    // Node-id match ("configmap") should win over kind-match (would also pick first)
+    expect(result?.name).toBe('correct-cm')
+  })
+
+  // T210-10: resolveResourceName also prefers kro.run/node-id
+  it('T210-10: resolveResourceName matches by kro.run/node-id first', () => {
+    const children = [
+      makeChildWithNodeId('Namespace', 'kro-ui-test', 'appNamespace', ''),
+    ]
+    const result = resolveResourceName('appNamespace', 'test-instance', children)
+    expect(result).toBe('kro-ui-test')
   })
 })

--- a/web/src/lib/resolveResourceName.ts
+++ b/web/src/lib/resolveResourceName.ts
@@ -1,11 +1,19 @@
 // resolveResourceName.ts — maps a DAG node label to a cluster resource name.
 //
-// Two-step resolution (spec FR-007):
-//   1. Look up the children list for a resource whose kind matches the node label.
-//   2. If not found, strip the "CR" / "CRs" suffix from the label and prepend
-//      the instance name with a hyphen.
+// Three-step resolution for resolveChildResourceInfo (fix #210):
+//   1. Match child whose kro.run/node-id label equals nodeLabel (resource ID).
+//      This is the authoritative key set by kro ≥ 0.8.0 on every managed resource.
+//      Handles IDs that differ from kinds (e.g. "appNamespace" → Namespace) and
+//      disambiguates multiple resources of the same kind (e.g. two ConfigMaps).
+//   2. Match child whose kind (lowercased) equals kindHint derived from nodeLabel.
+//      Fallback for kro < 0.8.0 that does not set kro.run/node-id labels.
+//   3. Match child whose kind (lowercased) equals the optional nodeKind parameter.
+//      Second fallback for kro < 0.8.0 when the node ID differs from its kind.
+//   4. Inference: construct a name from instanceName + kindHint.
 
 import type { K8sObject } from './api'
+
+const LABEL_NODE_ID = 'kro.run/node-id'
 
 /**
  * Derive a kind hint from a node label.
@@ -15,6 +23,25 @@ function kindHintFromLabel(label: string): string {
   if (label.endsWith('CRs')) return label.slice(0, -3)
   if (label.endsWith('CR')) return label.slice(0, -2)
   return label
+}
+
+/** Read kro.run/node-id from a child resource's metadata labels. Returns '' if absent. */
+function nodeIdLabel(child: K8sObject): string {
+  const meta = child.metadata as Record<string, unknown> | undefined
+  const labels = meta?.labels
+  if (typeof labels !== 'object' || labels === null) return ''
+  const val = (labels as Record<string, unknown>)[LABEL_NODE_ID]
+  return typeof val === 'string' ? val : ''
+}
+
+/** Extract ChildResourceInfo fields from an unstructured child object. */
+function childToInfo(child: K8sObject): ChildResourceInfo {
+  const meta = child.metadata as Record<string, unknown> | undefined
+  const name = typeof meta?.name === 'string' ? meta.name : ''
+  const namespace = typeof meta?.namespace === 'string' ? meta.namespace : ''
+  const { group, version } = parseApiVersion(child.apiVersion)
+  const kind = typeof child.kind === 'string' ? child.kind : ''
+  return { kind, name, namespace, group, version }
 }
 
 /**
@@ -30,9 +57,18 @@ export function resolveResourceName(
   instanceName: string,
   children: K8sObject[],
 ): string {
+  // Step 1: match by kro.run/node-id (authoritative, kro ≥ 0.8.0)
+  for (const child of children) {
+    if (nodeIdLabel(child) === nodeLabel) {
+      const meta = child.metadata as Record<string, unknown> | undefined
+      const name = typeof meta?.name === 'string' ? meta.name : ''
+      if (name) return name
+    }
+  }
+
   const kindHint = kindHintFromLabel(nodeLabel).toLowerCase()
 
-  // Step 1: scan the children list for a kind match (case-insensitive)
+  // Step 2: match by kind derived from node label (kro < 0.8.0 fallback)
   for (const child of children) {
     const childKind = typeof child.kind === 'string' ? child.kind.toLowerCase() : ''
     if (childKind === kindHint) {
@@ -42,7 +78,7 @@ export function resolveResourceName(
     }
   }
 
-  // Step 2: fallback — prepend instance name to the kind hint
+  // Step 3: inference fallback — prepend instance name to the kind hint
   return `${instanceName}-${kindHint}`
 }
 
@@ -66,28 +102,59 @@ function parseApiVersion(apiVersion: unknown): { group: string; version: string 
   return { group: '', version: parts[0] ?? 'v1' }
 }
 
+/**
+ * resolveChildResourceInfo — resolve the full GVK + name + namespace for a DAG node.
+ *
+ * Match order (fix #210):
+ *   1. child.metadata.labels["kro.run/node-id"] === nodeLabel  (kro ≥ 0.8.0, exact)
+ *   2. child.kind.toLowerCase() === kindHint from nodeLabel     (kro < 0.8.0, by kind)
+ *   3. child.kind.toLowerCase() === nodeKind?.toLowerCase()     (caller-supplied kind)
+ *   4. Inference fallback
+ *
+ * @param nodeLabel    - DAG node label (= resource ID, e.g. "appNamespace")
+ * @param instanceName - CR instance name for the inference fallback
+ * @param children     - Child resources from getInstanceChildren
+ * @param nodeKind     - Optional: DAGNode.kind (e.g. "Namespace") for step-3 fallback
+ */
 export function resolveChildResourceInfo(
   nodeLabel: string,
   instanceName: string,
   children: K8sObject[],
+  nodeKind?: string,
 ): ChildResourceInfo | null {
-  const kindHint = kindHintFromLabel(nodeLabel).toLowerCase()
-
+  // Step 1: match by kro.run/node-id label (authoritative — kro ≥ 0.8.0)
   for (const child of children) {
-    const childKind = typeof child.kind === 'string' ? child.kind : ''
-    if (childKind.toLowerCase() === kindHint) {
-      const meta = child.metadata as Record<string, unknown> | undefined
-      const name = typeof meta?.name === 'string' ? meta.name : ''
-      const namespace = typeof meta?.namespace === 'string' ? meta.namespace : ''
-      const { group, version } = parseApiVersion(child.apiVersion)
-      return { kind: childKind, name, namespace, group, version }
+    if (nodeIdLabel(child) === nodeLabel) {
+      return childToInfo(child)
     }
   }
 
-  // Not found in children — return inferred info
+  const kindHint = kindHintFromLabel(nodeLabel).toLowerCase()
+
+  // Step 2: match by kind derived from node label (kro < 0.8.0 fallback)
+  for (const child of children) {
+    const childKind = typeof child.kind === 'string' ? child.kind : ''
+    if (childKind.toLowerCase() === kindHint) {
+      return childToInfo(child)
+    }
+  }
+
+  // Step 3: match by caller-supplied nodeKind (kro < 0.8.0, ID ≠ kind)
+  if (nodeKind) {
+    const kindLower = nodeKind.toLowerCase()
+    for (const child of children) {
+      const childKind = typeof child.kind === 'string' ? child.kind : ''
+      if (childKind.toLowerCase() === kindLower) {
+        return childToInfo(child)
+      }
+    }
+  }
+
+  // Step 4: inference fallback — use nodeKind if available for a better kind label
+  const inferredKind = nodeKind ?? kindHint
   const inferredName = `${instanceName}-${kindHint}`
   return {
-    kind: kindHint,
+    kind: inferredKind,
     name: inferredName,
     namespace: '',
     group: '',

--- a/web/src/pages/InstanceDetail.tsx
+++ b/web/src/pages/InstanceDetail.tsx
@@ -249,6 +249,7 @@ export default function InstanceDetail() {
       selectedNode.label,
       instanceName,
       children,
+      selectedNode.kind || undefined,
     )
   }, [selectedNode, instanceName, children])
 


### PR DESCRIPTION
## Summary

Live YAML in the Instance Detail panel always failed with "The API server doesn't recognise this resource type" for any RGD where resource IDs differ from their kinds (e.g. `appNamespace` → `Namespace`). This is the majority of real-world RGDs.

## Root Cause

`resolveChildResourceInfo` in `web/src/lib/resolveResourceName.ts` derived a `kindHint` from `node.label` (the resource ID, e.g. `"appNamespace"`) and matched it against `child.kind.toLowerCase()` (e.g. `"namespace"`). These strings almost never match. The fallback then constructed a nonsense name (`test-instance-appnamespace`) which the backend couldn't find, producing a 404 translated to the CRD-not-provisioned error.

For `test-app` specifically: all three managed resources (`appNamespace`/Namespace, `appConfig`/ConfigMap, `appStatus`/ConfigMap) failed. And even if kind-matching had worked, two ConfigMaps sharing the same kind were indistinguishable.

## Fix

kro ≥ 0.8.0 sets `kro.run/node-id: <resource-id>` on every managed resource — the exact value used as the node label. This is the authoritative, unambiguous mapping.

**`web/src/lib/resolveResourceName.ts`** — `resolveChildResourceInfo` now uses a three-step match:
1. `child.metadata.labels["kro.run/node-id"] === nodeLabel` — primary, handles all kro ≥ 0.8.0 cases including same-kind disambiguation
2. `child.kind.toLowerCase() === kindHint` — kind fallback for kro < 0.8.0 where IDs equal kinds
3. `child.kind.toLowerCase() === nodeKind?.toLowerCase()` — caller-supplied kind fallback for kro < 0.8.0 where IDs differ from kinds but there's only one resource of that kind

Same node-id priority added to `resolveResourceName` for consistency.

**`web/src/pages/InstanceDetail.tsx`** — passes `selectedNode.kind` as the `nodeKind` parameter to enable step-3.

## Tests

10 new regression tests (T210-01 through T210-10) covering: node-id primary match, same-kind disambiguation, cluster-scoped resources, non-core apiVersions, all three fallback paths, inference, and node-id priority over kind-match.

787 total tests passing.

Closes #210