### PR TITLE
fix(api): fleet timeout coherence + errgroup derived context + kro label constants

### DIFF
--- a/.specify/fixes/fix-issue-225-226-228-fleet-label-constants/tasks.md
+++ b/.specify/fixes/fix-issue-225-226-228-fleet-label-constants/tasks.md
@@ -1,0 +1,46 @@
+# Fix: FleetSummary timeout coherence + errgroup context + label constants
+
+**Issue(s)**: #225, #226, #228
+**Branch**: fix/issue-225-226-228-fleet-label-constants
+**Labels**: bug, refactor
+
+## Root Cause
+
+- **#225**: `summariseContext` creates a 10s deadline on top of a parent context already bound by the 5s
+  `middleware.Timeout`. The minimum wins, making the 10s a dead letter and the comments wrong.
+  Fix: give the `/fleet/summary` route its own timeout (30s) outside the global 5s middleware.
+- **#226**: `errgroup.WithContext(tctx)` derived context is discarded (`_`). Since all goroutines
+  return `nil`, cancellation never fires, but passing `tctx` directly to the per-RGD goroutines
+  means a context cancellation (from the parent) doesn't propagate correctly. Fix: use the
+  derived `gctx` from errgroup so early cancellation propagates.
+- **#228**: `"kro.run/instance-name"` appears as two inline string literals in `rgd.go:178` and
+  `rgd.go:320`. `KroGroup` already exists in `client.go`. Fix: add `LabelInstanceName` and
+  `LabelNodeID` constants alongside `KroGroup` and use them everywhere.
+
+## Files to change
+
+- `internal/server/server.go` — exempt `/fleet/summary` from global 5s timeout
+- `internal/api/handlers/fleet.go` — fix 10s deadline comment + use derived gctx
+- `internal/k8s/client.go` — add `LabelInstanceName`, `LabelNodeID` constants
+- `internal/k8s/rgd.go` — replace inline label strings with constants
+- `internal/api/handlers/fleet_test.go` — update if any deadline assertions change
+
+## Tasks
+
+### Phase 1 — #228: Add label constants to client.go
+- [x] Add `LabelInstanceName = KroGroup + "/instance-name"` and `LabelNodeID = KroGroup + "/node-id"` constants in `internal/k8s/client.go` alongside `KroGroup`
+- [x] Replace `"kro.run/instance-name"` at `rgd.go:178` with `LabelInstanceName`
+- [x] Replace `"kro.run/instance-name"` at `rgd.go:320` with `LabelInstanceName`
+
+### Phase 2 — #225 + #226: Fix fleet.go timeout + errgroup context
+- [x] In `server.go`: move `/fleet/summary` registration outside the `r.Use(middleware.Timeout(5s))` block (or register a sub-router with a 30s timeout for fleet)
+- [x] In `fleet.go`: update `summariseContext` comment — remove misleading "10s deadline per cluster (NFR-003)" since fleet now has its own 30s at the route level; remove the `context.WithTimeout(parent, 10*time.Second)` and use `parent` directly (the route-level timeout is the deadline)
+- [x] In `fleet.go`: change `g, _ := errgroup.WithContext(tctx)` to `g, gctx := errgroup.WithContext(parent)` and pass `gctx` to per-RGD goroutines instead of `tctx`
+
+### Phase 3 — Tests
+- [x] Run `go vet ./...`
+- [x] Run `GOPROXY=direct GONOSUMDB="*" go test -race ./internal/...`
+
+### Phase 4 — PR
+- [ ] Commit: `fix(api): fleet timeout coherence + errgroup gctx + label constants — closes #225, closes #226, closes #228`
+- [ ] Push and open PR

--- a/internal/api/handlers/fleet.go
+++ b/internal/api/handlers/fleet.go
@@ -45,7 +45,7 @@ func (b *realFleetClientBuilder) BuildClient(kubeconfigPath, ctx string) (k8scli
 }
 
 // FleetSummary returns per-context summaries for all kubeconfig contexts.
-// It fans out in parallel with a 10s timeout per cluster (NFR-003).
+// It fans out in parallel, bounded by the route-level 30s timeout in server.go.
 // One unreachable cluster never blocks others (FR-003).
 func (h *Handler) FleetSummary(w http.ResponseWriter, r *http.Request) {
 	log := zerolog.Ctx(r.Context())
@@ -79,9 +79,9 @@ func (h *Handler) summariseContext(parent context.Context, ctx k8sclient.Context
 		Cluster: ctx.Cluster,
 	}
 
-	// Use a 10s deadline per cluster (NFR-003).
-	tctx, cancel := context.WithTimeout(parent, 10*time.Second)
-	defer cancel()
+	// parent is already bounded by the route-level 30s timeout (server.go).
+	// No additional per-cluster deadline is added here — the per-RGD goroutines
+	// each apply their own 2s deadline via rctx (Constitution §XI).
 
 	// Build ephemeral clients — does NOT affect the shared ClientFactory.
 	var kubeconfigPath string
@@ -97,7 +97,7 @@ func (h *Handler) summariseContext(parent context.Context, ctx k8sclient.Context
 	}
 
 	// List RGDs to determine kro presence and count.
-	list, err := clients.Dynamic().Resource(rgdGVR).List(tctx, metav1.ListOptions{})
+	list, err := clients.Dynamic().Resource(rgdGVR).List(parent, metav1.ListOptions{})
 	if err != nil {
 		// Distinguish kro-not-installed from generic unreachability.
 		errStr := err.Error()
@@ -149,11 +149,13 @@ func (h *Handler) summariseContext(parent context.Context, ctx k8sclient.Context
 	}
 	results := make([]instanceResult, len(entries))
 	var mu sync.Mutex
-	g, _ := errgroup.WithContext(tctx)
+	// Use the derived context from errgroup so any early cancellation propagates
+	// to all goroutines (Constitution §XI; fixes issue #226).
+	g, gctx := errgroup.WithContext(parent)
 	for i, entry := range entries {
 		i, entry := i, entry // capture
 		g.Go(func() error {
-			rctx, rcancel := context.WithTimeout(tctx, 2*time.Second)
+			rctx, rcancel := context.WithTimeout(gctx, 2*time.Second)
 			defer rcancel()
 
 			plural, err := k8sclient.DiscoverPlural(clients, entry.group, entry.apiVersion, entry.kind)

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -270,6 +270,15 @@ type Context struct {
 // KroGroup is the API group for kro resources.
 const KroGroup = "kro.run"
 
+// LabelInstanceName is the kro label key used to associate child resources with
+// their parent CR instance. Defined here as a single source of truth so label
+// renames only require one change.
+const LabelInstanceName = KroGroup + "/instance-name"
+
+// LabelNodeID is the kro label key that maps a child resource back to the RGD
+// resource node that produced it (kro.run/node-id).
+const LabelNodeID = KroGroup + "/node-id"
+
 // RGDResource is the plural resource name for ResourceGraphDefinitions.
 const RGDResource = "resourcegraphdefinitions"
 

--- a/internal/k8s/rgd.go
+++ b/internal/k8s/rgd.go
@@ -175,7 +175,7 @@ func ResolveInstanceGVR(ctx context.Context, clients K8sClients, rgdName string)
 // fan-out via goroutines with per-resource deadline.
 func ListChildResources(ctx context.Context, clients K8sClients, instanceName string) ([]map[string]any, error) {
 	log := zerolog.Ctx(ctx)
-	labelSelector := fmt.Sprintf("kro.run/instance-name=%s", instanceName)
+	labelSelector := fmt.Sprintf("%s=%s", LabelInstanceName, instanceName)
 
 	// Use cached discovery — avoids per-request ServerGroupsAndResources() call.
 	apiLists, err := clients.CachedServerGroupsAndResources()
@@ -317,7 +317,7 @@ func ListChildResourcesForRGD(ctx context.Context, clients K8sClients, instanceN
 					Str("rgd", rgdName).
 					Int("gvrs", len(gvrs)).
 					Msg("using RGD-scoped child listing")
-				labelSelector := fmt.Sprintf("kro.run/instance-name=%s", instanceName)
+				labelSelector := fmt.Sprintf("%s=%s", LabelInstanceName, instanceName)
 				return listWithLabelSelector(ctx, log, clients.Dynamic(), gvrs, labelSelector)
 			}
 		} else {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -114,11 +114,17 @@ func NewRouter(factory *k8sclient.ClientFactory) (chi.Router, error) {
 			// Smart event stream — kro-filtered Kubernetes Events
 			r.Get("/events", h.ListEvents)
 
-			// Fleet overview — aggregated multi-context summary
-			r.Get("/fleet/summary", h.FleetSummary)
-
 			// Controller metrics — kro Prometheus scrape summary
 			r.Get("/kro/metrics", h.GetMetrics)
+		}
+
+		// Fleet summary is registered outside the 5s middleware timeout block
+		// because it fans out across all kubeconfig contexts and legitimately
+		// needs a longer deadline (30s) — Constitution §XI allows per-handler
+		// overrides when documented and bounded.
+		if factory != nil {
+			h := handlers.New(factory)
+			r.With(middleware.Timeout(30*time.Second)).Get("/fleet/summary", h.FleetSummary)
 		}
 	})
 


### PR DESCRIPTION
## Summary

Three related backend correctness fixes in one commit — all in the same k8s package area.

## Root Cause & Fix

### #225 — Fleet 10s deadline is a dead letter
`summariseContext` created `context.WithTimeout(parent, 10s)` where `parent` is already bounded by the global 5s `middleware.Timeout`. The minimum wins — the 10s can never fire. Comments throughout `fleet.go` were factually wrong.

**Fix**: Register `/fleet/summary` outside the global 5s middleware block using `r.With(middleware.Timeout(30s)).Get(...)` — fleet legitimately needs a longer deadline for multi-cluster fan-out.

### #226 — errgroup derived context discarded
`g, _ := errgroup.WithContext(tctx)` discarded the derived `gctx`. Per-RGD goroutines used `tctx` directly, meaning `errgroup`-driven early cancellation never propagated.

**Fix**: Capture `gctx` and pass it to the per-RGD `context.WithTimeout(gctx, 2s)` calls.

### #228 — Inline `kro.run/instance-name` string literals in rgd.go
Two identical `fmt.Sprintf("kro.run/instance-name=%s", ...)` calls used raw string literals. `KroGroup` already existed as a constant.

**Fix**: Add `LabelInstanceName = KroGroup + "/instance-name"` and `LabelNodeID = KroGroup + "/node-id"` constants in `internal/k8s/client.go`. Replace both inline strings in `rgd.go`.

## Tests

- `go vet ./...` ✅
- `go test -race ./internal/...` ✅ (all packages pass)

Closes #225, closes #226, closes #228