### PR TITLE
fix(web): RGDCard chipLoading init — add regression tests

### DIFF
--- a/.specify/fixes/fix-issue-262-rgdcard-chiploading-init/tasks.md
+++ b/.specify/fixes/fix-issue-262-rgdcard-chiploading-init/tasks.md
@@ -1,0 +1,38 @@
+# Fix: RGDCard chipLoading initialised to true unconditionally
+
+**Issue**: #262
+**Branch**: fix/issue-262-rgdcard-chiploading-init
+**Labels**: bug
+
+## Root Cause
+
+`chipLoading` was initialised to `true` unconditionally in `RGDCard.tsx` line 40.
+When `name` is absent (empty string), the effect immediately sets it to `false`,
+but this fires after the first render — so `HealthChip` briefly receives
+`loading={true}` and shows a skeleton shimmer for one frame even when no fetch
+will ever be made.
+
+## Files to change
+
+- `web/src/components/RGDCard.tsx` — already fixed: `useState(Boolean(name))`
+- `web/src/components/RGDCard.test.tsx` — add regression tests for initial
+  `chipLoading` value in both the empty-name and non-empty-name cases
+
+## Tasks
+
+### Phase 1 — Fix
+- [x] `RGDCard.tsx:47` — initialise `chipLoading` to `Boolean(name)` (already landed in main)
+
+### Phase 2 — Tests
+- [ ] Add test: card with no name does NOT render HealthChip in loading state on first render
+- [ ] Add test: card with name renders HealthChip in loading state on first render (before fetch resolves)
+- [ ] Run `bun run --cwd web vitest run` — all tests pass
+
+### Phase 3 — Verify
+- [ ] Run `bun run --cwd web tsc --noEmit`
+- [ ] Run `bun run --cwd web vitest run`
+
+### Phase 4 — PR
+- [ ] Commit: `fix(web): add regression test for chipLoading init — closes #262`
+- [ ] Push branch: `git push -u origin fix/issue-262-rgdcard-chiploading-init`
+- [ ] Open PR: `gh pr create --base main --head fix/issue-262-rgdcard-chiploading-init`

--- a/web/src/components/RGDCard.test.tsx
+++ b/web/src/components/RGDCard.test.tsx
@@ -3,6 +3,16 @@ import { MemoryRouter } from 'react-router-dom'
 import RGDCard from './RGDCard'
 import type { K8sObject } from '@/lib/api'
 
+// Prevent real network calls; keep the promise pending so we can inspect
+// the initial render before any async state update.
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>()
+  return {
+    ...actual,
+    listInstances: vi.fn(() => new Promise(() => {})),
+  }
+})
+
 function renderCard(rgd: K8sObject) {
   return render(
     <MemoryRouter>
@@ -95,5 +105,21 @@ describe('RGDCard', () => {
     const { container } = renderCard(makeRGD())
     const dot = container.querySelector('.status-dot')
     expect(dot).toHaveClass('status-dot--ready')
+  })
+
+  // Regression: #262 — chipLoading must be initialised to Boolean(name) so that
+  // HealthChip does NOT flash a skeleton shimmer when the card has no name.
+  it('does not render health-chip skeleton on first render when name is absent', () => {
+    const { container } = renderCard(
+      makeRGD({ metadata: { creationTimestamp: '2026-03-15T10:00:00Z' } }),
+    )
+    // When name is empty, chipLoading starts false → no skeleton element
+    expect(container.querySelector('.health-chip--skeleton')).not.toBeInTheDocument()
+  })
+
+  it('renders health-chip skeleton on first render when name is present', () => {
+    const { container } = renderCard(makeRGD())
+    // When name is non-empty, chipLoading starts true → skeleton visible before fetch
+    expect(container.querySelector('.health-chip--skeleton')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

- The `chipLoading` state in `RGDCard` was already fixed to initialise as `Boolean(name)` (landed in a recent batch PR), but there were no tests asserting the initial render behaviour.
- This PR adds two regression tests to prevent the bug from regressing.

## Root Cause

`chipLoading` was initialised unconditionally to `true`, causing `HealthChip` to render a skeleton shimmer for one frame even when `name` is empty and no fetch would ever be made. The fix is `useState(Boolean(name))`.

## Fix

Added two regression tests to `RGDCard.test.tsx`:
- **No skeleton on first render when `name` is absent** — asserts `.health-chip--skeleton` is not in the DOM when the card has no name.
- **Skeleton visible on first render when `name` is present** — asserts `.health-chip--skeleton` appears immediately (before the mocked `listInstances` promise resolves), confirming `chipLoading` starts `true` for named cards.

`listInstances` is mocked to return a never-resolving promise so the initial render state is inspectable without async interference.

Closes #262