### PR TITLE
fix(web): state/pending nodes in live DAG panel — no YAML fetch, no stale badge

### DIFF
--- a/web/src/components/LiveNodeDetailPanel.test.tsx
+++ b/web/src/components/LiveNodeDetailPanel.test.tsx
@@ -1,0 +1,362 @@
+// LiveNodeDetailPanel.test.tsx — regression tests for live-mode node detail panel.
+//
+// Covers the three bugs fixed in the node-detail exploration session:
+//
+//   Bug 1: State nodes (nodeType='state') must NOT show a "Live YAML" section or
+//          attempt any API fetch. They produce no Kubernetes objects.
+//
+//   Bug 2: State nodes must NOT show a live-state badge ("Not Found", etc.).
+//          The badge is only meaningful for nodes that map to cluster resources.
+//
+//   Bug 3: Pending nodes (liveState='pending', excluded by includeWhen) must NOT
+//          show a "Live YAML" section or the misleading "CRD may not be provisioned"
+//          error. They are absent by design, not because their CRD is missing.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import LiveNodeDetailPanel from './LiveNodeDetailPanel'
+import type { DAGNode } from '@/lib/dag'
+
+// ── API mock ──────────────────────────────────────────────────────────────
+// getResource must be mocked so tests don't fire real network calls.
+// Tests for state/pending nodes assert it is NEVER called.
+
+vi.mock('@/lib/api', () => ({
+  getResource: vi.fn(),
+}))
+
+import { getResource } from '@/lib/api'
+const mockedGetResource = vi.mocked(getResource)
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function makeNode(overrides: Partial<DAGNode>): DAGNode {
+  return {
+    id: 'testNode',
+    label: 'testNode',
+    nodeType: 'resource',
+    kind: 'ConfigMap',
+    isConditional: false,
+    hasReadyWhen: false,
+    celExpressions: [],
+    includeWhen: [],
+    readyWhen: [],
+    isChainable: false,
+    x: 0,
+    y: 0,
+    width: 180,
+    height: 48,
+    ...overrides,
+  }
+}
+
+function makeResourceInfo() {
+  return {
+    kind: 'ConfigMap',
+    name: 'my-configmap',
+    namespace: 'default',
+    group: '',
+    version: 'v1',
+  }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('LiveNodeDetailPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default: resource fetch succeeds (for non-excluded nodes)
+    mockedGetResource.mockResolvedValue({
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { name: 'my-configmap', namespace: 'default' },
+    })
+  })
+
+  // ── Bug 1: State nodes must not show LIVE YAML or trigger API fetch ───────
+
+  it('Bug-1a: state node does not render "Live YAML" section label', () => {
+    const node = makeNode({
+      id: 'combatResolve',
+      label: 'combatResolve',
+      nodeType: 'state',
+      kind: '',
+      includeWhen: ['${schema.spec.attackSeq > kstate(schema.status.game, "seq", 0)}'],
+      isConditional: true,
+    })
+    render(
+      <LiveNodeDetailPanel
+        node={node}
+        liveState={undefined}
+        resourceInfo={makeResourceInfo()}
+        onClose={() => {}}
+      />,
+    )
+
+    expect(screen.queryByText('Live YAML')).not.toBeInTheDocument()
+  })
+
+  it('Bug-1b: state node does not call getResource', () => {
+    const node = makeNode({
+      id: 'dungeonInit',
+      label: 'dungeonInit',
+      nodeType: 'state',
+      kind: '',
+    })
+    render(
+      <LiveNodeDetailPanel
+        node={node}
+        liveState={undefined}
+        resourceInfo={makeResourceInfo()}
+        onClose={() => {}}
+      />,
+    )
+
+    expect(mockedGetResource).not.toHaveBeenCalled()
+  })
+
+  it('Bug-1c: state node shows the "State store node" note instead of YAML', () => {
+    const node = makeNode({
+      id: 'actionResolve',
+      label: 'actionResolve',
+      nodeType: 'state',
+      kind: '',
+    })
+    render(
+      <LiveNodeDetailPanel
+        node={node}
+        liveState={undefined}
+        resourceInfo={null}
+        onClose={() => {}}
+      />,
+    )
+
+    expect(screen.getByText(/state store node/i)).toBeInTheDocument()
+  })
+
+  it('Bug-1d: state node shows its includeWhen expression', () => {
+    const expr = '${kstate(schema.status.game, "initProcessedSeq", 0) == 0}'
+    const node = makeNode({
+      id: 'dungeonInit',
+      label: 'dungeonInit',
+      nodeType: 'state',
+      kind: '',
+      includeWhen: [expr],
+      isConditional: true,
+    })
+    render(
+      <LiveNodeDetailPanel
+        node={node}
+        liveState={undefined}
+        resourceInfo={null}
+        onClose={() => {}}
+      />,
+    )
+
+    // Include When section must be rendered
+    expect(screen.getByText('Include When')).toBeInTheDocument()
+    // No YAML section
+    expect(screen.queryByText('Live YAML')).not.toBeInTheDocument()
+  })
+
+  // ── Bug 2: State nodes must not show a live-state badge ──────────────────
+
+  it('Bug-2a: state node renders no live-state badge when liveState is undefined', () => {
+    const node = makeNode({
+      id: 'tickDoT',
+      label: 'tickDoT',
+      nodeType: 'state',
+      kind: '',
+    })
+    const { container } = render(
+      <LiveNodeDetailPanel
+        node={node}
+        liveState={undefined}
+        resourceInfo={null}
+        onClose={() => {}}
+      />,
+    )
+
+    // The live-state badge uses data-testid="node-detail-state-badge"
+    expect(container.querySelector('[data-testid="node-detail-state-badge"]')).toBeNull()
+  })
+
+  it('Bug-2b: resource node correctly shows Ready badge when liveState=alive', () => {
+    const node = makeNode({
+      id: 'configMap',
+      label: 'configMap',
+      nodeType: 'resource',
+      kind: 'ConfigMap',
+    })
+    render(
+      <LiveNodeDetailPanel
+        node={node}
+        liveState="alive"
+        resourceInfo={makeResourceInfo()}
+        onClose={() => {}}
+      />,
+    )
+
+    const badge = screen.getByTestId('node-detail-state-badge')
+    expect(badge).toHaveTextContent('Ready')
+  })
+
+  // ── Bug 3: Pending nodes (excluded by includeWhen) show accurate messaging ───
+  //
+  // InstanceDetail suppresses resourceInfo (returns null) for pending/not-found nodes.
+  // The panel then renders an inline note inside "Live YAML" instead of fetching.
+  // The state badge label is "Excluded" — more accurate than "Pending" since the
+  // resource is excluded by includeWhen, not waiting to be created.
+
+  it('Bug-3a: pending node with null resourceInfo does not call getResource', () => {
+    const node = makeNode({
+      id: 'modifierCR',
+      label: 'modifierCR',
+      nodeType: 'resource',
+      kind: 'Modifier',
+      includeWhen: ['${kstate(schema.status.game, "modifier", "none") != "none"}'],
+      isConditional: true,
+    })
+    render(
+      <LiveNodeDetailPanel
+        node={node}
+        liveState="pending"
+        resourceInfo={null}
+        onClose={() => {}}
+      />,
+    )
+
+    expect(mockedGetResource).not.toHaveBeenCalled()
+  })
+
+  it('Bug-3b: pending node with null resourceInfo shows "excluded by includeWhen" message', () => {
+    const node = makeNode({
+      id: 'modifierCR',
+      label: 'modifierCR',
+      nodeType: 'resource',
+      kind: 'Modifier',
+      includeWhen: ['${kstate(schema.status.game, "modifier", "none") != "none"}'],
+      isConditional: true,
+    })
+    render(
+      <LiveNodeDetailPanel
+        node={node}
+        liveState="pending"
+        resourceInfo={null}
+        onClose={() => {}}
+      />,
+    )
+
+    expect(screen.getByText(/excluded by its/i)).toBeInTheDocument()
+  })
+
+  it('Bug-3c: pending node with null resourceInfo does not show the misleading CRD error', () => {
+    const node = makeNode({
+      id: 'modifierCR',
+      label: 'modifierCR',
+      nodeType: 'resource',
+      kind: 'Modifier',
+      includeWhen: ['${kstate(schema.status.game, "modifier", "none") != "none"}'],
+      isConditional: true,
+    })
+    render(
+      <LiveNodeDetailPanel
+        node={node}
+        liveState="pending"
+        resourceInfo={null}
+        onClose={() => {}}
+      />,
+    )
+
+    expect(screen.queryByText(/CRD may not be provisioned/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/API server doesn't recognise/i)).not.toBeInTheDocument()
+  })
+
+  it('Bug-3d: pending resource node still shows includeWhen and readyWhen sections', () => {
+    const node = makeNode({
+      id: 'modifierCR',
+      label: 'modifierCR',
+      nodeType: 'resource',
+      kind: 'Modifier',
+      includeWhen: ['${kstate(schema.status.game, "modifier", "none") != "none"}'],
+      readyWhen: ['${modifierCR.status.?modifierType.orValue("") != ""}'],
+      isConditional: true,
+      hasReadyWhen: true,
+    })
+    render(
+      <LiveNodeDetailPanel
+        node={node}
+        liveState="pending"
+        resourceInfo={null}
+        onClose={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('Include When')).toBeInTheDocument()
+    expect(screen.getByText('Ready When')).toBeInTheDocument()
+  })
+
+  it('Bug-3e: pending resource node shows "Excluded" state badge', () => {
+    const node = makeNode({
+      id: 'modifierCR',
+      label: 'modifierCR',
+      nodeType: 'resource',
+      kind: 'Modifier',
+      includeWhen: ['${kstate(schema.status.game, "modifier", "none") != "none"}'],
+      isConditional: true,
+    })
+    render(
+      <LiveNodeDetailPanel
+        node={node}
+        liveState="pending"
+        resourceInfo={null}
+        onClose={() => {}}
+      />,
+    )
+
+    const badge = screen.getByTestId('node-detail-state-badge')
+    // "Excluded" is used instead of "Pending" — the resource is excluded by
+    // includeWhen, not waiting to be created
+    expect(badge).toHaveTextContent('Excluded')
+  })
+
+  // ── Positive: non-pending resource node still gets YAML section ──────────
+
+  it('positive: non-pending resource node renders "Live YAML" section', () => {
+    const node = makeNode({
+      id: 'heroCR',
+      label: 'heroCR',
+      nodeType: 'resource',
+      kind: 'Hero',
+    })
+    render(
+      <LiveNodeDetailPanel
+        node={node}
+        liveState="alive"
+        resourceInfo={makeResourceInfo()}
+        onClose={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('Live YAML')).toBeInTheDocument()
+  })
+
+  it('positive: non-pending resource node calls getResource for the YAML fetch', () => {
+    const node = makeNode({
+      id: 'gameConfig',
+      label: 'gameConfig',
+      nodeType: 'resource',
+      kind: 'ConfigMap',
+    })
+    render(
+      <LiveNodeDetailPanel
+        node={node}
+        liveState="alive"
+        resourceInfo={makeResourceInfo()}
+        onClose={() => {}}
+      />,
+    )
+
+    expect(mockedGetResource).toHaveBeenCalledOnce()
+  })
+})

--- a/web/src/components/LiveNodeDetailPanel.tsx
+++ b/web/src/components/LiveNodeDetailPanel.tsx
@@ -50,7 +50,9 @@ const STATE_LABEL: Record<NodeLiveState, string> = {
   alive: 'Ready',
   reconciling: 'Reconciling',
   error: 'Error',
-  pending: 'Pending',
+  // 'pending' means includeWhen evaluated to false — kro never created the resource.
+  // "Excluded" is more accurate than "Pending" (which implies "waiting to be created").
+  pending: 'Excluded',
   'not-found': 'Not Found',
 }
 
@@ -221,6 +223,10 @@ const CONCEPT_TEXT: Record<string, string> = {
   externalCollection:
     'External Reference Collection — References to pre-existing Kubernetes resources ' +
     'matched by label selector. kro reads them but does not create or own them.',
+  state:
+    'State Store — A kro state node. It does not create any Kubernetes resource; ' +
+    "instead it computes values and stores them in kro's internal state store (kstate()). " +
+    "Other resources can reference these values via ${kstate(schema.status.storeName, 'field', default)}.",
 }
 
 const TYPE_ICON: Record<string, string> = {
@@ -229,6 +235,7 @@ const TYPE_ICON: Record<string, string> = {
   collection: '∀',
   external: '⬡',
   externalCollection: '⬡',
+  state: '⊞',
 }
 
 /** Filter blank CEL expressions before rendering. */
@@ -270,6 +277,8 @@ export default function LiveNodeDetailPanel({
   const extMeta = extRef?.metadata as Record<string, unknown> | undefined
 
   const isForEach = node.nodeType === 'collection'
+  // State nodes produce no Kubernetes objects — never fetch YAML for them.
+  const isStateNode = node.nodeType === 'state'
 
   // ── Deletion metadata from fetched raw resource (FR-006) ──────────────────
   // Populated via the onRawObj callback from YamlSection when the resource fetch succeeds.
@@ -331,7 +340,7 @@ export default function LiveNodeDetailPanel({
             </span>
             {node.isConditional && (
               <span className="node-conditional-badge">
-                <span>?</span>
+                <span aria-hidden="true">◈</span>
                 <span>conditional</span>
               </span>
             )}
@@ -354,19 +363,42 @@ export default function LiveNodeDetailPanel({
           </Section>
         )}
 
-        {/* YAML section — resource and external nodes only */}
-        {!isForEach && node.nodeType !== 'instance' && (
-          <Section label="Live YAML">
-            <YamlSection
-              nodeId={node.id}
-              resourceInfo={resourceInfo}
-              onRawObj={setRawResourceObj}
-            />
+        {/* State node guidance — no YAML fetch (state nodes produce no K8s objects) */}
+        {isStateNode && (
+          <Section label="Note">
+            <p className="node-detail-concept node-detail-foreach-note">
+              State store node — no Kubernetes resource is created for this node.
+              It computes values and writes them into kro&apos;s internal state store.
+            </p>
           </Section>
         )}
 
-        {/* Finalizers (FR-006) — shown after YAML section for non-instance, non-forEach nodes */}
-        {!isForEach && node.nodeType !== 'instance' && resourceFinalizers.length > 0 && (
+        {/* YAML section — resource and external nodes only.
+            Suppressed for state nodes (no K8s object) and when resourceInfo is
+            null (node absent — pending/not-found). */}
+        {!isForEach && !isStateNode && node.nodeType !== 'instance' && (
+          <Section label="Live YAML">
+            {resourceInfo ? (
+              <YamlSection
+                nodeId={node.id}
+                resourceInfo={resourceInfo}
+                onRawObj={setRawResourceObj}
+              />
+            ) : liveState === 'pending' ? (
+              <p className="node-yaml-absent-note">
+                This resource is excluded by its <code>includeWhen</code> condition — it has
+                not been created yet.
+              </p>
+            ) : (
+              <p className="node-yaml-absent-note">
+                Resource not yet present in the cluster.
+              </p>
+            )}
+          </Section>
+        )}
+
+        {/* Finalizers (FR-006) — shown after YAML section for non-instance, non-forEach, non-state nodes */}
+        {!isForEach && !isStateNode && node.nodeType !== 'instance' && resourceFinalizers.length > 0 && (
           <Section label="Finalizers">
             <FinalizersPanel
               finalizers={resourceFinalizers}

--- a/web/src/components/NodeDetailPanel.tsx
+++ b/web/src/components/NodeDetailPanel.tsx
@@ -129,7 +129,7 @@ export default function NodeDetailPanel({ node, onClose }: NodeDetailPanelProps)
             </span>
             {node.isConditional && (
               <span className="node-conditional-badge">
-                <span>?</span>
+                <span aria-hidden="true">◈</span>
                 <span>conditional</span>
               </span>
             )}

--- a/web/src/pages/InstanceDetail.test.tsx
+++ b/web/src/pages/InstanceDetail.test.tsx
@@ -3,8 +3,12 @@
 // Issue #217: InstanceDetail was the only major page without tests.
 // Covers breadcrumb navigation, loading/error/success states, polling cleanup,
 // and graceful degradation for absent status.conditions.
+//
+// Regression tests added for state-node live-state badge (Bug-2):
+//   - Clicking a state node must NOT show a live-state badge ("Not Found", etc.).
+//   - State nodes produce no K8s resources; they have no meaningful live state.
 
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import InstanceDetail from './InstanceDetail'
 
@@ -16,6 +20,7 @@ vi.mock('@/lib/api', () => ({
   getInstanceChildren: vi.fn(),
   getRGD: vi.fn(),
   listRGDs: vi.fn(),
+  getResource: vi.fn(),
 }))
 
 import {
@@ -24,6 +29,7 @@ import {
   getInstanceChildren,
   getRGD,
   listRGDs,
+  getResource,
 } from '@/lib/api'
 
 const mockedGetInstance = vi.mocked(getInstance)
@@ -31,6 +37,7 @@ const mockedGetInstanceEvents = vi.mocked(getInstanceEvents)
 const mockedGetInstanceChildren = vi.mocked(getInstanceChildren)
 const mockedGetRGD = vi.mocked(getRGD)
 const mockedListRGDs = vi.mocked(listRGDs)
+const mockedGetResource = vi.mocked(getResource)
 
 // ── Test helpers ────────────────────────────────────────────────────────────
 
@@ -56,6 +63,27 @@ function makeRGD(name = 'test-app') {
       schema: { kind: 'WebApp', apiVersion: 'v1alpha1', group: 'app.k8s.io' },
       resources: [
         { id: 'cfg', template: { apiVersion: 'v1', kind: 'ConfigMap' } },
+      ],
+    },
+  }
+}
+
+/** RGD that includes one regular resource and one state node. */
+function makeRGDWithStateNode(name = 'test-app') {
+  return {
+    metadata: { name },
+    spec: {
+      schema: { kind: 'WebApp', apiVersion: 'v1alpha1', group: 'app.k8s.io' },
+      resources: [
+        { id: 'cfg', template: { apiVersion: 'v1', kind: 'ConfigMap' } },
+        {
+          id: 'initState',
+          includeWhen: ['${schema.spec.init == true}'],
+          state: {
+            storeName: 'game',
+            fields: { counter: '${0}' },
+          },
+        },
       ],
     },
   }
@@ -89,6 +117,8 @@ describe('InstanceDetail', () => {
     mockedGetInstanceChildren.mockResolvedValue({ items: [] })
     mockedGetRGD.mockResolvedValue(makeRGD())
     mockedListRGDs.mockResolvedValue({ items: [], metadata: {} })
+    // getResource is called by LiveNodeDetailPanel for YAML fetch
+    mockedGetResource.mockResolvedValue({ apiVersion: 'v1', kind: 'ConfigMap', metadata: { name: 'x', namespace: 'default' } })
   })
 
   // ── Loading state ──────────────────────────────────────────────────────────
@@ -167,5 +197,69 @@ describe('InstanceDetail', () => {
     // At least one clearInterval should fire (children interval + tick interval)
     expect(clearIntervalSpy).toHaveBeenCalled()
     clearIntervalSpy.mockRestore()
+  })
+
+  // ── Bug-2 regression: state node live-state badge ──────────────────────────
+  // State nodes produce no K8s resources; they must not show a live-state badge
+  // ("Not Found") when clicked in the instance detail live DAG.
+
+  it('Bug-2a: clicking a state node does not show a live-state badge', async () => {
+    mockedGetRGD.mockResolvedValue(makeRGDWithStateNode())
+    renderPage()
+
+    // Wait for the DAG to render with the state node
+    await waitFor(() => {
+      expect(screen.getByTestId('dag-node-initState')).toBeInTheDocument()
+    })
+
+    // Click the state node
+    fireEvent.click(screen.getByTestId('dag-node-initState'))
+
+    // Panel must open (node id appears in the panel header)
+    await waitFor(() => {
+      expect(screen.getByTestId('node-detail-panel')).toBeInTheDocument()
+    })
+
+    // No live-state badge for state nodes
+    expect(screen.queryByTestId('node-detail-state-badge')).not.toBeInTheDocument()
+  })
+
+  it('Bug-2b: clicking a state node does not show "Not Found" text', async () => {
+    mockedGetRGD.mockResolvedValue(makeRGDWithStateNode())
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dag-node-initState')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByTestId('dag-node-initState'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('node-detail-panel')).toBeInTheDocument()
+    })
+
+    // "Not Found" must not appear — state nodes have no live cluster state
+    const badge = screen.queryByTestId('node-detail-state-badge')
+    expect(badge).toBeNull()
+    // Also confirm the text "Not Found" does not leak into the panel
+    expect(screen.queryByText('Not Found')).not.toBeInTheDocument()
+  })
+
+  it('Bug-2c: clicking a resource node (cfg) still shows a live-state badge', async () => {
+    mockedGetRGD.mockResolvedValue(makeRGDWithStateNode())
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dag-node-cfg')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByTestId('dag-node-cfg'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('node-detail-panel')).toBeInTheDocument()
+    })
+
+    // Resource node must have a badge (Not Found because no children were returned)
+    expect(screen.getByTestId('node-detail-state-badge')).toBeInTheDocument()
   })
 })

--- a/web/src/pages/InstanceDetail.tsx
+++ b/web/src/pages/InstanceDetail.tsx
@@ -249,13 +249,22 @@ export default function InstanceDetail() {
     if (selectedNode.nodeType === 'collection') return null
     // Root instance node: no YAML
     if (selectedNode.nodeType === 'instance') return null
+    // Absent nodes: don't attempt a YAML fetch that will always fail.
+    // 'pending'   = includeWhen condition is false — resource was never created.
+    // 'not-found' = resource not yet created (e.g. kro still reconciling).
+    // In both cases resolveChildResourceInfo falls through to a guessed name,
+    // the API call fails with "resource type not found", and the panel shows a
+    // misleading error. Suppress the section instead.
+    const kindKey = (selectedNode.kind || selectedNode.label).toLowerCase()
+    const liveState = nodeStateMap[kindKey]?.state
+    if (liveState === 'pending' || liveState === 'not-found') return null
     return resolveChildResourceInfo(
       selectedNode.label,
       instanceName,
       children,
       selectedNode.kind || undefined,
     )
-  }, [selectedNode, instanceName, children])
+  }, [selectedNode, instanceName, children, nodeStateMap])
 
   // ── Live state for the selected node ────────────────────────────────────
   // Fall back to 'not-found' when children haven't loaded yet — ensures the
@@ -269,6 +278,9 @@ export default function InstanceDetail() {
       if (states.length > 0) return 'alive'
       return 'not-found'
     }
+    // State nodes produce no K8s resources — they have no meaningful live state.
+    // Returning undefined suppresses the state badge entirely for these nodes.
+    if (selectedNode.nodeType === 'state') return undefined
     const kindKey = (selectedNode.kind || selectedNode.label).toLowerCase()
     return nodeStateMap[kindKey]?.state ?? 'not-found'
   }, [selectedNode, fastData, nodeStateMap])


### PR DESCRIPTION
## Summary

- **State nodes** (orange nodes like `combatResolve`, `dungeonInit`) were triggering a YAML fetch and showing a misleading _"The API server doesn't recognise this resource type — the CRD may not be provisioned yet"_ error. State nodes produce **no Kubernetes objects**; they compute values into kro's internal state store only.
- **Pending nodes** (e.g. `modifierCR` when its `includeWhen` condition is false) showed the same CRD error. The resource is absent **by design**, not because the CRD is missing.
- **State nodes** also showed a stale _"Not Found"_ live-state badge, which is meaningless since they have no cluster resource to find.

## Changes

| File | What |
|------|------|
| `LiveNodeDetailPanel.tsx` | Exclude `state` nodes from YAML section entirely; add "State store node" Note. Suppress YAML section when `resourceInfo` is null (pending/not-found). Rename `pending` badge label from "Pending" → "Excluded". Add concept text + icon for state node type. |
| `InstanceDetail.tsx` | Return `null` resourceInfo for `pending`/`not-found` nodes (prevents inference-fallback fetch that always 404s). Return `undefined` liveState for `state` nodes (suppresses "Not Found" badge). |
| `NodeDetailPanel.tsx` | Use `◈` aria-hidden icon for conditional badge (cosmetic). |
| `LiveNodeDetailPanel.test.tsx` | **New file** — 13 tests: Bug-1 (state node YAML), Bug-2 (state node badge), Bug-3 (pending node messaging + no fetch), positive controls. |
| `InstanceDetail.test.tsx` | +3 integration tests: clicking a state node shows no badge; clicking a resource node still shows badge. |

## Testing

```
bun test   # 56 files, 872 tests, all pass
```

Manually verified on live cluster against `dungeon-graph` RGD:
- `combatResolve` (state) → shows "State store node" note, no YAML, no badge ✓
- `modifierCR` on `ellis` (pending, `modifier="none"`) → shows "excluded by includeWhen" note, no CRD error ✓  
- `modifierCR` on `carrlos` (alive, `modifier="curse-darkness"`) → shows full YAML as before ✓

Closes #270