### PR TITLE
feat(web): degraded health state, multi-segment health bar, copy YAML button

### DIFF
--- a/web/src/components/CopySpecButton.css
+++ b/web/src/components/CopySpecButton.css
@@ -1,0 +1,42 @@
+/* CopySpecButton.css — Copy YAML button for instance detail header.
+ * All colors via tokens.css — no hardcoded hex.
+ * F-6: Copy instance spec as YAML.
+ */
+
+.copy-spec-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-2);
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.5;
+  cursor: pointer;
+  user-select: none;
+  transition: color var(--transition-fast),
+              border-color var(--transition-fast),
+              background var(--transition-fast);
+  white-space: nowrap;
+}
+
+.copy-spec-btn:hover {
+  color: var(--color-text);
+  border-color: var(--color-border-strong);
+  background: var(--color-surface-3);
+}
+
+.copy-spec-btn:active {
+  background: var(--color-surface);
+}
+
+/* Confirmed state — brief green flash */
+.copy-spec-btn--copied {
+  color: var(--color-status-ready);
+  border-color: var(--color-alive);
+  background: var(--node-alive-bg);
+  cursor: default;
+}

--- a/web/src/components/CopySpecButton.tsx
+++ b/web/src/components/CopySpecButton.tsx
@@ -1,0 +1,138 @@
+// CopySpecButton.tsx — Copy instance spec to clipboard as YAML.
+//
+// Placed in the instance detail header. Converts spec.* fields to YAML
+// text and writes it to the clipboard using the Clipboard API with a
+// graceful fallback. Shows a brief "Copied!" confirmation.
+//
+// F-6: Copy instance spec as YAML from instance detail page.
+
+import { useState, useCallback } from 'react'
+import type { K8sObject } from '@/lib/api'
+import './CopySpecButton.css'
+
+interface CopySpecButtonProps {
+  instance: K8sObject
+}
+
+/**
+ * Minimal YAML serialiser for spec fields — no external dependency.
+ * Handles: strings, numbers, booleans, null, arrays of primitives, nested objects.
+ * Output matches the hand-written YAML style used by kubectl.
+ */
+function specToYaml(instance: K8sObject): string {
+  const meta = instance.metadata as Record<string, unknown> | undefined
+  const spec = instance.spec as Record<string, unknown> | undefined
+
+  const name = typeof meta?.name === 'string' ? meta.name : ''
+  const namespace = typeof meta?.namespace === 'string' ? meta.namespace : ''
+  const apiVersion = typeof instance.apiVersion === 'string' ? instance.apiVersion : ''
+  const kind = typeof instance.kind === 'string' ? instance.kind : ''
+
+  const lines: string[] = []
+  if (apiVersion) lines.push(`apiVersion: ${apiVersion}`)
+  if (kind) lines.push(`kind: ${kind}`)
+  lines.push('metadata:')
+  if (name) lines.push(`  name: ${name}`)
+  if (namespace) lines.push(`  namespace: ${namespace}`)
+
+  if (spec && Object.keys(spec).length > 0) {
+    lines.push('spec:')
+    appendObject(lines, spec, '  ')
+  }
+
+  return lines.join('\n') + '\n'
+}
+
+function appendValue(lines: string[], key: string, value: unknown, indent: string): void {
+  if (value === null || value === undefined) {
+    lines.push(`${indent}${key}: null`)
+  } else if (typeof value === 'boolean' || typeof value === 'number') {
+    lines.push(`${indent}${key}: ${value}`)
+  } else if (typeof value === 'string') {
+    // Quote strings that contain special chars or look like numbers/booleans
+    const needsQuote = /[:{}\[\]|>&*!,#?@`"'\\]/.test(value) ||
+      value === '' || value === 'true' || value === 'false' ||
+      value === 'null' || /^\d/.test(value)
+    lines.push(`${indent}${key}: ${needsQuote ? JSON.stringify(value) : value}`)
+  } else if (Array.isArray(value)) {
+    if (value.length === 0) {
+      lines.push(`${indent}${key}: []`)
+    } else {
+      lines.push(`${indent}${key}:`)
+      for (const item of value) {
+        if (typeof item === 'object' && item !== null) {
+          const entries = Object.entries(item as Record<string, unknown>)
+          if (entries.length > 0) {
+            const [firstKey, firstVal] = entries[0]
+            lines.push(`${indent}  - ${firstKey}: ${firstVal}`)
+            for (let i = 1; i < entries.length; i++) {
+              lines.push(`${indent}    ${entries[i][0]}: ${entries[i][1]}`)
+            }
+          } else {
+            lines.push(`${indent}  - {}`)
+          }
+        } else {
+          lines.push(`${indent}  - ${item}`)
+        }
+      }
+    }
+  } else if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+    if (entries.length === 0) {
+      lines.push(`${indent}${key}: {}`)
+    } else {
+      lines.push(`${indent}${key}:`)
+      appendObject(lines, value as Record<string, unknown>, indent + '  ')
+    }
+  }
+}
+
+function appendObject(lines: string[], obj: Record<string, unknown>, indent: string): void {
+  for (const [key, val] of Object.entries(obj)) {
+    appendValue(lines, key, val, indent)
+  }
+}
+
+/**
+ * CopySpecButton — clipboard button that copies the full instance YAML.
+ *
+ * Renders a small icon button. On click, serialises the instance spec
+ * to YAML and writes it to the clipboard. Shows "Copied!" for 2 seconds.
+ * Falls back to a textarea select + execCommand when Clipboard API is
+ * unavailable (HTTP context or older browsers).
+ */
+export default function CopySpecButton({ instance }: CopySpecButtonProps) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = useCallback(async () => {
+    const yaml = specToYaml(instance)
+    try {
+      await navigator.clipboard.writeText(yaml)
+    } catch {
+      // Fallback for HTTP or browsers without clipboard API
+      const el = document.createElement('textarea')
+      el.value = yaml
+      el.style.position = 'fixed'
+      el.style.opacity = '0'
+      document.body.appendChild(el)
+      el.select()
+      document.execCommand('copy')
+      document.body.removeChild(el)
+    }
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }, [instance])
+
+  return (
+    <button
+      type="button"
+      className={`copy-spec-btn${copied ? ' copy-spec-btn--copied' : ''}`}
+      onClick={handleCopy}
+      aria-label="Copy instance spec as YAML"
+      title="Copy spec as YAML"
+      data-testid="copy-spec-btn"
+    >
+      {copied ? '✓ Copied!' : '⎘ Copy YAML'}
+    </button>
+  )
+}

--- a/web/src/components/HealthChip.css
+++ b/web/src/components/HealthChip.css
@@ -23,6 +23,11 @@
   color: var(--color-alive);
 }
 
+/* Any instance degraded (CR ready but child errors) — orange */
+.health-chip--degraded {
+  color: var(--color-status-degraded);
+}
+
 /* Any instance has Ready=False — rose */
 .health-chip--error {
   color: var(--color-status-error);
@@ -47,6 +52,24 @@
 .health-chip--empty {
   color: var(--color-text-muted);
 }
+
+/* Multi-segment bar layout — shown when health is mixed */
+.health-chip--bar {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.health-chip__segment {
+  white-space: nowrap;
+}
+
+.health-chip__segment--error       { color: var(--color-status-error); }
+.health-chip__segment--degraded     { color: var(--color-status-degraded); }
+.health-chip__segment--reconciling  { color: var(--color-status-reconciling); }
+.health-chip__segment--pending      { color: var(--color-status-pending); }
+.health-chip__segment--unknown      { color: var(--color-status-unknown); }
+.health-chip__segment--ready        { color: var(--color-text-muted); }
 
 /* Loading skeleton */
 .health-chip--skeleton {

--- a/web/src/components/HealthChip.test.tsx
+++ b/web/src/components/HealthChip.test.tsx
@@ -9,6 +9,7 @@ function makeSummary(overrides: Partial<HealthSummary> = {}): HealthSummary {
   return {
     total: 0,
     ready: 0,
+    degraded: 0,
     error: 0,
     reconciling: 0,
     pending: 0,
@@ -42,27 +43,39 @@ describe('HealthChip', () => {
     expect(chip).toHaveAttribute('data-state', 'ready')
   })
 
-  it('renders "{ready} / {total} ready" when error > 0, uses data-state="error"', () => {
+  it('renders bar segments when error > 0, uses data-state="error"', () => {
     const summary = makeSummary({ total: 5, ready: 3, error: 2 })
     render(<HealthChip summary={summary} />)
     const chip = screen.getByTestId('health-chip')
-    expect(chip).toHaveTextContent('3 / 5 ready')
+    expect(chip).toHaveTextContent('✗ 2')
+    expect(chip).toHaveTextContent('3 ready')
     expect(chip).toHaveAttribute('data-state', 'error')
   })
 
-  it('renders "{ready} / {total} ready" when reconciling > 0 (no errors), uses data-state="reconciling"', () => {
+  it('renders bar segments when reconciling > 0 (no errors), uses data-state="reconciling"', () => {
     const summary = makeSummary({ total: 5, ready: 3, reconciling: 2 })
     render(<HealthChip summary={summary} />)
     const chip = screen.getByTestId('health-chip')
-    expect(chip).toHaveTextContent('3 / 5 ready')
+    expect(chip).toHaveTextContent('↻ 2')
+    expect(chip).toHaveTextContent('3 ready')
     expect(chip).toHaveAttribute('data-state', 'reconciling')
   })
 
-  it('renders "{ready} / {total} ready" when only unknown, uses data-state="unknown"', () => {
+  it('renders bar segments when degraded > 0, uses data-state="degraded"', () => {
+    const summary = makeSummary({ total: 3, ready: 2, degraded: 1 })
+    render(<HealthChip summary={summary} />)
+    const chip = screen.getByTestId('health-chip')
+    expect(chip).toHaveTextContent('⚠ 1')
+    expect(chip).toHaveTextContent('2 ready')
+    expect(chip).toHaveAttribute('data-state', 'degraded')
+  })
+
+  it('renders bar segments when only unknown, uses data-state="unknown"', () => {
     const summary = makeSummary({ total: 3, ready: 1, unknown: 2 })
     render(<HealthChip summary={summary} />)
     const chip = screen.getByTestId('health-chip')
-    expect(chip).toHaveTextContent('1 / 3 ready')
+    expect(chip).toHaveTextContent('? 2')
+    expect(chip).toHaveTextContent('1 ready')
     expect(chip).toHaveAttribute('data-state', 'unknown')
   })
 
@@ -71,6 +84,18 @@ describe('HealthChip', () => {
     render(<HealthChip summary={summary} />)
     const chip = screen.getByTestId('health-chip')
     expect(chip).toHaveAttribute('data-state', 'error')
+  })
+
+  it('degraded takes precedence over reconciling but not error', () => {
+    const summary = makeSummary({ total: 6, ready: 2, degraded: 2, reconciling: 2 })
+    render(<HealthChip summary={summary} />)
+    expect(screen.getByTestId('health-chip')).toHaveAttribute('data-state', 'degraded')
+    const summary2 = makeSummary({ total: 6, ready: 1, error: 1, degraded: 2, reconciling: 2 })
+    const { unmount } = render(<HealthChip summary={summary2} />)
+    // error wins over degraded
+    const chips = screen.getAllByTestId('health-chip')
+    expect(chips[chips.length - 1]).toHaveAttribute('data-state', 'error')
+    unmount()
   })
 
   it('always renders data-testid="health-chip" when summary is present', () => {

--- a/web/src/components/HealthChip.tsx
+++ b/web/src/components/HealthChip.tsx
@@ -1,7 +1,10 @@
-// HealthChip.tsx — Compact instance health summary chip for RGDCard.
+// HealthChip.tsx — Instance health summary chip for RGDCard.
 //
-// Shows "{ready} / {total} ready", "{total} ready", or "no instances"
-// depending on the aggregated health across all instances of an RGD.
+// F-7: Shows a multi-segment bar with counts per health state.
+// When all instances are ready: "{N} ready" in green.
+// When there are non-ready instances: shows each non-ready count as a
+// separate colored segment + the ready count, e.g.:
+//   "2 ready  1 ⚠ degraded  1 ✗ error"
 //
 // Spec: .specify/specs/028-instance-health-rollup/spec.md US1 FR-001–FR-004
 
@@ -17,15 +20,30 @@ interface HealthChipProps {
 
 /**
  * Derive the overall (worst) state from a HealthSummary.
- * Priority: error > reconciling > pending > unknown > ready
+ * Priority: error > degraded > reconciling > pending > unknown > ready
  */
 function overallState(s: HealthSummary): InstanceHealthState {
   if (s.error > 0) return 'error'
+  if (s.degraded > 0) return 'degraded'
   if (s.reconciling > 0) return 'reconciling'
   if (s.pending > 0) return 'pending'
   if (s.unknown > 0) return 'unknown'
   return 'ready'
 }
+
+interface SegmentDef {
+  state: InstanceHealthState
+  icon: string
+  label: string
+}
+
+const SEGMENTS: SegmentDef[] = [
+  { state: 'error',       icon: '✗', label: 'error'       },
+  { state: 'degraded',    icon: '⚠', label: 'degraded'    },
+  { state: 'reconciling', icon: '↻', label: 'reconciling' },
+  { state: 'pending',     icon: '…', label: 'pending'      },
+  { state: 'unknown',     icon: '?', label: 'unknown'      },
+]
 
 /**
  * HealthChip — colored text pill showing aggregated instance health for an RGD.
@@ -34,8 +52,8 @@ function overallState(s: HealthSummary): InstanceHealthState {
  *   - Skeleton while loading
  *   - Nothing when fetch failed (summary null, loading false)
  *   - "no instances" when total === 0
- *   - "{total} ready" when all instances are ready
- *   - "{ready} / {total} ready" otherwise
+ *   - "{total} ready" when all instances are ready (single green segment)
+ *   - Multi-segment bar showing each non-zero state with icon + count when mixed
  *
  * Spec: .specify/specs/028-instance-health-rollup/ FR-001, FR-002, FR-003, FR-004
  */
@@ -60,19 +78,43 @@ export default function HealthChip({ summary, loading = false }: HealthChipProps
   }
 
   const state = overallState(summary)
-  const label =
-    summary.ready === summary.total
-      ? `${summary.total} ready`
-      : `${summary.ready} / ${summary.total} ready`
+
+  // All ready — simple green label
+  if (state === 'ready') {
+    return (
+      <span
+        className="health-chip health-chip--ready"
+        data-testid="health-chip"
+        data-state="ready"
+        aria-label={`Instance health: ${summary.total} ready`}
+      >
+        {summary.total} ready
+      </span>
+    )
+  }
+
+  // Mixed — render a segment per non-zero non-ready state + ready count
+  const nonReadySegments = SEGMENTS.filter((seg) => summary[seg.state] > 0)
 
   return (
     <span
-      className={`health-chip health-chip--${state}`}
+      className={`health-chip health-chip--${state} health-chip--bar`}
       data-testid="health-chip"
       data-state={state}
-      aria-label={`Instance health: ${label}`}
+      aria-label={`Instance health: ${summary.ready} of ${summary.total} ready`}
     >
-      {label}
+      {nonReadySegments.map((seg) => (
+        <span
+          key={seg.state}
+          className={`health-chip__segment health-chip__segment--${seg.state}`}
+          title={`${summary[seg.state]} ${seg.label}`}
+        >
+          {seg.icon} {summary[seg.state]}
+        </span>
+      ))}
+      <span className="health-chip__segment health-chip__segment--ready">
+        {summary.ready} ready
+      </span>
     </span>
   )
 }

--- a/web/src/components/HealthPill.css
+++ b/web/src/components/HealthPill.css
@@ -27,6 +27,13 @@
   border: 1px solid var(--color-alive);
 }
 
+/* Ready=True but a child resource has errors — orange */
+.health-pill--degraded {
+  color: var(--color-status-degraded);
+  background: rgba(249, 115, 22, 0.10);
+  border: 1px solid var(--color-status-degraded);
+}
+
 /* Progressing=True — amber */
 .health-pill--reconciling {
   color: var(--color-status-reconciling);

--- a/web/src/components/HealthPill.tsx
+++ b/web/src/components/HealthPill.tsx
@@ -13,10 +13,11 @@ interface HealthPillProps {
   health: InstanceHealth | null
 }
 
-/** Map 5-state value to a human-readable label. */
+/** Map 6-state value to a human-readable label. */
 function pillLabel(state: string): string {
   switch (state) {
     case 'ready':       return 'Ready'
+    case 'degraded':    return 'Degraded'
     case 'reconciling': return 'Reconciling'
     case 'error':       return 'Error'
     case 'pending':     return 'Pending'
@@ -27,8 +28,8 @@ function pillLabel(state: string): string {
 /**
  * HealthPill — status pill rendered in the instance detail page header.
  *
- * Visible states: Ready (green), Reconciling (amber), Error (rose),
- *                 Pending (violet), Unknown (gray), loading skeleton.
+ * Visible states: Ready (green), Degraded (orange), Reconciling (amber),
+ *                 Error (rose), Pending (violet), Unknown (gray), loading skeleton.
  *
  * spec: .specify/specs/028-instance-health-rollup/ US3
  */

--- a/web/src/components/InstanceOverlayBar.tsx
+++ b/web/src/components/InstanceOverlayBar.tsx
@@ -64,6 +64,7 @@ export interface InstanceOverlayBarProps {
 
 const READINESS_LABEL: Record<InstanceHealthState, string> = {
   ready: 'Ready',
+  degraded: 'Degraded',
   reconciling: 'Reconciling',
   error: 'Error',
   pending: 'Pending',

--- a/web/src/components/InstanceTable.tsx
+++ b/web/src/components/InstanceTable.tsx
@@ -45,9 +45,9 @@ function compareItems(a: K8sObject, b: K8sObject, key: SortKey, dir: SortDir): n
   } else if (key === 'ready') {
     const { state: aState } = extractInstanceHealth(a)
     const { state: bState } = extractInstanceHealth(b)
-    // Worst first: error=0, reconciling=1, pending=2, unknown=3, ready=4
+    // Worst first: error=0, degraded=1, reconciling=2, pending=3, unknown=4, ready=5
     const order: Record<string, number> = {
-      error: 0, reconciling: 1, pending: 2, unknown: 3, ready: 4,
+      error: 0, degraded: 1, reconciling: 2, pending: 3, unknown: 4, ready: 5,
     }
     cmp = (order[aState] ?? 3) - (order[bState] ?? 3)
   }

--- a/web/src/components/ReadinessBadge.css
+++ b/web/src/components/ReadinessBadge.css
@@ -1,6 +1,7 @@
 /* ReadinessBadge — colored pill badge for instance readiness state.
  * Only CSS custom properties from tokens.css are used; no hardcoded hex.
- * Extended from 3 states to 5 by spec 028-instance-health-rollup. */
+ * Extended from 3 states to 5 by spec 028-instance-health-rollup.
+ * Extended to 6 states (degraded) by 047-ux-improvements. */
 
 .readiness-badge {
   display: inline-flex;
@@ -20,6 +21,13 @@
   color: var(--color-status-ready);
   background: var(--node-alive-bg);
   border: 1px solid var(--color-alive);
+}
+
+/* Ready=True but a child resource has errors — orange */
+.readiness-badge--degraded {
+  color: var(--color-status-degraded);
+  background: rgba(249, 115, 22, 0.10);
+  border: 1px solid var(--color-status-degraded);
 }
 
 /* Ready=False — rose */

--- a/web/src/components/ReadinessBadge.tsx
+++ b/web/src/components/ReadinessBadge.tsx
@@ -5,10 +5,11 @@ interface ReadinessBadgeProps {
   status: ReadyStatus | InstanceHealth
 }
 
-/** Map any 5-state value to its display label. */
+/** Map any 6-state value to its display label. */
 function stateLabel(state: string): string {
   switch (state) {
     case 'ready':       return 'Ready'
+    case 'degraded':    return 'Degraded'
     case 'error':       return 'Not Ready'
     case 'reconciling': return 'Reconciling'
     case 'pending':     return 'Pending'
@@ -19,14 +20,15 @@ function stateLabel(state: string): string {
 /**
  * ReadinessBadge — colored pill badge derived from the Ready condition.
  *
- * States (5):
+ * States (6):
  *   ready       → green "Ready"
+ *   degraded    → orange "Degraded" + tooltip (CR ready but child errors)
  *   error       → rose "Not Ready" + tooltip showing reason/message
  *   reconciling → amber "Reconciling" + tooltip showing reason
  *   pending     → violet "Pending"
  *   unknown     → gray "Unknown"
  *
- * Accepts both ReadyStatus (3-state) and InstanceHealth (5-state) since
+ * Accepts both ReadyStatus (3-state) and InstanceHealth (6-state) since
  * they share the same { state, reason, message } shape.
  *
  * Spec: .specify/specs/028-instance-health-rollup/ US2 FR-006
@@ -34,7 +36,7 @@ function stateLabel(state: string): string {
 export default function ReadinessBadge({ status }: ReadinessBadgeProps) {
   const label = stateLabel(status.state)
 
-  const showTooltip = (status.state === 'error' || status.state === 'reconciling') && status.reason
+  const showTooltip = (status.state === 'error' || status.state === 'reconciling' || status.state === 'degraded') && status.reason
   const tooltip = showTooltip
     ? `${status.reason}${status.message ? `: ${status.message}` : ''}`
     : label

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -378,7 +378,7 @@ describe('extractInstanceHealth', () => {
 describe('aggregateHealth', () => {
   it('returns all zeros for empty items array', () => {
     const summary = aggregateHealth([])
-    expect(summary).toEqual({ total: 0, ready: 0, error: 0, reconciling: 0, pending: 0, unknown: 0 })
+    expect(summary).toEqual({ total: 0, ready: 0, degraded: 0, error: 0, reconciling: 0, pending: 0, unknown: 0 })
   })
 
   it('counts totals correctly across mixed states', () => {

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -38,21 +38,27 @@ function isCondition(v: unknown): v is K8sCondition {
   return typeof obj.type === 'string' && typeof obj.status === 'string'
 }
 
-// ── Instance health (5-state) ─────────────────────────────────────────
+// ── Instance health (6-state) ─────────────────────────────────────────
 
 /**
- * Five-state health enumeration for a kro instance.
+ * Six-state health enumeration for a kro instance.
  *
- * Priority order (worst → best): error > reconciling > pending > unknown > ready
+ * Priority order (worst → best): error > degraded > reconciling > pending > unknown > ready
  *
- * - reconciling: kro is actively reconciling (Progressing=True)
- * - error:       Ready=False
- * - ready:       Ready=True
+ * - error:       Ready=False or a negation-polarity condition is unhealthy
+ * - degraded:    Ready=True (CR-level) but at least one child resource has
+ *                Available=False or its own Ready=False. CR is technically ready
+ *                but something is wrong underneath. Requires children data —
+ *                only available on the instance detail page, not the card.
+ * - reconciling: kro is actively reconciling (Progressing=True, GraphProgressing=True,
+ *                or kro status.state === 'IN_PROGRESS')
+ * - ready:       Ready=True, all children healthy (or children not checked)
  * - pending:     conditions present but all status=Unknown
  * - unknown:     conditions absent or empty array
  */
 export type InstanceHealthState =
   | 'ready'
+  | 'degraded'
   | 'reconciling'
   | 'error'
   | 'pending'
@@ -69,6 +75,7 @@ export interface InstanceHealth {
 export interface HealthSummary {
   total: number
   ready: number
+  degraded: number
   error: number
   reconciling: number
   pending: number
@@ -78,14 +85,23 @@ export interface HealthSummary {
 const UNKNOWN_INSTANCE_HEALTH: InstanceHealth = { state: 'unknown', reason: '', message: '' }
 
 /**
- * Extract a 5-state health value from an unstructured kro instance object.
+ * Extract a 6-state health value from an unstructured kro instance object.
+ *
+ * NOTE: This function only has access to the CR object (not its children), so
+ * the 'degraded' state is NOT returned here — it requires children data and
+ * is computed separately by the caller when available (InstanceDetail.tsx).
+ * Use `applyDegradedState()` to overlay the degraded state after computing it.
  *
  * Derivation order (deterministic, left-to-right):
  *  1. Absent/non-array conditions → 'unknown'
- *  2. Progressing=True → 'reconciling' (checked before Ready)
- *  3. Ready=True/False → 'ready'/'error'
- *  4. All conditions Unknown → 'pending'
- *  5. Otherwise → 'unknown'
+ *  2. kro status.state === 'IN_PROGRESS' → 'reconciling'
+ *     (kro v0.8.5 uses this field rather than a Progressing=True condition
+ *     when a resource is waiting for readyWhen to be satisfied)
+ *  3. Progressing=True OR GraphProgressing=True → 'reconciling'
+ *     (kro v0.9.x+ condition; also kro v0.8.x during active reconciliation)
+ *  4. Ready=True/False → 'ready'/'error'
+ *  5. All conditions Unknown → 'pending'
+ *  6. Otherwise → 'unknown'
  *
  * Never throws. `reason` and `message` are always strings.
  */
@@ -144,13 +160,35 @@ export function extractInstanceHealth(obj: K8sObject): InstanceHealth {
  * Used by RGDCard's async health chip.
  */
 export function aggregateHealth(items: K8sObject[]): HealthSummary {
-  const summary: HealthSummary = { total: 0, ready: 0, error: 0, reconciling: 0, pending: 0, unknown: 0 }
+  const summary: HealthSummary = { total: 0, ready: 0, degraded: 0, error: 0, reconciling: 0, pending: 0, unknown: 0 }
   for (const item of items) {
     summary.total++
     const { state } = extractInstanceHealth(item)
     summary[state]++
   }
   return summary
+}
+
+/**
+ * applyDegradedState — overlay the 'degraded' state onto an InstanceHealth
+ * when the CR itself is ready but children have errors.
+ *
+ * Called from InstanceDetail.tsx after computing the NodeStateMap.
+ * Only applies when:
+ *   - base health is 'ready' (CR-level Ready=True)
+ *   - hasChildError is true (at least one child has Available=False or error state)
+ *
+ * Returns a new InstanceHealth object — never mutates the input.
+ */
+export function applyDegradedState(health: InstanceHealth, hasChildError: boolean): InstanceHealth {
+  if (health.state === 'ready' && hasChildError) {
+    return {
+      state: 'degraded',
+      reason: 'ChildDegraded',
+      message: 'One or more child resources have errors while the CR is ready',
+    }
+  }
+  return health
 }
 
 // ── Age formatting ───────────────────────────────────────────────────

--- a/web/src/pages/InstanceDetail.tsx
+++ b/web/src/pages/InstanceDetail.tsx
@@ -29,7 +29,8 @@ import type { NodeLiveState } from '@/lib/instanceNodeState'
 import { buildDAGGraph } from '@/lib/dag'
 import { buildNodeStateMap } from '@/lib/instanceNodeState'
 import { resolveChildResourceInfo } from '@/lib/resolveResourceName'
-import { extractInstanceHealth } from '@/lib/format'
+import { extractInstanceHealth, applyDegradedState } from '@/lib/format'
+import { countHealthyChildren } from '@/lib/telemetry'
 import { usePolling } from '@/hooks/usePolling'
 import { isTerminating, getDeletionTimestamp, getFinalizers } from '@/lib/k8s'
 import { translateApiError } from '@/lib/errors'
@@ -43,6 +44,7 @@ import TerminatingBanner from '@/components/TerminatingBanner'
 import FinalizersPanel from '@/components/FinalizersPanel'
 import TelemetryPanel from '@/components/TelemetryPanel'
 import HealthPill from '@/components/HealthPill'
+import CopySpecButton from '@/components/CopySpecButton'
 import './InstanceDetail.css'
 
 // ── Poll result type ───────────────────────────────────────────────────────
@@ -328,7 +330,11 @@ export default function InstanceDetail() {
       {/* Header */}
       <div className="instance-detail-header">
         <h1 className="instance-detail-name">{displayName}</h1>
-        <HealthPill health={fastData ? extractInstanceHealth(fastData.instance) : null} />
+        <HealthPill health={fastData ? applyDegradedState(
+          extractInstanceHealth(fastData.instance),
+          countHealthyChildren(nodeStateMap).hasError,
+        ) : null} />
+        {fastData && <CopySpecButton instance={fastData.instance} />}
         <div className="instance-detail-meta">
           {namespace && <span className="instance-detail-ns">{namespace}</span>}
           <RefreshIndicator lastRefresh={lastRefresh} error={instanceGone ? null : (pollError && !pollLoading ? pollError : null)} />

--- a/web/src/tokens.css
+++ b/web/src/tokens.css
@@ -46,6 +46,7 @@
 
   /* Semantic: UI status badges (same hue, separate tokens for semantics) */
   --color-status-ready:          #10b981;
+  --color-status-degraded:       #f97316;   /* Degraded: CR ready but child has errors — orange */
   --color-status-error:          #f43f5e;
   --color-status-unknown:        #6b7280;
   --color-status-warning:        #f59e0b;
@@ -176,6 +177,7 @@
 
   /* Semantic: UI status */
   --color-status-ready:          #059669;
+  --color-status-degraded:       #ea580c;   /* Degraded — darker orange for dark mode */
   --color-status-error:          #e11d48;
   --color-status-unknown:        #6b7280;
   --color-status-warning:        #d97706;


### PR DESCRIPTION
## Summary

Three UX improvements discovered during agent-driven stress testing with new fixture RGDs.

### F-1 — Degraded health state (new 6th state)

**Problem**: `crashloop-demo` has `Ready=True` at the CR level (kro has no `readyWhen` on `badDeploy`), but `badDeploy` child has `Available=False`. The instance detail page showed a green **Ready** pill — misleading when a child is crash-looping.

**Fix**: Add `'degraded'` to `InstanceHealthState`. When CR is `Ready=True` AND `buildNodeStateMap` finds a child with `error` state, `applyDegradedState()` promotes the health to `degraded`. Rendered as an **orange pill** ("Degraded") on the instance detail page, distinct from amber (reconciling) and rose (error).

- `format.ts`: new `degraded` state, `applyDegradedState()` function, `HealthSummary.degraded` field
- `InstanceDetail.tsx`: wires `applyDegradedState(extractInstanceHealth(...), countHealthyChildren(nodeStateMap).hasError)`  
- `tokens.css`: `--color-status-degraded: #f97316` (orange), light + dark mode
- `HealthPill.css`, `ReadinessBadge.css`, `HealthChip.css`: degraded CSS variants

### F-7 — Multi-segment health bar on RGD cards

**Problem**: `HealthChip` showed `"0 / 3 ready"` — hides *which* states are non-ready. `never-ready` RGD's 3 reconciling instances showed identically to 3 error instances.

**Fix**: Replace the single "N / M ready" text with a multi-segment bar. When all ready: `"5 ready"` (green, unchanged). When mixed: one colored segment per non-zero non-ready state plus a muted ready count:
```
✗ 2  ↻ 1  3 ready    ← error + reconciling + ready
⚠ 1  3 ready          ← degraded (future, when card-level detection added)
```

- `HealthChip.tsx`: rewritten with `SEGMENTS` constant and per-state `health-chip__segment`
- `HealthChip.css`: new `health-chip--bar`, `health-chip__segment--{state}` classes

### F-6 — Copy instance spec as YAML

**Problem**: No way to copy an instance's spec from the UI — common when recreating in another namespace or debugging.

**Fix**: `CopySpecButton` added to the instance detail header, next to the health pill. Serialises `apiVersion`, `kind`, `metadata`, `spec` to YAML (no external library). Shows `⎘ Copy YAML` → `✓ Copied!` for 2s.

- `CopySpecButton.tsx`: pure inline YAML serialiser, clipboard API + execCommand fallback
- `CopySpecButton.css`: matches design system button style

## Tests

- Updated `HealthChip.test.tsx`: new degraded + multi-segment assertions
- Updated `format.test.ts`: `aggregateHealth` now includes `degraded: 0`
- All 1066 unit tests pass
- TypeScript strict mode: 0 errors

## Verified on cluster

- `crashloop-demo` instance detail: **Degraded** pill (orange) ✓  
- `never-ready` instances: `✗ 3  0 ready` on Overview card ✓  
- Copy YAML button visible and functional ✓  
- `never-ready-prod` still shows Reconciling pill + amber banner ✓