### PR TITLE
fix(web): state map keyed by node-id, IN_PROGRESS reconciling, items:null → []

### DIFF
--- a/internal/api/handlers/instances.go
+++ b/internal/api/handlers/instances.go
@@ -90,6 +90,10 @@ func (h *Handler) GetInstanceChildren(w http.ResponseWriter, r *http.Request) {
 		respondError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	// Coerce nil to empty slice so the response is always {"items":[]} not {"items":null}.
+	if children == nil {
+		children = []map[string]any{}
+	}
 	log.Debug().Int("count", len(children)).Str("namespace", namespace).Str("name", name).Str("rgd", rgdName).Msg("listed instance children")
 	respond(w, http.StatusOK, types.ChildrenResponse{Items: children})
 }

--- a/internal/k8s/rgd.go
+++ b/internal/k8s/rgd.go
@@ -339,7 +339,7 @@ func listWithLabelSelector(
 ) ([]map[string]any, error) {
 	var (
 		mu      sync.Mutex
-		results []map[string]any
+		results = make([]map[string]any, 0) // always a non-nil slice so JSON encodes as [] not null
 	)
 
 	var wg sync.WaitGroup

--- a/web/src/lib/dag.ts
+++ b/web/src/lib/dag.ts
@@ -651,8 +651,11 @@ export function liveStateClass(state: NodeLiveState | undefined): string {
  * Rules:
  *   - Root CR (nodeType 'instance'): aggregate over all entries in stateMap.
  *     Precedence: reconciling > error > alive > undefined.
- *   - All other nodes: direct lookup by lowercase kind (node.kind || node.label).
- *     Returns undefined when no matching child resource was found.
+ *   - All other nodes: look up by node.id (= kro.run/node-id label value).
+ *     The state map is keyed by node-id so this is the authoritative lookup.
+ *     Falls back to kind-based lookup for backward compat with any callers
+ *     that may pass a state map built by older code.
+ *     Returns undefined when no matching entry was found.
  *
  * Extracted from LiveDAG.tsx and DeepDAG.tsx to a single source of truth.
  * Constitution §IX: shared graph helpers must live in @/lib/dag.ts — never
@@ -674,8 +677,10 @@ export function nodeStateForNode(
     // undefined which maps to 'not-found' (gray). Fixes issue #230.
     return 'pending'
   }
+  // Primary: look up by node id (= kro.run/node-id label value).
+  // Fallback: kind-based lookup for compat with any stale callers.
   const kindKey = (node.kind || node.label).toLowerCase()
-  return stateMap[kindKey]?.state
+  return stateMap[node.id]?.state ?? stateMap[kindKey]?.state
 }
 
 // ── Chaining detection ────────────────────────────────────────────────────

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -246,6 +246,53 @@ describe('extractInstanceHealth', () => {
     expect(extractInstanceHealth(obj).state).toBe('reconciling')
   })
 
+  it("returns 'reconciling' when GraphProgressing=True (kro v0.8.x compat)", () => {
+    const obj = {
+      status: {
+        conditions: [
+          { type: 'GraphProgressing', status: 'True' },
+          { type: 'Ready', status: 'False' },
+        ],
+      },
+    }
+    expect(extractInstanceHealth(obj).state).toBe('reconciling')
+  })
+
+  it("returns 'reconciling' when kro status.state is IN_PROGRESS (Bug D-1 fix)", () => {
+    const obj = {
+      status: {
+        state: 'IN_PROGRESS',
+        conditions: [
+          { type: 'InstanceManaged', status: 'True' },
+          { type: 'GraphResolved', status: 'True' },
+          { type: 'ResourcesReady', status: 'False' },
+          { type: 'Ready', status: 'False' },
+        ],
+      },
+    }
+    expect(extractInstanceHealth(obj).state).toBe('reconciling')
+  })
+
+  it("IN_PROGRESS wins over Ready=False (reconciling > error)", () => {
+    const obj = {
+      status: {
+        state: 'IN_PROGRESS',
+        conditions: [{ type: 'Ready', status: 'False' }],
+      },
+    }
+    expect(extractInstanceHealth(obj).state).toBe('reconciling')
+  })
+
+  it("ACTIVE kro status.state with Ready=True returns ready (not affected)", () => {
+    const obj = {
+      status: {
+        state: 'ACTIVE',
+        conditions: [{ type: 'Ready', status: 'True' }],
+      },
+    }
+    expect(extractInstanceHealth(obj).state).toBe('ready')
+  })
+
   it("returns 'error' when Ready=False and Progressing absent", () => {
     const obj = {
       status: {

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -109,6 +109,14 @@ export function extractInstanceHealth(obj: K8sObject): InstanceHealth {
   const status = obj.status
   if (typeof status !== 'object' || status === null) return UNKNOWN_INSTANCE_HEALTH
 
+  // Step 2: kro status.state === 'IN_PROGRESS' → reconciling.
+  // kro v0.8.5 sets this field when readyWhen is unmet — does NOT emit
+  // Progressing=True in that case, only ResourcesReady=False + Ready=False.
+  const kroState = (status as Record<string, unknown>).state
+  if (kroState === 'IN_PROGRESS') {
+    return { state: 'reconciling', reason: 'InProgress', message: 'kro is reconciling this instance' }
+  }
+
   const conditions = (status as Record<string, unknown>).conditions
   if (!Array.isArray(conditions) || conditions.length === 0) return UNKNOWN_INSTANCE_HEALTH
 
@@ -116,8 +124,11 @@ export function extractInstanceHealth(obj: K8sObject): InstanceHealth {
   const valid = conditions.filter((c): c is K8sCondition => isCondition(c))
   if (valid.length === 0) return UNKNOWN_INSTANCE_HEALTH
 
-  // Step 2: Progressing=True → reconciling
-  const progressing = valid.find((c) => c.type === 'Progressing' && c.status === 'True')
+  // Step 3: Progressing=True OR GraphProgressing=True → reconciling.
+  // GraphProgressing is the kro v0.8.x predecessor; support both for compat.
+  const progressing = valid.find(
+    (c) => (c.type === 'Progressing' || c.type === 'GraphProgressing') && c.status === 'True',
+  )
   if (progressing) {
     return {
       state: 'reconciling',
@@ -126,8 +137,7 @@ export function extractInstanceHealth(obj: K8sObject): InstanceHealth {
     }
   }
 
-  // Step 3a: Ready condition (the primary health signal for kro instances).
-  // Use the first Ready condition as the authoritative answer.
+  // Step 4a: Ready condition (the primary health signal for kro instances).
   const ready = valid.find((c) => c.type === 'Ready')
   if (ready) {
     if (isHealthyCondition('Ready', ready.status)) {
@@ -138,7 +148,7 @@ export function extractInstanceHealth(obj: K8sObject): InstanceHealth {
     }
   }
 
-  // Step 3b: Check negation-polarity conditions (e.g. ReconciliationSuspended=True → error).
+  // Step 4b: Check negation-polarity conditions (e.g. ReconciliationSuspended=True → error).
   // These are not covered by the Ready=False path above. Issue #220 (028-F3).
   for (const c of valid) {
     if (c.type === 'Ready' || c.status === 'Unknown') continue
@@ -147,7 +157,7 @@ export function extractInstanceHealth(obj: K8sObject): InstanceHealth {
     }
   }
 
-  // Step 4: All conditions have status=Unknown → pending
+  // Step 5: All conditions have status=Unknown → pending
   if (valid.every((c) => c.status === 'Unknown')) {
     return { state: 'pending', reason: '', message: '' }
   }

--- a/web/src/lib/instanceNodeState.test.ts
+++ b/web/src/lib/instanceNodeState.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // instanceNodeState.test.ts — unit tests for buildNodeStateMap.
-// Maps child resources + instance conditions → per-node live state.
+// State map is keyed by kro.run/node-id label (not by kind).
 
 import { describe, it, expect } from 'vitest'
 import { buildNodeStateMap } from './instanceNodeState'
@@ -22,11 +22,52 @@ import type { DAGNode } from './dag'
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
-function makeChild(kind: string, name: string, namespace = 'default'): K8sObject {
+/** Child WITH kro.run/node-id label (kro ≥ 0.8.0 — the normal case). */
+function makeChild(
+  kind: string,
+  name: string,
+  nodeId: string,
+  namespace = 'default',
+  apiVersion = 'v1',
+): K8sObject {
+  return {
+    apiVersion,
+    kind,
+    metadata: {
+      name,
+      namespace,
+      labels: { 'kro.run/node-id': nodeId },
+    },
+  }
+}
+
+/** Child WITHOUT kro.run/node-id (kube-generated or kro < 0.8.0). */
+function makeChildNoLabel(kind: string, name: string, namespace = 'default'): K8sObject {
   return {
     apiVersion: 'v1',
     kind,
     metadata: { name, namespace },
+  }
+}
+
+/** Instance with kro status.state set (kro v0.8.5 field). */
+function makeInstanceWithKroState(
+  kroState: string,
+  conditions: Array<{ type: string; status: string }>,
+): K8sObject {
+  return {
+    metadata: { name: 'my-instance', namespace: 'default' },
+    spec: {},
+    status: {
+      state: kroState,
+      conditions: conditions.map((c) => ({
+        type: c.type,
+        status: c.status,
+        reason: 'SomeReason',
+        message: '',
+        lastTransitionTime: '2026-03-21T00:00:00Z',
+      })),
+    },
   }
 }
 
@@ -46,16 +87,21 @@ function makeInstance(conditions: Array<{ type: string; status: string }>): K8sO
   }
 }
 
-function makeNode(id: string, kind: string, nodeType: DAGNode['nodeType'] = 'resource'): DAGNode {
+function makeNode(
+  id: string,
+  kind: string,
+  nodeType: DAGNode['nodeType'] = 'resource',
+  includeWhen: string[] = [],
+): DAGNode {
   return {
     id,
     label: id,
     nodeType,
     kind,
-    isConditional: false,
+    isConditional: includeWhen.length > 0,
     hasReadyWhen: false,
     celExpressions: [],
-    includeWhen: [],
+    includeWhen,
     readyWhen: [],
     isChainable: false,
     x: 0,
@@ -66,32 +112,109 @@ function makeNode(id: string, kind: string, nodeType: DAGNode['nodeType'] = 'res
 }
 
 describe('buildNodeStateMap', () => {
-  // ── T010: alive when child exists + no error condition ─────────────────
+  // ── T010: alive when child has node-id + no error condition ───────────────
 
-  it('T010: returns alive when child resource exists and Ready=True', () => {
+  it('T010: returns alive for a child keyed by kro.run/node-id', () => {
     const instance = makeInstance([{ type: 'Ready', status: 'True' }])
-    const children = [makeChild('ConfigMap', 'my-instance-configmap')]
+    const children = [makeChild('ConfigMap', 'my-configmap', 'appConfig')]
 
     const stateMap = buildNodeStateMap(instance, children, [])
 
-    const configmapEntry = Object.entries(stateMap).find(([, v]) => v.kind === 'ConfigMap')
-    expect(configmapEntry).toBeDefined()
-    expect(configmapEntry![1].state).toBe('alive')
+    expect(stateMap['appConfig']?.state).toBe('alive')
+    expect(stateMap['appConfig']?.kind).toBe('ConfigMap')
+  })
+
+  // ── T010b: children WITHOUT node-id are silently skipped ─────────────────
+
+  it('T010b: children without kro.run/node-id (kube-generated) are silently skipped', () => {
+    const instance = makeInstance([{ type: 'Ready', status: 'True' }])
+    const children = [
+      makeChild('Service', 'my-svc', 'appService'),
+      makeChildNoLabel('EndpointSlice', 'my-svc-abc12'),
+    ]
+
+    const stateMap = buildNodeStateMap(instance, children, [])
+
+    expect(Object.keys(stateMap)).toHaveLength(1)
+    expect(stateMap['appService']?.state).toBe('alive')
+    expect(stateMap['endpointslice']).toBeUndefined()
   })
 
   // ── T011: reconciling when Progressing=True ────────────────────────────
 
   it('T011: returns reconciling for all nodes when Progressing=True', () => {
     const instance = makeInstance([{ type: 'Progressing', status: 'True' }])
-    const children = [makeChild('ConfigMap', 'my-instance-configmap')]
+    const children = [makeChild('ConfigMap', 'my-configmap', 'appConfig')]
 
     const stateMap = buildNodeStateMap(instance, children, [])
 
-    const configmapEntry = Object.entries(stateMap).find(([, v]) => v.kind === 'ConfigMap')
-    expect(configmapEntry![1].state).toBe('reconciling')
+    expect(stateMap['appConfig']?.state).toBe('reconciling')
   })
 
-  // ── T012: map is empty when children and rgdNodes are empty ───────────
+  // ── T011b: GraphProgressing=True (kro v0.8.x compat) ────────────────────
+
+  it('T011b: returns reconciling when GraphProgressing=True (kro v0.8.x compat)', () => {
+    const instance = makeInstance([{ type: 'GraphProgressing', status: 'True' }])
+    const children = [makeChild('ConfigMap', 'my-configmap', 'appConfig')]
+
+    const stateMap = buildNodeStateMap(instance, children, [])
+
+    expect(stateMap['appConfig']?.state).toBe('reconciling')
+  })
+
+  // ── T011c: GraphProgressing takes precedence over Ready=False ───────────
+
+  it('T011c: GraphProgressing=True wins over Ready=False (reconciling > error)', () => {
+    const instance = makeInstance([
+      { type: 'Ready', status: 'False' },
+      { type: 'GraphProgressing', status: 'True' },
+    ])
+    const children = [makeChild('ConfigMap', 'my-configmap', 'appConfig')]
+
+    const stateMap = buildNodeStateMap(instance, children, [])
+
+    expect(stateMap['appConfig']?.state).toBe('reconciling')
+  })
+
+  // ── T011d: kro status.state === 'IN_PROGRESS' → reconciling ─────────────
+
+  it('T011d: returns reconciling when kro status.state is IN_PROGRESS', () => {
+    const instance = makeInstanceWithKroState('IN_PROGRESS', [
+      { type: 'InstanceManaged', status: 'True' },
+      { type: 'GraphResolved', status: 'True' },
+      { type: 'ResourcesReady', status: 'False' },
+      { type: 'Ready', status: 'False' },
+    ])
+    const children = [makeChild('ConfigMap', 'my-configmap', 'appConfig')]
+
+    const stateMap = buildNodeStateMap(instance, children, [])
+
+    expect(stateMap['appConfig']?.state).toBe('reconciling')
+  })
+
+  it('T011e: IN_PROGRESS wins over Ready=False (reconciling > error)', () => {
+    const instance = makeInstanceWithKroState('IN_PROGRESS', [
+      { type: 'Ready', status: 'False' },
+    ])
+    const children = [makeChild('ConfigMap', 'my-configmap', 'appConfig')]
+
+    const stateMap = buildNodeStateMap(instance, children, [])
+
+    expect(stateMap['appConfig']?.state).toBe('reconciling')
+  })
+
+  it('T011f: ACTIVE kro state with Ready=True stays alive', () => {
+    const instance = makeInstanceWithKroState('ACTIVE', [
+      { type: 'Ready', status: 'True' },
+    ])
+    const children = [makeChild('ConfigMap', 'my-configmap', 'appConfig')]
+
+    const stateMap = buildNodeStateMap(instance, children, [])
+
+    expect(stateMap['appConfig']?.state).toBe('alive')
+  })
+
+  // ── T012: empty inputs ────────────────────────────────────────────────────
 
   it('T012: map is empty when both children and rgdNodes are empty', () => {
     const instance = makeInstance([{ type: 'Ready', status: 'True' }])
@@ -103,30 +226,28 @@ describe('buildNodeStateMap', () => {
 
   it('T012b: child present maps to alive; absent node in rgdNodes maps to not-found', () => {
     const instance = makeInstance([{ type: 'Ready', status: 'True' }])
-    const children = [makeChild('ConfigMap', 'my-instance-configmap')]
+    const children = [makeChild('ConfigMap', 'my-configmap', 'appConfig')]
     const nodes = [
       makeNode('schema', 'WebApp', 'instance'),
-      makeNode('configmap', 'ConfigMap'),
-      makeNode('namespace', 'Namespace'),
+      makeNode('appConfig', 'ConfigMap'),
+      makeNode('appNamespace', 'Namespace'),
     ]
 
     const stateMap = buildNodeStateMap(instance, children, nodes)
 
-    expect(stateMap['configmap']?.state).toBe('alive')
-    // Namespace was NOT in children → not-found (GH #165 fix)
-    expect(stateMap['namespace']?.state).toBe('not-found')
+    expect(stateMap['appConfig']?.state).toBe('alive')
+    expect(stateMap['appNamespace']?.state).toBe('not-found')
   })
 
   // ── T013: error when Ready=False ──────────────────────────────────────
 
   it('T013: returns error when Ready=False', () => {
     const instance = makeInstance([{ type: 'Ready', status: 'False' }])
-    const children = [makeChild('ConfigMap', 'my-instance-configmap')]
+    const children = [makeChild('ConfigMap', 'my-configmap', 'appConfig')]
 
     const stateMap = buildNodeStateMap(instance, children, [])
 
-    const configmapEntry = Object.entries(stateMap).find(([, v]) => v.kind === 'ConfigMap')
-    expect(configmapEntry![1].state).toBe('error')
+    expect(stateMap['appConfig']?.state).toBe('error')
   })
 
   // ── T014: handles absent conditions gracefully ─────────────────────────
@@ -137,13 +258,12 @@ describe('buildNodeStateMap', () => {
       spec: {},
       status: {},
     }
-    const children = [makeChild('ConfigMap', 'my-instance-configmap')]
+    const children = [makeChild('ConfigMap', 'my-configmap', 'appConfig')]
 
     expect(() => buildNodeStateMap(instance, children, [])).not.toThrow()
 
     const stateMap = buildNodeStateMap(instance, children, [])
-    const configmapEntry = Object.entries(stateMap).find(([, v]) => v.kind === 'ConfigMap')
-    expect(configmapEntry![1].state).toBe('alive')
+    expect(stateMap['appConfig']?.state).toBe('alive')
   })
 
   // ── T015: Progressing takes precedence over Ready ─────────────────────
@@ -153,97 +273,106 @@ describe('buildNodeStateMap', () => {
       { type: 'Ready', status: 'True' },
       { type: 'Progressing', status: 'True' },
     ])
-    const children = [makeChild('ConfigMap', 'my-instance-configmap')]
+    const children = [makeChild('ConfigMap', 'my-configmap', 'appConfig')]
 
     const stateMap = buildNodeStateMap(instance, children, [])
 
-    const configmapEntry = Object.entries(stateMap).find(([, v]) => v.kind === 'ConfigMap')
-    expect(configmapEntry![1].state).toBe('reconciling')
+    expect(stateMap['appConfig']?.state).toBe('reconciling')
   })
 
-  // ── AC-019: multi-resource RGD, 6 nodes, 2 present → all 6 entries ────
-  // Spec 029 AC-019 — GH #165 fix verification.
+  // ── T016: two ConfigMaps with different node-ids (the core bug) ───────────
 
-  describe('AC-019 — multi-resource RGD: all node entries present, absent nodes are not-found', () => {
-    const rgdNodes: DAGNode[] = [
-      makeNode('schema', 'WebApp', 'instance'),
-      makeNode('deployment', 'Deployment'),
-      makeNode('service', 'Service'),
-      makeNode('configmap', 'ConfigMap'),
-      makeNode('secret', 'Secret'),
-      makeNode('ingress', 'Ingress'),
-      makeNode('hpa', 'HorizontalPodAutoscaler'),
+  it('T016: two ConfigMaps with different node-ids both get correct independent state', () => {
+    const instance = makeInstance([{ type: 'Ready', status: 'True' }])
+    const children = [
+      makeChild('ConfigMap', 'my-app-config', 'appConfig'),
+      makeChild('ConfigMap', 'my-app-status', 'appStatus'),
     ]
 
-    it('emits an entry for every non-state non-instance RGD node', () => {
-      const instance = makeInstance([{ type: 'Ready', status: 'True' }])
-      const children = [makeChild('Deployment', 'app-dep'), makeChild('Service', 'app-svc')]
+    const stateMap = buildNodeStateMap(instance, children, [])
 
-      const map = buildNodeStateMap(instance, children, rgdNodes)
-
-      expect(map).toHaveProperty('deployment')
-      expect(map).toHaveProperty('service')
-      expect(map).toHaveProperty('configmap')
-      expect(map).toHaveProperty('secret')
-      expect(map).toHaveProperty('ingress')
-      expect(map).toHaveProperty('horizontalpodautoscaler')
-    })
-
-    it('2 present children are alive, 4 absent nodes are not-found', () => {
-      const instance = makeInstance([{ type: 'Ready', status: 'True' }])
-      const children = [makeChild('Deployment', 'app-dep'), makeChild('Service', 'app-svc')]
-
-      const map = buildNodeStateMap(instance, children, rgdNodes)
-
-      expect(map['deployment'].state).toBe('alive')
-      expect(map['service'].state).toBe('alive')
-      expect(map['configmap'].state).toBe('not-found')
-      expect(map['secret'].state).toBe('not-found')
-      expect(map['ingress'].state).toBe('not-found')
-      expect(map['horizontalpodautoscaler'].state).toBe('not-found')
-    })
-
-    it('empty children list → all 6 resource nodes are not-found', () => {
-      const instance = makeInstance([{ type: 'Ready', status: 'True' }])
-
-      const map = buildNodeStateMap(instance, [], rgdNodes)
-
-      const resourceNodes = rgdNodes.filter(
-        (n) => n.nodeType !== 'instance' && n.nodeType !== 'state',
-      )
-      expect(Object.keys(map)).toHaveLength(resourceNodes.length)
-      for (const node of resourceNodes) {
-        const key = (node.kind || node.label).toLowerCase()
-        expect(map[key]?.state).toBe('not-found')
-      }
-    })
-
-    it('state-type nodes are not emitted in the map', () => {
-      const nodesWithState: DAGNode[] = [
-        ...rgdNodes,
-        makeNode('state-node', 'State', 'state'),
-      ]
-      const instance = makeInstance([])
-      const map = buildNodeStateMap(instance, [], nodesWithState)
-      expect(map['state']).toBeUndefined()
-    })
+    expect(stateMap['appConfig']?.name).toBe('my-app-config')
+    expect(stateMap['appStatus']?.name).toBe('my-app-status')
+    expect(stateMap['appConfig']?.state).toBe('alive')
+    expect(stateMap['appStatus']?.state).toBe('alive')
   })
 
-  // ── kind fallback from kro.run/resource-id label ───────────────────────
+  // ── T017: EndpointSlice does not corrupt appService node state ────────────
 
-  it('uses resource-id label when .kind is absent on child resource', () => {
+  it('T017: EndpointSlice without node-id does not affect Service state lookup', () => {
     const instance = makeInstance([{ type: 'Ready', status: 'True' }])
-    const childWithoutKind: K8sObject = {
-      apiVersion: 'apps/v1',
-      metadata: {
-        name: 'dep',
-        namespace: 'default',
-        labels: { 'kro.run/resource-id': 'Deployment' },
-      },
-    } as unknown as K8sObject
-    const nodes = [makeNode('deployment', 'Deployment')]
+    const children = [
+      makeChild('Service', 'demo-proxy-svc', 'appService'),
+      makeChildNoLabel('EndpointSlice', 'demo-proxy-svc-f2hlq'),
+    ]
+    const nodes = [makeNode('appService', 'Service')]
 
-    const map = buildNodeStateMap(instance, [childWithoutKind], nodes)
-    expect(map['deployment'].state).toBe('alive')
+    const stateMap = buildNodeStateMap(instance, children, nodes)
+
+    expect(stateMap['appService']?.state).toBe('alive')
+    expect(stateMap['appService']?.kind).toBe('Service')
+    expect(stateMap['endpointslice']).toBeUndefined()
+  })
+
+  // ── T018: includeWhen absent node → 'pending' ─────────────────────────────
+
+  it('T018: absent node with includeWhen gets pending state (violet on DAG)', () => {
+    const instance = makeInstance([{ type: 'Ready', status: 'True' }])
+    const nodes = [
+      makeNode('appConfig', 'ConfigMap', 'resource', ['${schema.spec.enableConfig}']),
+    ]
+
+    const map = buildNodeStateMap(instance, [], nodes)
+
+    expect(map['appConfig']?.state).toBe('pending')
+  })
+
+  // ── T019: id="appNamespace", kind="Namespace" — id ≠ kind ────────────────
+
+  it('T019: node where id differs from kind is correctly keyed by id not kind', () => {
+    const instance = makeInstance([{ type: 'Ready', status: 'True' }])
+    const children = [makeChild('Namespace', 'kro-ui-test', 'appNamespace', '')]
+    const nodes = [makeNode('appNamespace', 'Namespace')]
+
+    const map = buildNodeStateMap(instance, children, nodes)
+
+    expect(map['appNamespace']?.state).toBe('alive')
+    expect(map['appNamespace']?.kind).toBe('Namespace')
+    expect(map['namespace']).toBeUndefined()
+  })
+
+  // ── AC-019: crashloop-app — two Deployments, different states ─────────────
+
+  describe('AC-019 — two same-kind nodes with different states (crashloop-app scenario)', () => {
+    it('goodDeploy=reconciling, badDeploy=error when conditions differ', () => {
+      const instance = makeInstance([{ type: 'Ready', status: 'True' }])
+      const badDeploy = {
+        apiVersion: 'apps/v1', kind: 'Deployment',
+        metadata: { name: 'bad', namespace: 'ns', labels: { 'kro.run/node-id': 'badDeploy' } },
+        status: { conditions: [{ type: 'Available', status: 'False' }, { type: 'Progressing', status: 'False' }] },
+      } as K8sObject
+      const goodDeploy = {
+        apiVersion: 'apps/v1', kind: 'Deployment',
+        metadata: { name: 'good', namespace: 'ns', labels: { 'kro.run/node-id': 'goodDeploy' } },
+        status: { conditions: [{ type: 'Available', status: 'True' }, { type: 'Progressing', status: 'True' }] },
+      } as K8sObject
+
+      const map = buildNodeStateMap(instance, [badDeploy, goodDeploy], [
+        makeNode('badDeploy', 'Deployment'),
+        makeNode('goodDeploy', 'Deployment'),
+      ])
+
+      expect(map['badDeploy']?.state).toBe('error')
+      expect(map['goodDeploy']?.state).toBe('reconciling')
+    })
+
+    it('state-type nodes are never emitted in the map', () => {
+      const instance = makeInstance([])
+      const map = buildNodeStateMap(instance, [], [
+        makeNode('appConfig', 'ConfigMap'),
+        makeNode('state-node', 'State', 'state'),
+      ])
+      expect(map['state-node']).toBeUndefined()
+    })
   })
 })

--- a/web/src/lib/instanceNodeState.ts
+++ b/web/src/lib/instanceNodeState.ts
@@ -2,10 +2,33 @@
 //
 // This is the ONLY place that knows how to derive a live node state from
 // Kubernetes conditions and child resource presence.
+//
+// Key design: the state map is keyed by kro.run/node-id label, NOT by
+// resource kind. This is the same authoritative key used by resolveChildResourceInfo
+// and avoids two classes of bugs:
+//   1. Kube-generated resources (EndpointSlice, ReplicaSet, etc.) that are
+//      returned by GetInstanceChildren but lack kro.run/node-id are silently
+//      skipped — they don't pollute the state map or confuse the DAG overlay.
+//   2. Nodes where the RGD id differs from the resource kind (e.g. id="appNamespace",
+//      kind="Namespace") are correctly matched because the label is the id, not
+//      the kind.
+//   3. Two nodes of the same kind with different IDs (e.g. two ConfigMaps with
+//      id="appConfig" and id="appStatus") both get their correct state.
 
 import type { K8sObject } from './api'
 import { isTerminating, getFinalizers, getDeletionTimestamp } from './k8s'
 import type { DAGNode } from './dag'
+
+const LABEL_NODE_ID = 'kro.run/node-id'
+
+/** Read kro.run/node-id from a child resource's metadata labels. Returns '' if absent. */
+function nodeIdLabel(child: K8sObject): string {
+  const meta = child.metadata as Record<string, unknown> | undefined
+  const labels = meta?.labels
+  if (typeof labels !== 'object' || labels === null) return ''
+  const val = (labels as Record<string, unknown>)[LABEL_NODE_ID]
+  return typeof val === 'string' ? val : ''
+}
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -115,24 +138,27 @@ function parseApiVersion(apiVersion: unknown): { group: string; version: string 
  *
  * Algorithm:
  * 1. Determine the global state from instance conditions:
- *    - Progressing=True → globalState = 'reconciling'
- *    - Ready=False      → globalState = 'error'
- *    - Otherwise        → globalState = 'alive'
- * 2. Build a presence map from children, keyed by lowercase kind.
+ *    - kro status.state === 'IN_PROGRESS' → globalState = 'reconciling'
+ *      (kro v0.8.5 uses this field when readyWhen is unmet — does not emit
+ *      Progressing=True in this case, only ResourcesReady=False + Ready=False)
+ *    - Progressing=True OR GraphProgressing=True → globalState = 'reconciling'
+ *      (kro v0.9.x+ condition; GraphProgressing is the v0.8.x predecessor)
+ *    - Ready=False → globalState = 'error'
+ *    - Otherwise  → globalState = 'alive'
+ *    Precedence: reconciling > error > alive
+ * 2. Build a presence map from children, keyed by kro.run/node-id label.
+ *    - Children lacking kro.run/node-id (kube-generated: EndpointSlice,
+ *      ReplicaSet, etc.) are silently skipped — not kro-managed nodes.
+ *    - First child for each node-id wins (handles rare duplicates).
  *    - Terminating children always get state 'error'.
  *    - When globalState is 'reconciling' or 'error', all present children
  *      inherit that global state (CR-level signal wins).
  *    - When globalState is 'alive', each child's own status.conditions are
- *      inspected individually via deriveChildState() — enabling per-node
- *      health differentiation even when the CR itself is healthy.
+ *      inspected individually via deriveChildState().
  * 3. Enumerate every non-state, non-instance RGD node and emit an explicit
  *    entry for absent nodes:
  *    - Node has includeWhen expressions → state = 'pending' (excluded by cond)
  *    - Node has no includeWhen          → state = 'not-found' (not yet created)
- *
- * The `rgdNodes` parameter (GH #165 fix) ensures every DAG node has an entry
- * so that absent nodes receive the correct CSS class rather than being
- * silently unstyled. Pass `dagGraph.nodes` from the call site.
  */
 export function buildNodeStateMap(
   instance: K8sObject,
@@ -147,34 +173,36 @@ export function buildNodeStateMap(
   if (hasCondition(conditions, 'Ready', 'False')) {
     globalState = 'error'
   }
-  // Progressing=True wins over error — kro actively working
-  if (hasCondition(conditions, 'Progressing', 'True')) {
+  // kro v0.8.5: status.state === 'IN_PROGRESS' when readyWhen is unmet.
+  // Does NOT emit Progressing=True in this state — must check status.state directly.
+  const kroState = (instance.status as Record<string, unknown> | undefined)?.state
+  if (kroState === 'IN_PROGRESS') {
+    globalState = 'reconciling'
+  }
+  // Progressing=True OR GraphProgressing=True wins — kro actively working.
+  // GraphProgressing is the kro v0.8.x predecessor to Progressing.
+  if (
+    hasCondition(conditions, 'Progressing', 'True') ||
+    hasCondition(conditions, 'GraphProgressing', 'True')
+  ) {
     globalState = 'reconciling'
   }
 
   const result: NodeStateMap = {}
 
-  // ── Step 2: build result from observed children ───────────────────────────
-  // Key by lowercase kind; first child of each kind wins.
+  // ── Step 2: build result from observed children, keyed by kro.run/node-id ──
+  // Children without kro.run/node-id (kube-generated: EndpointSlice, ReplicaSet,
+  // etc.) are skipped entirely — they are not kro-managed DAG nodes.
+  // First child for each node-id wins (handles rare duplicate labels gracefully).
   for (const child of children) {
+    const nodeId = nodeIdLabel(child)
+    if (!nodeId) continue // not a kro-managed resource — skip
+    if (nodeId in result) continue // first child for this node-id wins
+
     const meta = child.metadata as Record<string, unknown> | undefined
     if (!meta) continue
 
-    // Prefer the top-level .kind field; fall back to resource-id label (kro ≤0.2 quirk)
-    const kindRaw =
-      typeof child.kind === 'string' && child.kind
-        ? child.kind
-        : typeof (meta.labels as Record<string, unknown> | undefined)?.[
-            'kro.run/resource-id'
-          ] === 'string'
-        ? String((meta.labels as Record<string, unknown>)['kro.run/resource-id'])
-        : ''
-
-    if (!kindRaw) continue
-
-    const key = kindRaw.toLowerCase()
-    if (key in result) continue // first child of each kind wins
-
+    const kindRaw = typeof child.kind === 'string' && child.kind ? child.kind : ''
     const name = typeof meta.name === 'string' ? meta.name : ''
     const namespace = typeof meta.namespace === 'string' ? meta.namespace : ''
     const { group, version } = parseApiVersion(child.apiVersion)
@@ -183,9 +211,6 @@ export function buildNodeStateMap(
     const childFinalizers = getFinalizers(child)
     const childDeletionTimestamp = getDeletionTimestamp(child)
 
-    // Terminating children force error state regardless of global or per-node state.
-    // When globalState is 'reconciling' or 'error', it propagates to all present nodes.
-    // When globalState is 'alive', inspect the child's own conditions for per-node state.
     let nodeState: NodeLiveState
     if (childTerminating) {
       nodeState = 'error'
@@ -195,7 +220,7 @@ export function buildNodeStateMap(
       nodeState = deriveChildState(getChildConditions(child))
     }
 
-    result[key] = {
+    result[nodeId] = {
       state: nodeState,
       kind: kindRaw,
       name,
@@ -210,19 +235,17 @@ export function buildNodeStateMap(
 
   // ── Step 3: enumerate every non-state, non-instance RGD node ─────────────
   // Absent nodes receive 'pending' when the node has includeWhen expressions
-  // (meaning it is actively excluded by a condition), or 'not-found' otherwise
-  // (meaning the resource hasn't been created yet).
-  // This guarantees every DAG node has an entry when the overlay is active.
+  // (meaning it is actively excluded by a condition), or 'not-found' otherwise.
   for (const node of rgdNodes) {
     if (node.nodeType === 'instance' || node.nodeType === 'state') continue
-    const kindKey = (node.kind || node.label || '').toLowerCase()
-    if (!kindKey) continue
-    if (kindKey in result) continue // already set by an observed child
+    const nodeId = node.id  // use the RGD resource id, matching kro.run/node-id
+    if (!nodeId) continue
+    if (nodeId in result) continue // already set by an observed child
 
     const hasIncludeWhen = node.includeWhen.some((e) => e.trim() !== '')
-    result[kindKey] = {
+    result[nodeId] = {
       state: hasIncludeWhen ? 'pending' : 'not-found',
-      kind: node.kind || node.label || kindKey,
+      kind: node.kind || node.label || nodeId,
       name: '',
       namespace: '',
       group: '',

--- a/web/src/lib/resolveResourceName.test.ts
+++ b/web/src/lib/resolveResourceName.test.ts
@@ -228,4 +228,26 @@ describe('resolveChildResourceInfo — kro.run/node-id matching (T210)', () => {
     const result = resolveResourceName('appNamespace', 'test-instance', children)
     expect(result).toBe('kro-ui-test')
   })
+
+  // T211: Service + EndpointSlice share node-id — kind tie-break ─────────────
+
+  it('T211-01: prefers Service over EndpointSlice when both share node-id and nodeKind=Service', () => {
+    const children = [
+      makeChildWithNodeId('EndpointSlice', 'demo-proxy-svc-f2hlq', 'appService', 'ns', 'discovery.k8s.io/v1'),
+      makeChildWithNodeId('Service', 'demo-proxy-svc', 'appService', 'ns', 'v1'),
+    ]
+    const withHint = resolveChildResourceInfo('appService', 'autoscaled-proxy', children, 'Service')
+    expect(withHint?.kind).toBe('Service')
+    expect(withHint?.name).toBe('demo-proxy-svc')
+  })
+
+  it('T211-02: when only Service has node-id label, returns Service regardless', () => {
+    const children = [
+      makeChild('EndpointSlice', 'demo-proxy-svc-f2hlq', 'ns'),
+      makeChildWithNodeId('Service', 'demo-proxy-svc', 'appService', 'ns', 'v1'),
+    ]
+    const result = resolveChildResourceInfo('appService', 'autoscaled-proxy', children, 'Service')
+    expect(result?.kind).toBe('Service')
+    expect(result?.name).toBe('demo-proxy-svc')
+  })
 })

--- a/web/src/lib/resolveResourceName.ts
+++ b/web/src/lib/resolveResourceName.ts
@@ -107,6 +107,9 @@ function parseApiVersion(apiVersion: unknown): { group: string; version: string 
  *
  * Match order (fix #210):
  *   1. child.metadata.labels["kro.run/node-id"] === nodeLabel  (kro ≥ 0.8.0, exact)
+ *      When multiple children share the same node-id (e.g. kube auto-creates an
+ *      EndpointSlice alongside a Service, both labelled with the same kro node-id),
+ *      prefer the child whose kind matches nodeKind. Falls back to first match.
  *   2. child.kind.toLowerCase() === kindHint from nodeLabel     (kro < 0.8.0, by kind)
  *   3. child.kind.toLowerCase() === nodeKind?.toLowerCase()     (caller-supplied kind)
  *   4. Inference fallback
@@ -114,7 +117,7 @@ function parseApiVersion(apiVersion: unknown): { group: string; version: string 
  * @param nodeLabel    - DAG node label (= resource ID, e.g. "appNamespace")
  * @param instanceName - CR instance name for the inference fallback
  * @param children     - Child resources from getInstanceChildren
- * @param nodeKind     - Optional: DAGNode.kind (e.g. "Namespace") for step-3 fallback
+ * @param nodeKind     - Optional: DAGNode.kind (e.g. "Service") for tie-break and step-3
  */
 export function resolveChildResourceInfo(
   nodeLabel: string,
@@ -122,11 +125,20 @@ export function resolveChildResourceInfo(
   children: K8sObject[],
   nodeKind?: string,
 ): ChildResourceInfo | null {
-  // Step 1: match by kro.run/node-id label (authoritative — kro ≥ 0.8.0)
-  for (const child of children) {
-    if (nodeIdLabel(child) === nodeLabel) {
-      return childToInfo(child)
+  // Step 1: match by kro.run/node-id label (authoritative — kro ≥ 0.8.0).
+  // Collect all matches, then prefer the one whose kind matches nodeKind.
+  // This handles kube-generated resources (EndpointSlice, etc.) that inherit
+  // kro labels from their parent Service.
+  const nodeIdMatches = children.filter((c) => nodeIdLabel(c) === nodeLabel)
+  if (nodeIdMatches.length > 0) {
+    if (nodeKind) {
+      const kindLower = nodeKind.toLowerCase()
+      const kindMatch = nodeIdMatches.find(
+        (c) => typeof c.kind === 'string' && c.kind.toLowerCase() === kindLower,
+      )
+      if (kindMatch) return childToInfo(kindMatch)
     }
+    return childToInfo(nodeIdMatches[0])
   }
 
   const kindHint = kindHintFromLabel(nodeLabel).toLowerCase()

--- a/web/src/pages/InstanceDetail.tsx
+++ b/web/src/pages/InstanceDetail.tsx
@@ -102,11 +102,13 @@ function isReconciling(instance: K8sObject | null): boolean {
   if (!instance) return false
   const status = instance.status as Record<string, unknown> | undefined
   if (!status) return false
+  // kro v0.8.5: status.state === 'IN_PROGRESS' when readyWhen is unmet —
+  // does NOT emit Progressing=True; without this the banner is invisible.
+  if (status.state === 'IN_PROGRESS') return true
   const conditions = status.conditions
   if (!Array.isArray(conditions)) return false
   return (conditions as Array<{ type: string; status: string }>).some(
     // Issue #243: kro v0.8.x uses 'GraphProgressing'; v0.9.x+ uses 'Progressing'.
-    // Support both to avoid the reconciling banner being invisible on older clusters.
     (c) =>
       (c.type === 'Progressing' || c.type === 'GraphProgressing') &&
       c.status === 'True',


### PR DESCRIPTION
## Summary

Four correctness bugs discovered during stress-test session with new fixture RGDs (`crashloop-app` with two Deployments of different health, `never-ready` with stuck readyWhen).

### Bug 1 — `buildNodeStateMap` keyed by kind, not `kro.run/node-id`

**Symptom**: `crashloop-app` has `goodDeploy` (reconciling) and `badDeploy` (error), both `Deployment` kind. With the old kind-keyed map, one silently overwrote the other — both nodes showed grey (`not-found`) rings.

**Also**: kube-auto-created `EndpointSlice` resources (no `kro.run/node-id`) were inserted into the state map as `"endpointslice"`, and could cause the `appService` node to show `not-found` if `EndpointSlice` arrived before `Service` in the children array.

**Fix** (`instanceNodeState.ts`): State map now keyed by `kro.run/node-id` label. Children without the label are silently skipped. Step 3 (absent-node fallback) uses `node.id` instead of `node.kind`.

### Bug 2 — `nodeStateForNode` looked up by kind instead of node.id

**Symptom**: After Bug 1 fix, the DAG overlay still showed wrong states because `dag.ts:nodeStateForNode` looked up `stateMap[node.kind.toLowerCase()]`.

**Fix** (`dag.ts`): `stateMap[node.id]?.state ?? stateMap[kindKey]?.state` — id-first with kind fallback.

### Bug 3 — `IN_PROGRESS` kro state showed as Error not Reconciling

**Symptom**: `never-ready-prod` showed red **Error** pill and no amber banner. kro v0.8.5 sets `status.state=IN_PROGRESS` when `readyWhen` is unmet — it does NOT emit `Progressing=True`, only `ResourcesReady=False` + `Ready=False`. Without checking `status.state`, all three health derivation sites mapped this to `error`.

**Fix**: `extractInstanceHealth`, `isReconciling`, and `buildNodeStateMap` all now check `kroState === 'IN_PROGRESS'` before inspecting conditions. Also adds `GraphProgressing=True` compat (kro v0.8.x predecessor to `Progressing`).

### Bug 4 — `GetInstanceChildren` returned `{"items":null}` for zero children

**Symptom**: Instances with all nodes excluded by `includeWhen` (e.g. `contagious-api-disabled`) returned `{"items":null}` instead of `{"items":[]}`. Semantically wrong even though the frontend handled it with `?? []`.

**Fix** (`instances.go` + `rgd.go`): Coerce nil slice to `[]map[string]any{}`.

### Also
- `resolveChildResourceInfo` kind tie-break: when `Service` and `EndpointSlice` both carry the same `kro.run/node-id` label, prefer the child whose `kind` matches `nodeKind` so the YAML panel shows the correct resource.

## Tests
18 new unit tests: T010b, T011b-f, T016, T017, T018, T019, AC-019 (crashloop two-deployment scenario), T211-01/02. **1079 tests total, all passing**.

## Verified on kind cluster

| Scenario | Before | After |
|---|---|---|
| `crashloop-demo` goodDeploy | grey (not-found) | amber (reconciling) ✓ |
| `crashloop-demo` badDeploy | grey (not-found) | red (error) ✓ |
| `crashloop-demo` pill | green Ready | orange Degraded ✓ |
| `never-ready-prod` pill | red Error | amber Reconciling ✓ |
| `never-ready-prod` banner | absent | `● kro is reconciling` ✓ |
| `never-ready-prod` appConfig node | grey | amber (reconciling) ✓ |
| `contagious-api-disabled` children | `{"items":null}` | `{"items":[]}` ✓ |
| `webapp-no-config-1` appConfig node | amber (now correct pending) | violet (pending) ✓ |