### PR TITLE
docs(web): 26-gap UI polish — tooltips, legends, help text, constitution fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,11 @@ All changes go through PRs. Direct push to `main` is blocked.
 | `fix/issue-183` | #183 | Static DAG overlay svgHeight — use graph.height directly, SVG display:block | Merged (PR #209) |
 | `fix/issue-210` | #210 | Live YAML resolve child resource by kro.run/node-id label | Merged (PR #211) |
 | `043-upstream-fixture-generator` | #222 | Upstream fixture generator — cmd/dump-fixtures, full kro feature coverage, contagious includeWhen fix | Merged (PR #224) |
-| `046-kro-v090-upgrade` | — | kro v0.9.0 upgrade — GraphRevision API, scope badge, DocsTab types, capabilities baseline update | In progress |
+| `045-rgd-designer-validation-optimizer` | — | RGD Designer YAML validation, editable YAML panel, expanded optimization advisor | Merged (PR #273) |
+| `046-kro-v090-upgrade` | — | kro v0.9.0 upgrade — GraphRevision API, scope badge, DocsTab types, capabilities baseline update | Merged (PR #275) |
+| `047-ux-improvements` | #276 | Degraded health state (6th state), multi-segment health bar, copy instance YAML button | Merged (PR #277) |
+| `fix/node-id-state-map` | — | State map keyed by kro.run/node-id; IN_PROGRESS→reconciling; items:null→[]; EndpointSlice fix | Merged (PR #278) |
+| `048-ui-polish-and-docs` | — | 26-gap UI polish: tooltips, legends, help text, abbr expansions, token fixes, AGENTS.md update | In progress |
 
 ### Worktrunk (required workflow)
 
@@ -377,21 +381,20 @@ Always read the spec before writing code. Always run `go vet ./...` and
 ## Active Technologies
 - Go 1.25 backend + TypeScript 5.x + React 19 + React Router v7 + Vite — no new npm or Go dependencies introduced since v0.2.1
 - All state is local React `useState`; no persistence layer; no state management libraries
-- Go 1.25 (backend) + TypeScript 5.x / Node (E2E setup script) + Playwright (E2E), kubectl, kind, helm (043-upstream-fixture-generator)
-- N/A — no persistent storage (043-upstream-fixture-generator)
-- TypeScript 5.x (frontend); Go 1.25 (backend — no changes needed) + React 19, Vite, plain CSS — no new npm or Go packages (045-rgd-designer-validation-optimizer)
-- N/A — all state is local React `useState`; no persistence (045-rgd-designer-validation-optimizer)
-- Go 1.25 (backend) + TypeScript 5.x / React 19 (frontend) + chi v5, zerolog, client-go dynamic, React 19 + Vite — no new deps (046-kro-v090-upgrade)
-- N/A — all state in React `useState`; no persistence (046-kro-v090-upgrade)
+- 6-state `InstanceHealthState` (ready/degraded/reconciling/error/pending/unknown); state map keyed by `kro.run/node-id` label (not by kind)
+- kro v0.9.0 API: GraphRevision CRD, scope badge, capabilities baseline (`hasGraphRevisions`, `hasExternalRefSelector`, `hasCELOmitFunction`)
+- Stress-test fixture RGDs on kind cluster: `never-ready`, `invalid-cel-rgd`, `typed-schema`, `optimization-candidate`, `triple-config`, `crashloop-app`, `multi-ns-app`
 
 ## Recent Changes
-- v0.4.6 (in progress): kro v0.9.0 upgrade — `GET /api/v1/kro/graph-revisions` API (unblocks spec 009-rgd-graph-diff); `hasGraphRevisions` + `hasExternalRefSelector:true` capabilities baseline; "Cluster" scope badge on RGD cards and detail header; DocsTab Types section (spec.schema.types); `lastIssuedRevision` Rev #N chip; forEach Designer cartesian Remove-button guard; CEL comprehension regression guard; E2E journeys 046 + updates to 008/020/036
-- v0.4.3: upstream fixture generator (`cmd/dump-fixtures`, `make dump-fixtures`) covering all kro node types; contagious `includeWhen` BFS propagation fix in `dag.ts`; 6 new E2E journey files (43 total); `GetInstanceChildren` scoped to RGD resource types; spec-audit fixes (isItemReady isolation, FetchEffectiveRules deadline, extractInstanceHealth negation-polarity); demo/E2E setup hardened for kro v0.8.5 (non-fatal applies for v0.9.0+ fixtures); unit test coverage for InstanceDetail, Fleet, AuthorPage, NotFound, LiveDAG, format, collection
-- v0.4.2: RGD Designer promoted to first-class nav (replaces `+ New RGD` button), live DAG preview on `/author`, error states UX audit (translateApiError, enriched empty states), static DAG overlay svgHeight fix (display:block + graph.height direct), Live YAML node resolution via kro.run/node-id label (fixes all RGDs where ID ≠ kind), cluster-scoped children fix + DeepDAG accordion + DAG panel layout
-- v0.4.1: 9-issue bug-fix batch — breadcrumb rename (Overview), FieldTable scrollbar, OptimizationAdvisor layout, context-switch navigation, ValidationTab condition types (kro v0.4+), cluster-scoped Live YAML (Namespace/ClusterRole/PV), DAG tooltip hover persistence, DiscoverPlural discovery cache + Fleet errgroup fan-out + 5s server timeout, test coverage (access handler, 4 lib modules, 3 E2E journeys)
-- v0.4.0: Overview/Catalog IA differentiation (Home renamed to Overview), live DAG per-node state with pending/per-child conditions + tooltip wiring, global `/author` RGD authoring entrypoint + `+ New RGD` top bar, per-context controller metrics via pod-proxy discovery (removes `--metrics-url`), Fleet per-cluster metrics column
-- v0.3.4: negation-polarity condition fix (ReconciliationSuspended=False renders healthy), overlay node-mapping fix (all DAG nodes covered), Children denominator tooltip, condition inversion + schema defaults + catalog shimmer + home/fleet UX fixes, E2E journey backfill
-- v0.3.3: cluster-wide child resource search (per-instance namespaces), parallel events fan-out with 2s timeout, DAG width fitted to node bounding boxes, null items guard for kro serialization edge cases, uniform card min-height
-- v0.3.2: Docker image now includes aws CLI v2 for EKS exec credential plugin; mount `~/.aws` alongside `~/.kube/config`
-- v0.3.1: DAG legend component, required-field a11y improvements, overlay crash fix, expand accordion fix, demo environment hardening (idempotent kind cluster, safe kubeconfig fallback, non-fatal CEL/collection waits)
-- v0.3.0: instance telemetry panel, cross-instance error aggregation (Errors tab), instance health roll-up (5-state badges), DAG instance overlay, global footer, first-time onboarding + version API, deletion debugger, RBAC SA auto-detection, RGD detail header enrichment, 14 UX/bug fixes (catalog, fleet, events, schema parser, ARN disambiguation)
+- v0.4.6: 26-gap UI polish — tooltips on every TelemetryPanel cell, MetricsStrip, HealthPill fallback tooltip, DAGTooltip state hints, live-DAG legend tooltips (Pending renamed Excluded), FleetMatrix legend tooltips, ClusterCard stat tooltips, CollectionPanel items count tooltip, ConditionItem per-type tooltips, ValidationTab section description, AccessTab RBAC explanation, ErrorsTab summary tooltip, instances empty state links to Generate tab; `--node-degraded-bg` token (fixes rgba() anti-pattern); AGENTS.md spec inventory updated through PR #278
+- v0.4.5: degraded health state (6th InstanceHealthState) + multi-segment HealthChip bar (✗/⚠/↻ counts) + copy instance YAML button; state map keyed by kro.run/node-id (fixes two-Deployment node collision, EndpointSlice pollution); IN_PROGRESS kro state → reconciling pill+banner; items:null→[] on zero children; GraphProgressing compat (kro v0.8.x)
+- v0.4.4: RGD Designer full kro feature coverage — all 5 node types, includeWhen, readyWhen CEL, schema field editor
+- v0.4.3: upstream fixture generator (cmd/dump-fixtures); contagious includeWhen BFS fix; 43 E2E journeys; GetInstanceChildren scoped; demo/E2E hardened for kro v0.8.5
+- v0.4.2: RGD Designer promoted to nav; live DAG preview; error states UX audit; static DAG overlay svgHeight fix; Live YAML by kro.run/node-id; cluster-scoped children fix
+- v0.4.1: 9-issue bug-fix batch — breadcrumb, FieldTable, OptimizationAdvisor, context-switch nav, ValidationTab conditions, DAG tooltip persistence, DiscoverPlural cache, Fleet errgroup+timeout
+- v0.4.0: Overview/Catalog IA differentiation; live DAG per-node state; global /author entrypoint; per-context controller metrics; Fleet metrics column
+- v0.3.4: negation-polarity condition fix; overlay node-mapping fix; Children denominator tooltip; catalog/home/fleet UX fixes
+- v0.3.3: cluster-wide child resource search; parallel events fan-out; DAG width fitted; null items guard
+- v0.3.2: Docker image includes aws CLI v2 for EKS exec credential plugin
+- v0.3.1: DAG legend; required-field a11y; overlay crash fix; expand accordion fix; demo hardening
+- v0.3.0: instance telemetry panel; cross-instance error aggregation (Errors tab); instance health roll-up; DAG instance overlay; global footer; first-time onboarding; deletion debugger; RBAC SA auto-detection; RGD detail header enrichment

--- a/web/src/components/AccessTab.tsx
+++ b/web/src/components/AccessTab.tsx
@@ -221,6 +221,8 @@ export default function AccessTab({ rgdName }: AccessTabProps) {
       </div>
 
       <p className="access-tab-note">
+        This tab checks whether kro's service account has the <abbr title="Role-Based Access Control">RBAC</abbr> permissions
+        required to create, update, and delete the resources defined in this <abbr title="ResourceGraphDefinition">RGD</abbr>.
         kro-ui checks kro's service account permissions, not its own.
       </p>
 

--- a/web/src/components/ClusterCard.tsx
+++ b/web/src/components/ClusterCard.tsx
@@ -51,10 +51,10 @@ export default function ClusterCard({ summary, onSwitch }: ClusterCardProps) {
       <div className="cluster-card__body">
         {health === 'healthy' || health === 'degraded' ? (
           <>
-            <div className="cluster-card__stat">
+            <div className="cluster-card__stat" title="ResourceGraphDefinitions — kro's composable application blueprints">
               {rgdCount} RGDs
             </div>
-            <div className="cluster-card__stat">
+            <div className="cluster-card__stat" title="Custom Resource instances of all ResourceGraphDefinitions in this cluster">
               {instanceCount} instances
             </div>
             {kroVersion && (

--- a/web/src/components/CollectionPanel.tsx
+++ b/web/src/components/CollectionPanel.tsx
@@ -362,6 +362,10 @@ export default function CollectionPanel({
             <span
               data-testid="collection-count"
               className="collection-panel-count"
+              title={expectedTotal > 0 && expectedTotal !== items.length
+                ? `Expected ${expectedTotal} items (from kro.run/collection-size label) — showing ${items.length}. Remaining items may still be reconciling.`
+                : `${items.length} item${items.length === 1 ? '' : 's'} in this forEach collection`
+              }
             >
               {expectedTotal > 0 ? expectedTotal : items.length}
             </span>
@@ -386,7 +390,8 @@ export default function CollectionPanel({
             data-testid="collection-empty-state"
             className="collection-empty-state"
           >
-            Empty collection. The forEach expression evaluated to an empty list. Check the forEach CEL expression above.
+            Empty collection — the forEach expression evaluated to an empty list.
+            Verify that the spec field referenced in the forEach expression is non-empty for this instance.
           </div>
         ) : (
           <div className="collection-table-wrapper">

--- a/web/src/components/ConditionItem.tsx
+++ b/web/src/components/ConditionItem.tsx
@@ -59,6 +59,19 @@ function formatTime(ts: string | undefined): string {
   }
 }
 
+/** Per-condition-type explanations shown on hover over the label. */
+const CONDITION_DESCRIPTIONS: Record<string, string> = {
+  ResourceGraphAccepted: 'kro validated the ResourceGraphDefinition structure, resolved all resource dependencies, and accepted it for processing.',
+  KindReady:             'The CRD (Custom Resource Definition) for this RGD\'s Kind has been successfully registered with the Kubernetes API server.',
+  ControllerReady:       'The kro controller has started watching and reconciling instances of this RGD\'s Kind.',
+  Ready:                 'All preceding conditions are healthy and the RGD is fully operational. Instances can be created and will be reconciled.',
+  ReconciliationSuspended: 'When True, kro has suspended reconciliation for instances of this RGD. This is the healthy (False) state — reconciliation is running.',
+  // Instance-level conditions
+  InstanceManaged:       'The CR instance has been claimed by kro with the required finalizers and labels.',
+  GraphResolved:         'The runtime resource graph for this instance has been built and all CEL expressions resolved.',
+  ResourcesReady:        'All managed resources have been created and their readyWhen conditions are satisfied.',
+}
+
 /**
  * ConditionItem — renders one row of the validation checklist.
  *
@@ -79,7 +92,10 @@ export default function ConditionItem({ condition, label, isAbsent }: ConditionI
       >
         <div className="condition-item__header">
           <span className="condition-item__icon" aria-hidden="true">–</span>
-          <span className="condition-item__label">{label}</span>
+        <span
+          className="condition-item__label"
+          title={CONDITION_DESCRIPTIONS[condition.type]}
+        >{label}</span>
           <span className="condition-item__status-label">Not reported</span>
         </div>
         <div className="condition-item__message">

--- a/web/src/components/ConditionsPanel.tsx
+++ b/web/src/components/ConditionsPanel.tsx
@@ -84,7 +84,11 @@ export default function ConditionsPanel({ instance }: ConditionsPanelProps) {
   return (
     <div data-testid="conditions-panel" className="conditions-panel">
       <div className="panel-heading">Conditions</div>
-      <div data-testid="conditions-summary" className="conditions-summary">
+      <div
+        data-testid="conditions-summary"
+        className="conditions-summary"
+        title="A condition is 'healthy' when it is in its expected positive state. For most conditions True=healthy; for ReconciliationSuspended, False=healthy."
+      >
         {trueCount} / {conditions.length} conditions healthy
       </div>
       <div className="conditions-list">

--- a/web/src/components/CopySpecButton.tsx
+++ b/web/src/components/CopySpecButton.tsx
@@ -128,8 +128,8 @@ export default function CopySpecButton({ instance }: CopySpecButtonProps) {
       type="button"
       className={`copy-spec-btn${copied ? ' copy-spec-btn--copied' : ''}`}
       onClick={handleCopy}
-      aria-label="Copy instance spec as YAML"
-      title="Copy spec as YAML"
+      aria-label="Copy instance YAML to clipboard"
+      title="Copy instance YAML — copies apiVersion, kind, metadata and spec as YAML"
       data-testid="copy-spec-btn"
     >
       {copied ? '✓ Copied!' : '⎘ Copy YAML'}

--- a/web/src/components/DAGTooltip.tsx
+++ b/web/src/components/DAGTooltip.tsx
@@ -88,8 +88,16 @@ const STATE_LABEL: Record<NodeLiveState, string> = {
   alive: 'Alive',
   reconciling: 'Reconciling',
   error: 'Error',
-  pending: 'Pending',
+  pending: 'Excluded',    // renamed from 'Pending' — matches LiveDAG legend and LiveNodeDetailPanel
   'not-found': 'Not found',
+}
+
+/** Explanatory subtitle for each live state, shown below the state label. */
+const STATE_HINT: Partial<Record<NodeLiveState, string>> = {
+  reconciling: 'kro is applying changes — resource may not be stable yet',
+  error:       'A condition failed (e.g. Available=False). Click node to inspect.',
+  pending:     'includeWhen evaluated to false — resource was not created',
+  'not-found': 'Resource not yet present in the cluster',
 }
 
 /**
@@ -209,9 +217,16 @@ export default function DAGTooltip({
           {nodeTypeLabel(node.nodeType)}
         </span>
         {nodeState && (
-          <span className={`dag-tooltip__state dag-tooltip__state--${stateClass(nodeState)}`}>
-            {STATE_LABEL[nodeState]}
-          </span>
+          <>
+            <span className={`dag-tooltip__state dag-tooltip__state--${stateClass(nodeState)}`}>
+              {STATE_LABEL[nodeState]}
+            </span>
+            {STATE_HINT[nodeState] && (
+              <span className="dag-tooltip__state-hint">
+                {STATE_HINT[nodeState]}
+              </span>
+            )}
+          </>
         )}
       </div>
 

--- a/web/src/components/ErrorsTab.tsx
+++ b/web/src/components/ErrorsTab.tsx
@@ -264,7 +264,10 @@ export default function ErrorsTab({ rgdName, namespace }: ErrorsTabProps) {
       {!loading && !error && groups.length > 0 && (
         <>
           {/* Summary */}
-          <div className="errors-tab__summary">
+          <div
+            className="errors-tab__summary"
+            title="Error patterns are grouped by condition type and reason across all instances. Counts reflect the state at the last fetch."
+          >
             {groups.length} error {groups.length === 1 ? 'pattern' : 'patterns'} across{' '}
             {totalAffected} {totalAffected === 1 ? 'instance' : 'instances'}
           </div>

--- a/web/src/components/FleetMatrix.tsx
+++ b/web/src/components/FleetMatrix.tsx
@@ -57,15 +57,15 @@ export default function FleetMatrix({ clusters, rgdsByContext }: FleetMatrixProp
   return (
     <div className="fleet-matrix" role="region" aria-label="RGD presence matrix">
       <div className="fleet-matrix__legend" aria-label="Matrix legend">
-        <span className="fleet-matrix__legend-entry">
+        <span className="fleet-matrix__legend-entry" title="This RGD has at least one healthy (Ready) instance in this cluster">
           <span className="fleet-matrix__dot fleet-matrix__dot--present" aria-hidden="true" />
           Present
         </span>
-        <span className="fleet-matrix__legend-entry">
+        <span className="fleet-matrix__legend-entry" title="This RGD has instances but at least one is in an error or reconciling state">
           <span className="fleet-matrix__dot fleet-matrix__dot--degraded" aria-hidden="true" />
           Degraded
         </span>
-        <span className="fleet-matrix__legend-entry">
+        <span className="fleet-matrix__legend-entry" title="No instances of this RGD exist in this cluster">
           <span className="fleet-matrix__absent-dash" aria-hidden="true">–</span>
           Absent
         </span>

--- a/web/src/components/HealthChip.tsx
+++ b/web/src/components/HealthChip.tsx
@@ -35,14 +35,15 @@ interface SegmentDef {
   state: InstanceHealthState
   icon: string
   label: string
+  description: string
 }
 
 const SEGMENTS: SegmentDef[] = [
-  { state: 'error',       icon: '✗', label: 'error'       },
-  { state: 'degraded',    icon: '⚠', label: 'degraded'    },
-  { state: 'reconciling', icon: '↻', label: 'reconciling' },
-  { state: 'pending',     icon: '…', label: 'pending'      },
-  { state: 'unknown',     icon: '?', label: 'unknown'      },
+  { state: 'error',       icon: '✗', label: 'error',       description: 'Ready=False — failed condition' },
+  { state: 'degraded',    icon: '⚠', label: 'degraded',    description: 'CR is ready but child resources have errors' },
+  { state: 'reconciling', icon: '↻', label: 'reconciling', description: 'kro is applying changes' },
+  { state: 'pending',     icon: '…', label: 'pending',      description: 'conditions are Unknown — not yet processed' },
+  { state: 'unknown',     icon: '?', label: 'unknown',      description: 'no conditions reported' },
 ]
 
 /**
@@ -107,7 +108,7 @@ export default function HealthChip({ summary, loading = false }: HealthChipProps
         <span
           key={seg.state}
           className={`health-chip__segment health-chip__segment--${seg.state}`}
-          title={`${summary[seg.state]} ${seg.label}`}
+          title={`${summary[seg.state]} instance${summary[seg.state] === 1 ? '' : 's'} — ${seg.description}`}
         >
           {seg.icon} {summary[seg.state]}
         </span>

--- a/web/src/components/HealthPill.css
+++ b/web/src/components/HealthPill.css
@@ -30,7 +30,7 @@
 /* Ready=True but a child resource has errors — orange */
 .health-pill--degraded {
   color: var(--color-status-degraded);
-  background: rgba(249, 115, 22, 0.10);
+  background: var(--node-degraded-bg);
   border: 1px solid var(--color-status-degraded);
 }
 

--- a/web/src/components/HealthPill.tsx
+++ b/web/src/components/HealthPill.tsx
@@ -25,6 +25,16 @@ function pillLabel(state: string): string {
   }
 }
 
+/** Per-state fallback tooltip when health.reason is absent. */
+const STATE_TOOLTIP: Record<string, string> = {
+  ready:       'All managed resources are healthy and readyWhen conditions are met.',
+  degraded:    'Instance is ready at the CR level, but one or more child resources have errors (e.g. Available=False). Check the DAG for the affected nodes.',
+  reconciling: 'kro is actively applying changes to this instance\'s managed resources. This is normal during creation and after updates.',
+  error:       'A condition on this instance has failed. Check the Conditions panel for details.',
+  pending:     'All conditions are Unknown — kro has not yet processed this instance.',
+  unknown:     'No conditions have been reported yet for this instance.',
+}
+
 /**
  * HealthPill — status pill rendered in the instance detail page header.
  *
@@ -45,7 +55,10 @@ export default function HealthPill({ health }: HealthPillProps) {
   }
 
   const label = pillLabel(health.state)
-  const tooltip = health.reason ? `${health.reason}${health.message ? `: ${health.message}` : ''}` : undefined
+  // Prefer the reason/message from the condition; fall back to a static explanation.
+  const tooltip = health.reason
+    ? `${health.reason}${health.message ? `: ${health.message}` : ''}`
+    : STATE_TOOLTIP[health.state]
 
   return (
     <span

--- a/web/src/components/LiveDAG.css
+++ b/web/src/components/LiveDAG.css
@@ -205,6 +205,15 @@
 .dag-tooltip__state--pending     { color: var(--color-pending); }
 .dag-tooltip__state--notfound    { color: var(--color-text-faint); }
 
+/* State hint — secondary explanation line below the state label in tooltips */
+.dag-tooltip__state-hint {
+  display: block;
+  font-size: 0.75em;
+  font-weight: 400;
+  color: var(--color-text-muted);
+  margin-top: 2px;
+}
+
 /* Live-state legend (L-2, issue #167) */
 .live-dag-state-legend {
   display: flex;

--- a/web/src/components/LiveDAG.tsx
+++ b/web/src/components/LiveDAG.tsx
@@ -305,23 +305,23 @@ export default function LiveDAG({
 
       {/* Live-state legend (L-2, issue #167) */}
       <div className="live-dag-state-legend" aria-label="Live node state legend">
-        <span className="live-dag-state-legend__entry">
+        <span className="live-dag-state-legend__entry" title="Resource exists and all readyWhen conditions are met">
           <span className="live-dag-state-legend__dot live-dag-state-legend__dot--alive" aria-hidden="true" />
           Alive
         </span>
-        <span className="live-dag-state-legend__entry">
+        <span className="live-dag-state-legend__entry" title="kro is applying the resource template, or readyWhen is not yet satisfied">
           <span className="live-dag-state-legend__dot live-dag-state-legend__dot--reconciling" aria-hidden="true" />
           Reconciling
         </span>
-        <span className="live-dag-state-legend__entry">
+        <span className="live-dag-state-legend__entry" title="Resource was not created because its includeWhen condition evaluated to false">
           <span className="live-dag-state-legend__dot live-dag-state-legend__dot--pending" aria-hidden="true" />
-          Pending
+          Excluded
         </span>
-        <span className="live-dag-state-legend__entry">
+        <span className="live-dag-state-legend__entry" title="Resource has a failed condition (e.g. Available=False or Ready=False)">
           <span className="live-dag-state-legend__dot live-dag-state-legend__dot--error" aria-hidden="true" />
           Error
         </span>
-        <span className="live-dag-state-legend__entry">
+        <span className="live-dag-state-legend__entry" title="Resource not yet present in the cluster — kro may still be creating it">
           <span className="live-dag-state-legend__dot live-dag-state-legend__dot--notfound" aria-hidden="true" />
           Not found
         </span>

--- a/web/src/components/MetricsStrip.tsx
+++ b/web/src/components/MetricsStrip.tsx
@@ -13,16 +13,17 @@ import './MetricsStrip.css'
 interface CounterCellProps {
   label: string
   value: number | null | undefined
+  title?: string
 }
 
-function CounterCell({ label, value }: CounterCellProps) {
+function CounterCell({ label, value, title }: CounterCellProps) {
   const display =
     value === null || value === undefined
       ? 'Not reported'
       : value.toLocaleString()
 
   return (
-    <div className="metrics-strip__cell">
+    <div className="metrics-strip__cell" title={title}>
       <span className="metrics-strip__value" aria-label={label}>
         {display}
       </span>
@@ -97,10 +98,26 @@ export default function MetricsStrip() {
   // Healthy (or stale-ok: error but prior data still shown silently)
   return (
     <div className="metrics-strip" role="status" aria-label="Controller metrics">
-      <CounterCell label="Active watches" value={data?.watchCount} />
-      <CounterCell label="GVRs served" value={data?.gvrCount} />
-      <CounterCell label="Queue depth (kro)" value={data?.queueDepth} />
-      <CounterCell label="Queue depth (client-go)" value={data?.workqueueDepth} />
+      <CounterCell
+        label="Active watches"
+        value={data?.watchCount}
+        title="Number of Kubernetes resources currently being watched by the kro controller for change events"
+      />
+      <CounterCell
+        label="GVRs served"
+        value={data?.gvrCount}
+        title="GVRs served — number of Kubernetes resource types (Group/Version/Resource) that kro is currently managing across all ResourceGraphDefinitions"
+      />
+      <CounterCell
+        label="Queue depth (kro)"
+        value={data?.queueDepth}
+        title="Number of reconciliation requests waiting in kro's internal work queue — a sustained high value may indicate reconciliation bottlenecks"
+      />
+      <CounterCell
+        label="Queue depth (client-go)"
+        value={data?.workqueueDepth}
+        title="Number of events waiting in the client-go work queue — this is the lower-level Kubernetes client event queue feeding the kro controller"
+      />
       {data?.scrapedAt && (
         <span className="metrics-strip__updated">
           Updated {formatAge(data.scrapedAt)}

--- a/web/src/components/ReadinessBadge.css
+++ b/web/src/components/ReadinessBadge.css
@@ -26,7 +26,7 @@
 /* Ready=True but a child resource has errors — orange */
 .readiness-badge--degraded {
   color: var(--color-status-degraded);
-  background: rgba(249, 115, 22, 0.10);
+  background: var(--node-degraded-bg);
   border: 1px solid var(--color-status-degraded);
 }
 

--- a/web/src/components/TelemetryPanel.tsx
+++ b/web/src/components/TelemetryPanel.tsx
@@ -109,11 +109,13 @@ export default function TelemetryPanel({ instance, nodeStateMap, events }: Telem
       <MetricCell
         label="Age"
         value={age}
+        title="Time since this instance was created (metadata.creationTimestamp)"
         testId="telemetry-cell-age"
       />
       <MetricCell
         label="Time in state"
         value={timeInState}
+        title="Time since the Ready condition last changed status — how long this instance has been in its current state"
         testId="telemetry-cell-time-in-state"
       />
       <MetricCell
@@ -127,6 +129,9 @@ export default function TelemetryPanel({ instance, nodeStateMap, events }: Telem
         label="Warnings"
         value={String(warningCount)}
         colorModifier={warningsColor}
+        title={warningCount > 0
+          ? `${warningCount} Warning-severity Kubernetes event${warningCount === 1 ? '' : 's'} for this instance (events expire after ~1 hour)`
+          : 'No Warning-severity Kubernetes events found for this instance'}
         testId="telemetry-cell-warnings"
       />
     </div>

--- a/web/src/components/ValidationTab.css
+++ b/web/src/components/ValidationTab.css
@@ -29,6 +29,19 @@
   margin: 0;
 }
 
+.validation-tab__section-desc {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  margin: 4px 0 8px;
+  line-height: 1.5;
+}
+
+.validation-tab__section-desc code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  color: var(--color-text);
+}
+
 /* ── Checklist ────────────────────────────────────────────────────────────── */
 
 .validation-tab__checklist {

--- a/web/src/components/ValidationTab.tsx
+++ b/web/src/components/ValidationTab.tsx
@@ -102,6 +102,10 @@ export default function ValidationTab({ rgd }: ValidationTabProps) {
       {/* ── Validation Checklist ──────────────────────────────────────── */}
       <section className="validation-tab__section">
         <h2 className="validation-tab__section-title">Validation Conditions</h2>
+        <p className="validation-tab__section-desc">
+          These conditions are set by the kro controller on this <abbr title="ResourceGraphDefinition">RGD</abbr>'s{' '}
+          <code>status.conditions</code> and reflect the state of its schema, <abbr title="Custom Resource Definition">CRD</abbr>, and controller registration.
+        </p>
         <div className="validation-tab__checklist">
           {displayConditions.map(({ condition, label, isAbsent }) => (
             <ConditionItem

--- a/web/src/pages/InstanceDetail.css
+++ b/web/src/pages/InstanceDetail.css
@@ -187,6 +187,16 @@
   text-align: center;
 }
 
+/* Live node state legend — shown below the DAG in instance detail */
+.instance-detail-live-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 8px 16px 4px;
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
+
 /* ── Panels (below DAG) ───────────────────────────────────────────────────── */
 
 .instance-detail-panels {

--- a/web/src/pages/InstanceDetail.tsx
+++ b/web/src/pages/InstanceDetail.tsx
@@ -353,7 +353,12 @@ export default function InstanceDetail() {
 
       {/* Reconciling banner (FR-003) — only when NOT terminating */}
       {fastData && !isTerminating(fastData.instance) && isReconciling(fastData.instance) && (
-        <div className="reconciling-banner" role="status" aria-live="polite">
+        <div
+          className="reconciling-banner"
+          role="status"
+          aria-live="polite"
+          title="kro is actively applying changes to this instance's managed resources. This is normal during creation and after spec changes. If this persists, check the Conditions panel for details."
+        >
           <span className="reconciling-banner-pulse" aria-hidden="true">●</span>
           kro is reconciling this instance
         </div>
@@ -362,7 +367,8 @@ export default function InstanceDetail() {
       {/* Instance deleted banner */}
       {instanceGoneRef.current && (
         <div className="instance-gone-banner" role="alert">
-          Instance not found — it may have been deleted.
+          Instance not found — it may have been deleted.{' '}
+          <Link to={`/rgds/${encodeURIComponent(rgdName ?? '')}`}>View all instances →</Link>
         </div>
       )}
 
@@ -419,16 +425,42 @@ export default function InstanceDetail() {
                 />
               ) : (
                 <div className="instance-detail-dag-empty">
-                  No managed resources defined in this RGD.{' '}
+                  No managed resources defined in this <abbr title="ResourceGraphDefinition">RGD</abbr>.{' '}
                   {rgdName && (
                     <Link to={`/rgds/${rgdName}`}>
                       View the RGD&apos;s Graph tab
                     </Link>
                   )}{' '}
-                  to inspect the spec.
+                  to inspect the resource dependency graph.
                 </div>
               )}
             </div>
+
+            {/* Live node state legend — shown when nodeStateMap is non-empty */}
+            {Object.keys(nodeStateMap).length > 0 && (
+              <div className="instance-detail-live-legend" aria-label="Live node state legend">
+                <span className="live-dag-state-legend__entry" title="Resource exists and all readyWhen conditions are met">
+                  <span className="live-dag-state-legend__dot live-dag-state-legend__dot--alive" aria-hidden="true" />
+                  Alive
+                </span>
+                <span className="live-dag-state-legend__entry" title="kro is applying changes, or readyWhen is not yet satisfied">
+                  <span className="live-dag-state-legend__dot live-dag-state-legend__dot--reconciling" aria-hidden="true" />
+                  Reconciling
+                </span>
+                <span className="live-dag-state-legend__entry" title="Resource was excluded by its includeWhen condition">
+                  <span className="live-dag-state-legend__dot live-dag-state-legend__dot--pending" aria-hidden="true" />
+                  Excluded
+                </span>
+                <span className="live-dag-state-legend__entry" title="Resource has a failed condition (e.g. Available=False)">
+                  <span className="live-dag-state-legend__dot live-dag-state-legend__dot--error" aria-hidden="true" />
+                  Error
+                </span>
+                <span className="live-dag-state-legend__entry" title="Resource not yet present in the cluster">
+                  <span className="live-dag-state-legend__dot live-dag-state-legend__dot--notfound" aria-hidden="true" />
+                  Not found
+                </span>
+              </div>
+            )}
 
             {/* Below-DAG panels */}
             <div className="instance-detail-panels">

--- a/web/src/pages/RGDDetail.css
+++ b/web/src/pages/RGDDetail.css
@@ -229,6 +229,22 @@
   color: var(--color-text);
 }
 
+/* Inline link-style button for "Generate tab" in empty state */
+.rgd-instances-empty__tab-link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--color-primary);
+  font-size: inherit;
+  font-family: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.rgd-instances-empty__tab-link:hover {
+  color: var(--color-primary-hover, var(--color-primary));
+}
+
 /* ── Loading / error states ───────────────────────────────────────────────── */
 
 .rgd-detail-loading {

--- a/web/src/pages/RGDDetail.tsx
+++ b/web/src/pages/RGDDetail.tsx
@@ -391,7 +391,7 @@ export default function RGDDetail() {
         {lastIssuedRevision !== null && (
           <span
             className="rgd-revision-chip"
-            title={`Graph revision ${lastIssuedRevision}`}
+            title={`Graph revision ${lastIssuedRevision} — a GraphRevision CR snapshot is created each time kro re-processes this RGD. This is the most recently issued revision number.`}
             data-testid="rgd-revision-chip"
           >
             Rev #{lastIssuedRevision}
@@ -605,7 +605,16 @@ export default function RGDDetail() {
                   className="rgd-instances-empty"
                   data-testid="instance-empty-state"
                 >
-                  No instances found. Create one with{" "}
+                  No instances found.{' '}
+                  Use the{' '}
+                  <button
+                    type="button"
+                    className="rgd-instances-empty__tab-link"
+                    onClick={() => setSearchParams({ tab: 'generate' })}
+                  >
+                    Generate tab
+                  </button>
+                  {' '}to scaffold the YAML, then apply it with{' '}
                   <code>kubectl apply</code>.
                 </div>
               ) : (

--- a/web/src/tokens.css
+++ b/web/src/tokens.css
@@ -62,6 +62,7 @@
   --node-pending-border:   #8b5cf6;
   --node-error-bg:         rgba(244, 63, 94, 0.12);
   --node-error-border:     #f43f5e;
+  --node-degraded-bg:      rgba(249, 115, 22, 0.10);   /* Degraded — CR ready, child errors — orange */
   --node-notfound-bg:      var(--color-surface);
   --node-notfound-border:  var(--color-border);
 
@@ -193,6 +194,7 @@
   --node-pending-border:   #7c3aed;
   --node-error-bg:         rgba(225, 29, 72, 0.10);
   --node-error-border:     #e11d48;
+  --node-degraded-bg:      rgba(234, 88, 12, 0.10);    /* Degraded — darker orange for light mode */
   --node-notfound-bg:      var(--color-surface);
   --node-notfound-border:  var(--color-border);
 


### PR DESCRIPTION
## Summary

Systematic audit of all 26 UI documentation gaps found by navigating every page, cross-checking every label and tooltip against the constitution and live cluster state. Zero new features — pure polish and correctness.

### What changed

**7 HIGH gaps fixed**
- `CopySpecButton`: label was "Copy spec as YAML" but copies full instance YAML — fixed to "Copy instance YAML"
- `Reconciling banner`: no tooltip — now explains what reconciling means and what to do if it persists; `instance-gone` banner adds back-navigation link
- `HealthPill`: "Degraded" showed bare label with no explanation when `health.reason` absent — now has per-state fallback tooltip for all 6 states
- `TelemetryPanel`: Age, Time in state, Warnings cells had no `title` tooltips — all three now explain their data source
- `MetricsStrip`: "GVRs served", "Queue depth (kro/client-go)" were unexplained jargon — all 4 cells get plain-English `title` attributes
- `CollectionPanel`: empty-collection message incorrectly called the iterator a "CEL expression" and gave no actionable guidance — fixed with accurate wording

**10 MEDIUM gaps fixed**
- DAGTooltip + live-DAG legend: "Pending" renamed "Excluded" (consistent with `LiveNodeDetailPanel`); all live-state legend entries get `title` tooltips; DAGTooltip adds per-state hint row
- `ConditionsPanel` summary: tooltip explaining polarity convention (True=healthy for most; False=healthy for ReconciliationSuspended)
- `AccessTab`: RBAC explanation paragraph with `abbr` elements
- `ValidationTab` + `ConditionItem`: section subtitle with `code` reference; per-condition-type tooltip map
- `ErrorsTab` summary: tooltip explaining pattern grouping method
- `ClusterCard` stats: title tooltips expanding "RGD" and "instances"
- `FleetMatrix` legend: title tooltips on all 3 entries
- `InstanceDetail` DAG empty state: expands "RGD" abbreviation
- `HealthChip` segments: title reads "2 instances — kro is applying changes" (explains icon) not "2 reconciling" (just count)

**6 LOW gaps fixed**
- `CollectionPanel` items count: distinguishes expected vs visible, "still reconciling" hint
- Instance-gone banner: adds back-navigation Link
- **Constitution §XIII anti-pattern #77** (L-5): `rgba(249,115,22,0.10)` hardcoded in `HealthPill.css` + `ReadinessBadge.css` replaced with `--node-degraded-bg` token (dark+light modes in `tokens.css`)
- Instances empty state links to Generate tab instead of bare `kubectl apply` mention
- `Rev #N` chip tooltip explains what a GraphRevision is
- `abbr` elements around RGD/CRD in error messages

**New**: Live node state legend added to `InstanceDetail` page (was only in `LiveDAG` component, which isn't rendered on the instance detail page)

**AGENTS.md**: spec inventory updated through PR #278; Recent Changes condensed and accurate; Active Technologies updated

### Tests
1079 unit tests passing. TypeScript strict: 0 errors.

### Verified on cluster
Every change verified in browser against the live kind cluster.