### PR TITLE
feat(web): refresh now button, Designer CEL/scope help text, optimizer URL fix

### DIFF
--- a/web/src/components/OptimizationAdvisor.test.tsx
+++ b/web/src/components/OptimizationAdvisor.test.tsx
@@ -116,7 +116,7 @@ describe('OptimizationAdvisor — US3 (expand, explanation, docs link)', () => {
     fireEvent.click(screen.getByTestId('advisor-item-Deployment-expand'))
     const link = screen.getByTestId('advisor-item-Deployment-docs-link')
     expect(link).toBeInTheDocument()
-    expect(link).toHaveAttribute('href', 'https://kro.run/docs/concepts/forEach')
+    expect(link).toHaveAttribute('href', 'https://kro.run/docs/concepts/collections')
   })
 
   it('docs link has target=_blank', () => {

--- a/web/src/components/OptimizationAdvisor.tsx
+++ b/web/src/components/OptimizationAdvisor.tsx
@@ -4,7 +4,9 @@ import './OptimizationAdvisor.css'
 
 // Spec: .specify/specs/023-rgd-optimization-advisor/
 
-const FOREACH_DOCS_URL = 'https://kro.run/docs/concepts/forEach'
+// The kro.run/docs/concepts/forEach path returns 404 as of v0.9.0.
+// The correct docs path for collections/forEach in kro v0.9.0 is the concepts page.
+const FOREACH_DOCS_URL = 'https://kro.run/docs/concepts/collections'
 
 interface CollapseGroupSuggestion {
   group: CollapseGroup

--- a/web/src/components/RGDAuthoringForm.tsx
+++ b/web/src/components/RGDAuthoringForm.tsx
@@ -446,7 +446,10 @@ export default function RGDAuthoringForm({ state, onChange, staticIssues }: RGDA
           />
 
           {/* US7: Scope toggle */}
-          <span className="rgd-authoring-form__label">Scope</span>
+          <span
+            className="rgd-authoring-form__label"
+            title="Namespaced: instances are created in a specific namespace (the default for most RGDs). Cluster: instances are cluster-scoped with no namespace (for platform-wide resources like ClusterRoles)."
+          >Scope</span>
           <div className="rgd-authoring-form__scope-group">
             <label className="rgd-authoring-form__scope-label">
               <input
@@ -649,7 +652,10 @@ export default function RGDAuthoringForm({ state, onChange, staticIssues }: RGDA
                   data-testid={`status-field-expr-${sf.id}`}
                   aria-label="Status field CEL expression"
                 />
-                <span className="rgd-authoring-form__cel-badge">CEL</span>
+                <span
+                  className="rgd-authoring-form__cel-badge"
+                  title="CEL — Common Expression Language. References schema fields with ${schema.spec.fieldName}. Example: ${schema.spec.replicas}"
+                >CEL</span>
               </div>
               <button
                 type="button"
@@ -864,7 +870,10 @@ export default function RGDAuthoringForm({ state, onChange, staticIssues }: RGDA
                           data-testid={`foreach-expr-${res._key}-${i}`}
                           aria-label="Iterator CEL expression"
                         />
-                        <span className="rgd-authoring-form__cel-badge">CEL</span>
+                        <span
+                          className="rgd-authoring-form__cel-badge"
+                          title="CEL — Common Expression Language. The forEach iterator references a schema array field. Example: schema.spec.regions"
+                        >CEL</span>
                       </div>
                       {/* FR-060: Hide Remove button when there is only 1 iterator.
                           Prevents accidentally leaving a forEach with 0 iterators. */}
@@ -1042,7 +1051,10 @@ export default function RGDAuthoringForm({ state, onChange, staticIssues }: RGDA
                 <div className="rgd-authoring-form__advanced-section">
                   {/* US3: includeWhen */}
                   <div className="rgd-authoring-form__advanced-row">
-                    <label className="rgd-authoring-form__sublabel">includeWhen</label>
+                    <label
+                      className="rgd-authoring-form__sublabel"
+                      title="includeWhen — a CEL expression that controls whether this resource is created at all. When false, the resource is excluded (shown as violet in the DAG). Example: ${schema.spec.enableCache}"
+                    >includeWhen</label>
                     <div className="rgd-authoring-form__cel-wrap">
                       <input
                         type="text"
@@ -1055,13 +1067,19 @@ export default function RGDAuthoringForm({ state, onChange, staticIssues }: RGDA
                         data-testid={`resource-include-when-${res._key}`}
                         aria-label="includeWhen CEL expression"
                       />
-                      <span className="rgd-authoring-form__cel-badge">CEL</span>
+                      <span
+                        className="rgd-authoring-form__cel-badge"
+                        title="CEL — Common Expression Language. When this expression evaluates to false, the resource is not created. Example: ${schema.spec.enableCache} == true"
+                      >CEL</span>
                     </div>
                   </div>
 
                   {/* US4: readyWhen repeatable rows */}
                   <div className="rgd-authoring-form__advanced-row">
-                    <label className="rgd-authoring-form__sublabel">readyWhen</label>
+                    <label
+                      className="rgd-authoring-form__sublabel"
+                      title="readyWhen — one or more CEL expressions that must ALL evaluate to true before kro considers this resource Ready. The instance stays in 'Reconciling' state until all readyWhen conditions pass. Example: ${web.status.availableReplicas} >= 1"
+                    >readyWhen</label>
                     <div className="rgd-authoring-form__readywhen-rows">
                       {(res.readyWhen ?? []).map((rw, i) => (
                         <div key={i} className="rgd-authoring-form__readywhen-row">
@@ -1075,7 +1093,10 @@ export default function RGDAuthoringForm({ state, onChange, staticIssues }: RGDA
                               data-testid={`readywhen-expr-${res._key}-${i}`}
                               aria-label={`readyWhen expression ${i + 1}`}
                             />
-                            <span className="rgd-authoring-form__cel-badge">CEL</span>
+                            <span
+                              className="rgd-authoring-form__cel-badge"
+                              title="CEL — Common Expression Language. This expression must evaluate to true for the resource to be considered Ready. Example: ${web.status.availableReplicas} >= 1"
+                            >CEL</span>
                           </div>
                           <button
                             type="button"

--- a/web/src/pages/InstanceDetail.css
+++ b/web/src/pages/InstanceDetail.css
@@ -91,6 +91,35 @@
 
 /* ── Refresh indicator ────────────────────────────────────────────────────── */
 
+/* Manual refresh button — sits next to the refresh indicator in the header */
+.instance-detail-refresh-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-2);
+  color: var(--color-text-muted);
+  font-size: 13px;
+  cursor: pointer;
+  line-height: 1;
+  transition: color var(--transition-fast), background var(--transition-fast), border-color var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.instance-detail-refresh-btn:hover {
+  color: var(--color-text);
+  background: var(--color-surface-3);
+  border-color: var(--color-border);
+}
+
+.instance-detail-refresh-btn:active {
+  background: var(--color-surface);
+}
+
 .refresh-indicator {
   font-size: 12px;
   color: var(--color-text-faint);

--- a/web/src/pages/InstanceDetail.tsx
+++ b/web/src/pages/InstanceDetail.tsx
@@ -183,7 +183,7 @@ export default function InstanceDetail() {
     return { instance, events }
   }, [namespace, instanceName, rgdName])
 
-  const { data: fastData, error: pollError, loading: pollLoading, lastRefresh } = usePolling(
+  const { data: fastData, error: pollError, loading: pollLoading, lastRefresh, refresh: pollRefresh } = usePolling(
     fetcher,
     [namespace, instanceName, rgdName],
     { intervalMs: 5000 },
@@ -340,6 +340,16 @@ export default function InstanceDetail() {
         <div className="instance-detail-meta">
           {namespace && <span className="instance-detail-ns">{namespace}</span>}
           <RefreshIndicator lastRefresh={lastRefresh} error={instanceGone ? null : (pollError && !pollLoading ? pollError : null)} />
+          <button
+            type="button"
+            className="instance-detail-refresh-btn"
+            onClick={pollRefresh}
+            aria-label="Refresh now"
+            title="Refresh now — trigger an immediate poll instead of waiting for the next 5-second cycle"
+            data-testid="instance-refresh-btn"
+          >
+            ↻
+          </button>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Four gaps closed in one batch: a feature backlog item (F-4) plus three documentation gaps missed in the previous polish cycle.

### F-4 — Refresh now button (GH #276)

A small `↻` button added to the instance detail header, next to the existing `refreshed Ns ago` indicator. Clicking it calls `usePolling`'s exposed `refresh()` callback immediately, firing a new poll cycle without waiting for the 5-second timer. Useful during active debugging — no need to watch the clock. The button has a `title` tooltip explaining the behaviour.

**Implementation**: `usePolling` already exposes `refresh` — only the destructure and the button render were missing.

### H-4 — CEL badge tooltips in RGD Designer

All four `<span class="rgd-authoring-form__cel-badge">CEL</span>` instances had no `title` attribute. Added context-aware tooltips:
- **Status field**: generic CEL explanation + `${schema.spec.fieldName}` example
- **forEach iterator**: explains the iterator references a schema array field
- **includeWhen**: explains "false = resource excluded" with example
- **readyWhen**: explains "all must be true for resource to be Ready" with example

### M-8 — Designer Scope and Advanced option help text

- **Scope label**: `title` explaining Namespaced vs Cluster scope difference
- **includeWhen sublabel**: `title` explaining exclusion semantics + CEL example
- **readyWhen sublabel**: `title` explaining readiness gate + reconciling state + CEL example

### L-6 — Fix OptimizationAdvisor docs link (404)

`FOREACH_DOCS_URL = 'https://kro.run/docs/concepts/forEach'` returned HTTP 404. Updated to `'https://kro.run/docs/concepts/collections'` (correct kro v0.9.0 path). `OptimizationAdvisor.test.tsx` assertion updated.

## Tests
1079 unit tests passing. TypeScript strict: 0 errors. `OptimizationAdvisor.test.tsx` updated to match corrected URL.

## Verified on cluster
- `↻` button visible and functional on instance detail pages
- Clicking button immediately triggers a new poll (refreshed 0s ago counter resets)
- Designer Scope label tooltip visible on hover
- CEL badge tooltips visible on hover in Advanced options section