### PR TITLE
feat(web): reconcile-paused banner, cluster-scoped namespace display

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,9 @@ All changes go through PRs. Direct push to `main` is blocked.
 | `046-kro-v090-upgrade` | — | kro v0.9.0 upgrade — GraphRevision API, scope badge, DocsTab types, capabilities baseline update | Merged (PR #275) |
 | `047-ux-improvements` | #276 | Degraded health state (6th state), multi-segment health bar, copy instance YAML button | Merged (PR #277) |
 | `fix/node-id-state-map` | — | State map keyed by kro.run/node-id; IN_PROGRESS→reconciling; items:null→[]; EndpointSlice fix | Merged (PR #278) |
-| `048-ui-polish-and-docs` | — | 26-gap UI polish: tooltips, legends, help text, abbr expansions, token fixes, AGENTS.md update | In progress |
+| `048-ui-polish-and-docs` | — | 26-gap UI polish: tooltips, legends, help text, abbr expansions, token fixes, AGENTS.md update | Merged (PR #279) |
+| `049-designer-ux-refresh-button` | — | Refresh now button; Designer CEL/scope help text; optimizer docs URL fix | Merged (PR #280) |
+| `050-kro-v090-phase2` | #274 | kro v0.9.0 phase 2 — reconcile-paused banner, cluster-scoped namespace display, displayNamespace utility | In progress |
 
 ### Worktrunk (required workflow)
 
@@ -386,7 +388,8 @@ Always read the spec before writing code. Always run `go vet ./...` and
 - Stress-test fixture RGDs on kind cluster: `never-ready`, `invalid-cel-rgd`, `typed-schema`, `optimization-candidate`, `triple-config`, `crashloop-app`, `multi-ns-app`
 
 ## Recent Changes
-- v0.4.6: 26-gap UI polish — tooltips on every TelemetryPanel cell, MetricsStrip, HealthPill fallback tooltip, DAGTooltip state hints, live-DAG legend tooltips (Pending renamed Excluded), FleetMatrix legend tooltips, ClusterCard stat tooltips, CollectionPanel items count tooltip, ConditionItem per-type tooltips, ValidationTab section description, AccessTab RBAC explanation, ErrorsTab summary tooltip, instances empty state links to Generate tab; `--node-degraded-bg` token (fixes rgba() anti-pattern); AGENTS.md spec inventory updated through PR #278
+- v0.4.7 (in progress): kro v0.9.0 phase 2 — reconcile-paused banner (`kro.run/reconcile: disabled` annotation), `displayNamespace()` utility (`_` → "cluster-scoped" in InstanceTable, InstanceDetail meta, OverlayBar picker)
+- v0.4.6: 26-gap UI polish (PR #279) + refresh button + Designer help text + optimizer URL fix (PR #280)
 - v0.4.5: degraded health state (6th InstanceHealthState) + multi-segment HealthChip bar (✗/⚠/↻ counts) + copy instance YAML button; state map keyed by kro.run/node-id (fixes two-Deployment node collision, EndpointSlice pollution); IN_PROGRESS kro state → reconciling pill+banner; items:null→[] on zero children; GraphProgressing compat (kro v0.8.x)
 - v0.4.4: RGD Designer full kro feature coverage — all 5 node types, includeWhen, readyWhen CEL, schema field editor
 - v0.4.3: upstream fixture generator (cmd/dump-fixtures); contagious includeWhen BFS fix; 43 E2E journeys; GetInstanceChildren scoped; demo/E2E hardened for kro v0.8.5

--- a/web/src/components/InstanceOverlayBar.tsx
+++ b/web/src/components/InstanceOverlayBar.tsx
@@ -18,6 +18,7 @@
 import { Link } from 'react-router-dom'
 import type { K8sObject } from '@/lib/api'
 import { extractInstanceHealth } from '@/lib/format'
+import { displayNamespace } from '@/lib/format'
 import type { InstanceHealthState } from '@/lib/format'
 import { translateApiError } from '@/lib/errors'
 import './InstanceOverlayBar.css'
@@ -143,7 +144,9 @@ export default function InstanceOverlayBar({
           <option value="">No overlay</option>
           {items.map((item) => {
             const value = item.namespace ? `${item.namespace}/${item.name}` : item.name
-            const label = item.namespace ? `${item.namespace}/${item.name}` : item.name
+            const label = item.namespace
+              ? `${displayNamespace(item.namespace)}/${item.name}`
+              : item.name
             return (
               <option key={value} value={value}>
                 {label}

--- a/web/src/components/InstanceTable.tsx
+++ b/web/src/components/InstanceTable.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import type { K8sObject } from '@/lib/api'
-import { extractInstanceHealth, formatAge, extractCreationTimestamp } from '@/lib/format'
+import { extractInstanceHealth, formatAge, extractCreationTimestamp, displayNamespace } from '@/lib/format'
 import { isTerminating } from '@/lib/k8s'
 import ReadinessBadge from './ReadinessBadge'
 import './InstanceTable.css'
@@ -211,7 +211,7 @@ export default function InstanceTable({ items, rgdName }: InstanceTableProps) {
                   className="instance-table__td"
                   data-testid="instance-namespace"
                 >
-                  {namespace}
+                  {displayNamespace(namespace)}
                 </td>
                 <td className="instance-table__td" data-testid="instance-age">
                   {age}

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -9,6 +9,7 @@ import {
   extractInstanceHealth,
   aggregateHealth,
   abbreviateContext,
+  displayNamespace,
 } from './format'
 
 // ── formatAge ────────────────────────────────────────────────────────
@@ -500,5 +501,31 @@ describe('abbreviateContext', () => {
   it('returns non-EKS ARN-format contexts as-is (no guessing)', () => {
     const oidcCtx = 'kubernetes-admin@my.cluster.example.com'
     expect(abbreviateContext(oidcCtx)).toBe(oidcCtx)
+  })
+})
+
+// ── displayNamespace ─────────────────────────────────────────────────
+
+describe('displayNamespace', () => {
+  it('returns "cluster-scoped" for the _ URL sentinel', () => {
+    expect(displayNamespace('_')).toBe('cluster-scoped')
+  })
+
+  it('returns "cluster-scoped" for empty string', () => {
+    expect(displayNamespace('')).toBe('cluster-scoped')
+  })
+
+  it('returns "cluster-scoped" for undefined', () => {
+    expect(displayNamespace(undefined)).toBe('cluster-scoped')
+  })
+
+  it('returns "cluster-scoped" for null', () => {
+    expect(displayNamespace(null)).toBe('cluster-scoped')
+  })
+
+  it('returns the namespace unchanged for a real namespace', () => {
+    expect(displayNamespace('kro-ui-demo')).toBe('kro-ui-demo')
+    expect(displayNamespace('default')).toBe('default')
+    expect(displayNamespace('kube-system')).toBe('kube-system')
   })
 })

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -381,3 +381,24 @@ export function abbreviateContext(ctx: string): string {
   // risks ambiguity. The full value is always on the title attribute.
   return ctx
 }
+
+// ── Namespace display ────────────────────────────────────────────────────────
+
+/**
+ * displayNamespace — translate the internal `_` cluster-scoped sentinel to the
+ * human-readable string "cluster-scoped".
+ *
+ * kro-ui uses `_` as a URL routing sentinel for cluster-scoped instances
+ * (e.g. /rgds/my-rgd/instances/_/my-instance). This sentinel must NEVER be
+ * shown to users in rendered text. Every place that renders a namespace string
+ * must call this function.
+ *
+ * Also handles the empty string case for graceful degradation.
+ *
+ * Per constitution §XIII §XII: "cluster-scoped" is the correct human-readable
+ * label; `_` and `""` must never appear in UI text for namespace fields.
+ */
+export function displayNamespace(ns: string | undefined | null): string {
+  if (!ns || ns === '_') return 'cluster-scoped'
+  return ns
+}

--- a/web/src/pages/InstanceDetail.css
+++ b/web/src/pages/InstanceDetail.css
@@ -132,6 +132,30 @@
 
 /* ── Banners ─────────────────────────────────────────────────────────────── */
 
+/* Reconciliation paused banner — kro.run/reconcile: disabled annotation detected */
+.reconcile-paused-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background: var(--node-pending-bg);
+  border: 1px solid var(--node-pending-border);
+  border-radius: var(--radius);
+  font-size: 13px;
+  color: var(--color-pending);
+}
+
+.reconcile-paused-banner__icon {
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
+.reconcile-paused-banner__code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  color: var(--color-pending);
+}
+
 .reconciling-banner {
   display: flex;
   align-items: center;

--- a/web/src/pages/InstanceDetail.tsx
+++ b/web/src/pages/InstanceDetail.tsx
@@ -29,7 +29,7 @@ import type { NodeLiveState } from '@/lib/instanceNodeState'
 import { buildDAGGraph } from '@/lib/dag'
 import { buildNodeStateMap } from '@/lib/instanceNodeState'
 import { resolveChildResourceInfo } from '@/lib/resolveResourceName'
-import { extractInstanceHealth, applyDegradedState } from '@/lib/format'
+import { extractInstanceHealth, applyDegradedState, displayNamespace } from '@/lib/format'
 import { countHealthyChildren } from '@/lib/telemetry'
 import { usePolling } from '@/hooks/usePolling'
 import { isTerminating, getDeletionTimestamp, getFinalizers } from '@/lib/k8s'
@@ -94,6 +94,20 @@ function RefreshIndicator({
       refreshed {secondsAgo}s ago
     </span>
   )
+}
+
+// ── Reconcile-paused detection ────────────────────────────────────────────
+// kro v0.9.0 changed from a label to an annotation:
+//   Annotation: metadata.annotations["kro.run/reconcile"] === "disabled"
+// When present, kro stops reconciling the instance until the annotation is removed.
+
+function isReconcilePaused(instance: K8sObject | null): boolean {
+  if (!instance) return false
+  const meta = instance.metadata as Record<string, unknown> | undefined
+  if (!meta) return false
+  const annotations = meta.annotations
+  if (typeof annotations !== 'object' || annotations === null) return false
+  return (annotations as Record<string, unknown>)['kro.run/reconcile'] === 'disabled'
 }
 
 // ── Reconciling banner ─────────────────────────────────────────────────────
@@ -338,7 +352,7 @@ export default function InstanceDetail() {
         ) : null} />
         {fastData && <CopySpecButton instance={fastData.instance} />}
         <div className="instance-detail-meta">
-          {namespace && <span className="instance-detail-ns">{namespace}</span>}
+          {namespace && <span className="instance-detail-ns">{displayNamespace(namespace)}</span>}
           <RefreshIndicator lastRefresh={lastRefresh} error={instanceGone ? null : (pollError && !pollLoading ? pollError : null)} />
           <button
             type="button"
@@ -359,6 +373,21 @@ export default function InstanceDetail() {
           deletionTimestamp={getDeletionTimestamp(fastData.instance) ?? ''}
           tick={pollTick}
         />
+      )}
+
+      {/* Reconciliation paused banner (kro v0.9.0 — annotation kro.run/reconcile=disabled) */}
+      {fastData && isReconcilePaused(fastData.instance) && (
+        <div
+          className="reconcile-paused-banner"
+          role="status"
+          aria-live="polite"
+          title="kro.run/reconcile: disabled annotation is present. Remove the annotation to resume reconciliation: kubectl annotate <kind> <name> kro.run/reconcile-"
+        >
+          <span className="reconcile-paused-banner__icon" aria-hidden="true">⏸</span>
+          Reconciliation paused — kro will not apply changes until the{' '}
+          <code className="reconcile-paused-banner__code">kro.run/reconcile: disabled</code>
+          {' '}annotation is removed.
+        </div>
       )}
 
       {/* Reconciling banner (FR-003) — only when NOT terminating */}


### PR DESCRIPTION
## Summary

Two outstanding items from GH #274 (kro v0.9.0 upgrade audit, Phase 2).

### Reconciliation paused banner

kro v0.9.0 changed how instance reconciliation is suspended: from a label to an annotation:

```
metadata.annotations['kro.run/reconcile'] === 'disabled'
```

Previously the UI had no indicator when reconciliation was paused. Now a **violet info banner** appears at the top of the instance detail page:

> ⏸ Reconciliation paused — kro will not apply changes until the `kro.run/reconcile: disabled` annotation is removed.

The banner:
- Appears within one 5-second poll cycle of the annotation being applied
- Disappears within one cycle of the annotation being removed
- Uses the pending/violet color (visually distinct from amber reconciling and rose error)
- Has a `title` tooltip with the kubectl command to resume: `kubectl annotate <kind> <name> kro.run/reconcile-`

**Verified on cluster**: applied and removed annotation on `autoscaled-proxy` — banner appeared and disappeared correctly.

### Cluster-scoped namespace display

kro-ui uses `_` as a URL routing sentinel for cluster-scoped instances. This sentinel was rendering literally in the UI in three places. Fixed with a new `displayNamespace(ns)` utility in `format.ts`:

```ts
displayNamespace('_')          → 'cluster-scoped'
displayNamespace('')           → 'cluster-scoped'
displayNamespace(undefined)    → 'cluster-scoped'
displayNamespace('kro-ui-demo') → 'kro-ui-demo'  // unchanged
```

Updated display sites:
- `InstanceTable.tsx` — Namespace column
- `InstanceDetail.tsx` — header meta pill  
- `InstanceOverlayBar.tsx` — Graph tab instance picker dropdown label

## Tests

5 new unit tests for `displayNamespace` in `format.test.ts`. 1084 tests total, all passing.

## Closes

Partially addresses GH #274 (Phase 2 items: reconcile-paused, cluster-scoped display).