### PR TITLE
fix(web): ErrorsTab unique-instance dedup; OptimizationAdvisor emoji removed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,8 @@ All changes go through PRs. Direct push to `main` is blocked.
 | `fix/node-id-state-map` | — | State map keyed by kro.run/node-id; IN_PROGRESS→reconciling; items:null→[]; EndpointSlice fix | Merged (PR #278) |
 | `048-ui-polish-and-docs` | — | 26-gap UI polish: tooltips, legends, help text, abbr expansions, token fixes, AGENTS.md update | Merged (PR #279) |
 | `049-designer-ux-refresh-button` | — | Refresh now button; Designer CEL/scope help text; optimizer docs URL fix | Merged (PR #280) |
-| `050-kro-v090-phase2` | #274 | kro v0.9.0 phase 2 — reconcile-paused banner, cluster-scoped namespace display, displayNamespace utility | In progress |
+| `050-kro-v090-phase2` | #274 | kro v0.9.0 phase 2 — reconcile-paused banner, cluster-scoped namespace display, displayNamespace utility | Merged (PR #281) |
+| `fix/errortab-dedup-chip` | — | ErrorsTab unique-instance dedup in summary; OptimizationAdvisor emoji removed | In progress |
 
 ### Worktrunk (required workflow)
 

--- a/web/src/components/ErrorsTab.tsx
+++ b/web/src/components/ErrorsTab.tsx
@@ -209,7 +209,16 @@ export default function ErrorsTab({ rgdName, namespace }: ErrorsTabProps) {
 
   // ── Render ───────────────────────────────────────────────────────────────
 
-  const totalAffected = groups.reduce((s, g) => s + g.count, 0)
+  // Count unique affected instances across all groups.
+  // groups.reduce((s, g) => s + g.count) would double-count instances that
+  // have multiple failing conditions (e.g. both Ready=False and ResourcesReady=False).
+  const affectedSet = new Set<string>()
+  for (const g of groups) {
+    for (const inst of g.instances) {
+      affectedSet.add(`${inst.namespace}/${inst.name}`)
+    }
+  }
+  const totalAffected = affectedSet.size
 
   return (
     <div className="errors-tab" data-testid="errors-tab">

--- a/web/src/components/OptimizationAdvisor.tsx
+++ b/web/src/components/OptimizationAdvisor.tsx
@@ -60,7 +60,7 @@ export default function OptimizationAdvisor({ groups }: OptimizationAdvisorProps
   return (
     <div className="optimization-advisor" data-testid="optimization-advisor">
       <div className="optimization-advisor__header">
-        <span className="optimization-advisor__icon" aria-hidden="true">💡</span>
+        <span className="optimization-advisor__icon" aria-hidden="true">⚙</span>
         <span className="optimization-advisor__title">Optimization suggestions</span>
       </div>
       {suggestions.map((suggestion, idx) => {


### PR DESCRIPTION
## Summary

Two small correctness/constitution fixes.

### ErrorsTab: `totalAffected` counts unique instances, not sum of group counts

**Bug**: The Errors tab showed "2 error patterns across 6 instances" when there were only 3 unique instances. The 3 instances each had both `Ready=False` and `ResourcesReady=False`, so they appeared in 2 error groups and were counted twice. `groups.reduce((s, g) => s + g.count)` summed instance counts across groups instead of counting unique instances.

**Fix**: Build a `Set<string>` of `namespace/name` keys across all groups and use `.size`. Now correctly shows "2 error patterns across 3 instances".

Verified on the `never-ready` RGD which has 3 instances each with 2 failing conditions.

### OptimizationAdvisor: remove `💡` emoji (constitution §IX)

The constitution prohibits emojis by default unless explicitly requested. The `💡` in the advisor header was hardcoded. Replaced with `⚙` which has comparable visual weight without emoji renderer dependency.

## Tests
1084 tests passing.