### PR TITLE
fix(web): DocsTab JSON Schema object fields render as map/array type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,8 @@ All changes go through PRs. Direct push to `main` is blocked.
 | `048-ui-polish-and-docs` | — | 26-gap UI polish: tooltips, legends, help text, abbr expansions, token fixes, AGENTS.md update | Merged (PR #279) |
 | `049-designer-ux-refresh-button` | — | Refresh now button; Designer CEL/scope help text; optimizer docs URL fix | Merged (PR #280) |
 | `050-kro-v090-phase2` | #274 | kro v0.9.0 phase 2 — reconcile-paused banner, cluster-scoped namespace display, displayNamespace utility | Merged (PR #281) |
-| `fix/errortab-dedup-chip` | — | ErrorsTab unique-instance dedup in summary; OptimizationAdvisor emoji removed | In progress |
+| `fix/errortab-dedup-chip` | — | ErrorsTab unique-instance dedup in summary; OptimizationAdvisor emoji removed | Merged (PR #282) |
+| `fix/schema-object-type` | — | DocsTab: JSON Schema object fields render as map/array type, not [object Object] | In progress |
 
 ### Worktrunk (required workflow)
 
@@ -389,7 +390,8 @@ Always read the spec before writing code. Always run `go vet ./...` and
 - Stress-test fixture RGDs on kind cluster: `never-ready`, `invalid-cel-rgd`, `typed-schema`, `optimization-candidate`, `triple-config`, `crashloop-app`, `multi-ns-app`
 
 ## Recent Changes
-- v0.4.7 (in progress): kro v0.9.0 phase 2 — reconcile-paused banner (`kro.run/reconcile: disabled` annotation), `displayNamespace()` utility (`_` → "cluster-scoped" in InstanceTable, InstanceDetail meta, OverlayBar picker)
+- v0.4.8 (in progress): DocsTab JSON Schema object field rendering fix (`[object Object]` → `map[string]string`); `/pdca-improvements` slash command
+- v0.4.7: kro v0.9.0 phase 2 — reconcile-paused banner, cluster-scoped namespace display (PR #281); ErrorsTab unique-instance dedup, optimizer emoji (PR #282)
 - v0.4.6: 26-gap UI polish (PR #279) + refresh button + Designer help text + optimizer URL fix (PR #280)
 - v0.4.5: degraded health state (6th InstanceHealthState) + multi-segment HealthChip bar (✗/⚠/↻ counts) + copy instance YAML button; state map keyed by kro.run/node-id (fixes two-Deployment node collision, EndpointSlice pollution); IN_PROGRESS kro state → reconciling pill+banner; items:null→[] on zero children; GraphProgressing compat (kro v0.8.x)
 - v0.4.4: RGD Designer full kro feature coverage — all 5 node types, includeWhen, readyWhen CEL, schema field editor

--- a/web/src/lib/schema.test.ts
+++ b/web/src/lib/schema.test.ts
@@ -14,8 +14,8 @@ import type { K8sObject } from '@/lib/api'
 
 /** Build a minimal RGD K8sObject for testing buildSchemaDoc. */
 function makeRGD(
-  schemaSpec: Record<string, string>,
-  schemaStatus: Record<string, string> = {},
+  schemaSpec: Record<string, unknown>,
+  schemaStatus: Record<string, unknown> = {},
   kind = 'WebApplication',
 ): K8sObject {
   return {
@@ -458,5 +458,57 @@ describe('buildSchemaDoc', () => {
 
     expect(doc.kind).toBe('')
     expect(doc.specFields).toHaveLength(0)
+  })
+
+  // JSON Schema object fields — kro v0.9.0 allows full JSON Schema in spec
+  // Previously these produced "[object Object]" via String(value) (AGENTS anti-pattern #77 / §XII)
+
+  it('parses JSON Schema object with additionalProperties as map type', () => {
+    const rgd = makeRGD({
+      labels: { type: 'object', additionalProperties: { type: 'string' } },
+    })
+    const doc = buildSchemaDoc(rgd)
+
+    const labelsField = doc.specFields.find((f) => f.name === 'labels')
+    expect(labelsField).toBeDefined()
+    expect(labelsField?.raw).toBe('map[string]string')
+    expect(labelsField?.parsedType).toEqual({ type: 'map', key: 'string', value: 'string' })
+    // Must NOT contain "[object Object]"
+    expect(labelsField?.raw).not.toContain('[object Object]')
+  })
+
+  it('parses JSON Schema array field with items type', () => {
+    const rgd = makeRGD({
+      tags: { type: 'array', items: { type: 'string' } },
+    })
+    const doc = buildSchemaDoc(rgd)
+
+    const tagsField = doc.specFields.find((f) => f.name === 'tags')
+    expect(tagsField?.raw).toBe('[]string')
+    expect(tagsField?.parsedType).toEqual({ type: 'array', items: 'string' })
+  })
+
+  it('parses bare JSON Schema type object', () => {
+    const rgd = makeRGD({
+      metadata: { type: 'object' },
+    })
+    const doc = buildSchemaDoc(rgd)
+
+    const metaField = doc.specFields.find((f) => f.name === 'metadata')
+    expect(metaField?.raw).toBe('object')
+    expect(metaField?.parsedType).toEqual({ type: 'object' })
+  })
+
+  it('never produces [object Object] for any spec field value', () => {
+    const rgd = makeRGD({
+      str: 'string',
+      map: { type: 'object', additionalProperties: { type: 'integer' } },
+      arr: { type: 'array', items: { type: 'boolean' } },
+    })
+    const doc = buildSchemaDoc(rgd)
+
+    for (const f of doc.specFields) {
+      expect(f.raw).not.toContain('[object Object]')
+    }
   })
 })

--- a/web/src/lib/schema.ts
+++ b/web/src/lib/schema.ts
@@ -197,7 +197,65 @@ function parseBaseType(base: string): ParsedType {
   return { type: base }
 }
 
-// ── Status type inference ─────────────────────────────────────────────────
+// ── JSON Schema object → kro SimpleSchema type string ────────────────────
+
+/**
+ * Convert a raw spec field value to a display type string.
+ *
+ * kro SimpleSchema fields are normally strings like "string | default=foo"
+ * or "integer | required". However, when a field is defined using full
+ * JSON Schema syntax (e.g. `type: object` with `additionalProperties`),
+ * the value is a plain JavaScript object — NOT a string.
+ *
+ * Calling String() on such an object produces "[object Object]" which
+ * violates constitution §XII (graceful degradation: never render raw JS
+ * object coercions). This function produces a human-readable type label
+ * instead.
+ *
+ * Supported JSON Schema shapes → output:
+ *   { type: "object" }                            → "object"
+ *   { type: "object", additionalProperties: {type:"string"} } → "map[string]string"
+ *   { type: "array", items: {type: "string"} }    → "[]string"
+ *   { type: "array", items: "string" }             → "[]string"
+ *   { type: "boolean" }                            → "boolean"
+ *   anything else (unknown structure)              → JSON.stringify(value) truncated to 40 chars
+ */
+function rawSchemaValueToString(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (typeof value !== 'object' || value === null) return String(value)
+
+  const obj = value as Record<string, unknown>
+  const t = obj.type
+
+  if (t === 'object') {
+    const ap = obj.additionalProperties
+    if (ap && typeof ap === 'object') {
+      const apObj = ap as Record<string, unknown>
+      const valueType = typeof apObj.type === 'string' ? apObj.type : 'string'
+      return `map[string]${valueType}`
+    }
+    return 'object'
+  }
+
+  if (t === 'array') {
+    const items = obj.items
+    if (items && typeof items === 'object') {
+      const itemsObj = items as Record<string, unknown>
+      const itemType = typeof itemsObj.type === 'string' ? itemsObj.type : 'any'
+      return `[]${itemType}`
+    }
+    if (typeof items === 'string') return `[]${items}`
+    return '[]'
+  }
+
+  if (typeof t === 'string') return t
+
+  // Unknown JSON Schema shape — show compact JSON, capped at 40 chars.
+  const compact = JSON.stringify(value)
+  return compact.length > 40 ? compact.slice(0, 37) + '…' : compact
+}
+
+
 
 /**
  * Infer the display type for a status field from its CEL expression.
@@ -242,7 +300,11 @@ export function buildSchemaDoc(rgd: K8sObject): SchemaDoc {
 
   const specFields: ParsedField[] = Object.entries(rawSpec).map(
     ([name, value]) => {
-      const raw = typeof value === 'string' ? value : String(value)
+      // Use rawSchemaValueToString instead of String(value) to avoid
+      // "[object Object]" for fields defined with full JSON Schema syntax
+      // (e.g. { type: "object", additionalProperties: { type: "string" } }).
+      // Constitution §XII: graceful degradation — never render raw JS coercions.
+      const raw = rawSchemaValueToString(value)
       return {
         name,
         raw,
@@ -253,7 +315,7 @@ export function buildSchemaDoc(rgd: K8sObject): SchemaDoc {
 
   const statusFields: ParsedField[] = Object.entries(rawStatus).map(
     ([name, value]) => {
-      const raw = typeof value === 'string' ? value : String(value)
+      const raw = rawSchemaValueToString(value)
       return {
         name,
         raw,


### PR DESCRIPTION
## Summary

When a kro RGD spec field is defined with full JSON Schema syntax (object with `additionalProperties`, or array with `items`), the DocsTab was showing `[object Object]` in the Type column and generating a broken example manifest.

### Bug

```yaml
spec:
  schema:
    spec:
      labels:
        type: object
        additionalProperties:
          type: string
```

**Before**: Type column showed `[object Object]`, example manifest showed `labels: ""`

**After**: Type column shows `map[string]string`, example manifest shows `labels: {}     # required - map[string]string`

### Root cause

`buildSchemaDoc` used `String(value)` as a fallback for non-string spec field values. `String({type:"object",...})` → `"[object Object]"` — a constitution §XII violation (graceful degradation: never render raw JS object coercions in user-visible output).

### Fix

New `rawSchemaValueToString()` in `schema.ts` derives a human-readable kro SimpleSchema-compatible type string from JSON Schema shapes:

| JSON Schema shape | Output |
|-------------------|--------|
| `{type:"object", additionalProperties:{type:"string"}}` | `map[string]string` |
| `{type:"array", items:{type:"string"}}` | `[]string` |
| `{type:"object"}` | `object` |
| `{type:"boolean"}` | `boolean` |
| Unknown shape | Compact JSON ≤ 40 chars |

`parseSimpleSchema("map[string]string")` then parses correctly to `{type:"map",key:"string",value:"string"}`, which `FieldTable.formatType()` renders as `map[string]string` and `ExampleYAML` renders as `labels: {}     # required - map[string]string`.

### Tests

4 new unit tests verifying that JSON Schema object/array/map fields never produce `[object Object]`. 1088 total passing.

### Verified on cluster

Navigated to `/rgds/typed-schema?tab=docs` — `labels` field now shows `map[string]string` in Type column and `labels: {}` in the example manifest.