### PR TITLE
fix(web): isItemReady treats stateless resources (ConfigMap etc.) as healthy by existence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,8 @@ All changes go through PRs. Direct push to `main` is blocked.
 | `049-designer-ux-refresh-button` | — | Refresh now button; Designer CEL/scope help text; optimizer docs URL fix | Merged (PR #280) |
 | `050-kro-v090-phase2` | #274 | kro v0.9.0 phase 2 — reconcile-paused banner, cluster-scoped namespace display, displayNamespace utility | Merged (PR #281) |
 | `fix/errortab-dedup-chip` | — | ErrorsTab unique-instance dedup in summary; OptimizationAdvisor emoji removed | Merged (PR #282) |
-| `fix/schema-object-type` | — | DocsTab: JSON Schema object fields render as map/array type, not [object Object] | In progress |
+| `fix/schema-object-type` | — | DocsTab: JSON Schema object fields render as map/array type, not [object Object] | Merged (PR #283) |
+| `fix/collection-item-ready` | — | isItemReady: stateless resources (ConfigMap etc.) are healthy by existence | In progress |
 
 ### Worktrunk (required workflow)
 

--- a/web/src/components/CollectionPanel.test.tsx
+++ b/web/src/components/CollectionPanel.test.tsx
@@ -130,10 +130,14 @@ describe('isItemReady', () => {
     expect(isItemReady(item)).toBe(false)
   })
 
-  it('returns false for missing status', () => {
+  it('returns true for missing status (stateless resources like ConfigMap are healthy by existence)', () => {
+    // Previous behavior: missing status → false.
+    // New behavior: resources with no status don't emit health conditions
+    // (ConfigMap, Secret, ServiceAccount etc.) — their existence is success.
+    // See collection.ts step 5.
     const item = makeItem(0, 1, 'pods')
     ;(item as Record<string, unknown>).status = undefined
-    expect(isItemReady(item)).toBe(false)
+    expect(isItemReady(item)).toBe(true)
   })
 })
 

--- a/web/src/lib/collection.test.ts
+++ b/web/src/lib/collection.test.ts
@@ -1,0 +1,145 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// collection.test.ts — unit tests for isItemReady.
+//
+// Critical correctness tests: ConfigMap/Secret have no status → should be
+// healthy (step 5). Failed phase, Ready=False → unhealthy. Actively healthy
+// states → healthy.
+
+import { describe, it, expect } from 'vitest'
+import { isItemReady } from './collection'
+import type { K8sObject } from './api'
+
+function makeItem(status: unknown): K8sObject {
+  return { metadata: { name: 'item', namespace: 'ns' }, status }
+}
+
+describe('isItemReady', () => {
+  // ── Step 5: stateless resources with no/empty status → healthy ────────────
+
+  it('returns true for ConfigMap with no status (no conditions, no phase)', () => {
+    expect(isItemReady(makeItem(undefined))).toBe(true)
+  })
+
+  it('returns true for item with null status', () => {
+    expect(isItemReady(makeItem(null))).toBe(true)
+  })
+
+  it('returns true for item with empty status object {}', () => {
+    expect(isItemReady(makeItem({}))).toBe(true)
+  })
+
+  it('returns true for item with status but no recognized health fields', () => {
+    expect(isItemReady(makeItem({ someField: 'value' }))).toBe(true)
+  })
+
+  // ── Step 1: actively failed phase → unhealthy ─────────────────────────────
+
+  it('returns false for Pod with phase=Failed', () => {
+    expect(isItemReady(makeItem({ phase: 'Failed' }))).toBe(false)
+  })
+
+  it('returns false for phase=Error', () => {
+    expect(isItemReady(makeItem({ phase: 'Error' }))).toBe(false)
+  })
+
+  it('returns false for phase=CrashLoopBackOff', () => {
+    expect(isItemReady(makeItem({ phase: 'CrashLoopBackOff' }))).toBe(false)
+  })
+
+  it('returns false for phase=Terminating', () => {
+    expect(isItemReady(makeItem({ phase: 'Terminating' }))).toBe(false)
+  })
+
+  it('returns false for phase=Pending (not yet scheduled/running)', () => {
+    expect(isItemReady(makeItem({ phase: 'Pending' }))).toBe(false)
+  })
+
+  // ── Step 2: successful phase → healthy ────────────────────────────────────
+
+  it('returns true for Pod with phase=Running', () => {
+    expect(isItemReady(makeItem({ phase: 'Running' }))).toBe(true)
+  })
+
+  it('returns true for phase=Active', () => {
+    expect(isItemReady(makeItem({ phase: 'Active' }))).toBe(true)
+  })
+
+  it('returns true for phase=Succeeded', () => {
+    expect(isItemReady(makeItem({ phase: 'Succeeded' }))).toBe(true)
+  })
+
+  it('returns true for PVC with phase=Bound', () => {
+    expect(isItemReady(makeItem({ phase: 'Bound' }))).toBe(true)
+  })
+
+  // ── Step 3: Ready=False or Available=False → unhealthy ───────────────────
+
+  it('returns false when Ready=False', () => {
+    expect(isItemReady(makeItem({
+      conditions: [{ type: 'Ready', status: 'False' }],
+    }))).toBe(false)
+  })
+
+  it('returns false when Available=False', () => {
+    expect(isItemReady(makeItem({
+      conditions: [{ type: 'Available', status: 'False' }],
+    }))).toBe(false)
+  })
+
+  // ── Step 4: Ready=True or Available=True → healthy ───────────────────────
+
+  it('returns true when Ready=True', () => {
+    expect(isItemReady(makeItem({
+      conditions: [{ type: 'Ready', status: 'True' }],
+    }))).toBe(true)
+  })
+
+  it('returns true when Available=True', () => {
+    expect(isItemReady(makeItem({
+      conditions: [{ type: 'Available', status: 'True' }],
+    }))).toBe(true)
+  })
+
+  // ── Step 5: conditions present but none are Ready/Available → healthy ─────
+
+  it('returns true for item with only non-Ready conditions (ConfigMap edge case)', () => {
+    // ConfigMap might have some vendor-added conditions that aren't Ready/Available
+    expect(isItemReady(makeItem({
+      conditions: [{ type: 'CustomCondition', status: 'True' }],
+    }))).toBe(true)
+  })
+
+  // ── False wins over True when both present ────────────────────────────────
+
+  it('returns false when Ready=False even if other condition is True', () => {
+    expect(isItemReady(makeItem({
+      conditions: [
+        { type: 'Progressing', status: 'True' },
+        { type: 'Ready', status: 'False' },
+      ],
+    }))).toBe(false)
+  })
+
+  // ── Real-world: 9 ConfigMaps in a cartesian forEach should all be healthy ──
+
+  it('9 ConfigMaps with no status all return true (cartesian forEach)', () => {
+    const items = Array.from({ length: 9 }, () =>
+      makeItem(null) as K8sObject & { metadata: { name: string } }
+    )
+    const healthyCount = items.filter(isItemReady).length
+    expect(healthyCount).toBe(9)
+  })
+})

--- a/web/src/lib/collection.ts
+++ b/web/src/lib/collection.ts
@@ -11,42 +11,69 @@ import type { K8sObject } from './api'
 /**
  * Determine whether a collection item resource is "ready".
  *
- * Priority:
- *   1. status.phase — Running, Active, or Succeeded → true
- *   2. status.conditions — Ready=True or Available=True → true
- *   3. All other cases → false
+ * Algorithm (order matters):
+ *
+ *   1. Actively failed phase → false
+ *      status.phase ∈ {Failed, Error, CrashLoopBackOff, Unknown, Terminating}
+ *
+ *   2. Successfully ready phase → true
+ *      status.phase ∈ {Running, Active, Succeeded, Bound, Complete, Available}
+ *
+ *   3. Active failure condition → false
+ *      status.conditions has Ready=False or Available=False
+ *
+ *   4. Active success condition → true
+ *      status.conditions has Ready=True or Available=True
+ *
+ *   5. No status, empty status, or status with no health indicators → true
+ *      Resources like ConfigMap, Secret, and ServiceAccount do not emit
+ *      status.conditions or status.phase. Their existence means success.
+ *      Returning false would produce misleading "0/N healthy" badges for
+ *      entirely functional collections of stateless resources.
  *
  * Pure function — no side effects.
  */
 export function isItemReady(item: K8sObject): boolean {
   const status = item.status
-  if (typeof status !== 'object' || status === null) return false
+
+  // Step 5 fast-path: no status at all → resource type doesn't report health → healthy
+  if (typeof status !== 'object' || status === null) return true
 
   const s = status as Record<string, unknown>
-
-  // Phase check
   const phase = s.phase
-  if (typeof phase === 'string') {
-    if (phase === 'Running' || phase === 'Active' || phase === 'Succeeded') return true
-    // Known non-ready phases — fall through to conditions check
-  }
-
-  // Conditions check
   const conditions = s.conditions
-  if (Array.isArray(conditions)) {
+
+  // Step 1: actively failed or not-yet-ready phase
+  // Pending means the resource hasn't been scheduled/created yet — not healthy.
+  const failedPhases = new Set(['Failed', 'Error', 'CrashLoopBackOff', 'Unknown', 'Terminating', 'Pending'])
+  if (typeof phase === 'string' && failedPhases.has(phase)) return false
+
+  // Step 2: successfully ready phase
+  const readyPhases = new Set(['Running', 'Active', 'Succeeded', 'Bound', 'Complete', 'Available'])
+  if (typeof phase === 'string' && readyPhases.has(phase)) return true
+
+  // Steps 3+4: inspect conditions
+  if (Array.isArray(conditions) && conditions.length > 0) {
+    let hasHealthIndicator = false
     for (const c of conditions) {
       if (typeof c !== 'object' || c === null) continue
       const cond = c as Record<string, unknown>
-      if (
-        typeof cond.type === 'string' &&
-        typeof cond.status === 'string' &&
-        (cond.type === 'Ready' || cond.type === 'Available') &&
-        cond.status === 'True'
-      ) {
-        return true
+      if (typeof cond.type !== 'string' || typeof cond.status !== 'string') continue
+
+      const t = cond.type
+      const st = cond.status
+      if (t === 'Ready' || t === 'Available') {
+        hasHealthIndicator = true
+        if (st === 'False') return false   // Step 3: active failure
+        if (st === 'True') return true     // Step 4: active success
       }
     }
+
+    // Has conditions but none are Ready/Available — no health signal → healthy
+    if (!hasHealthIndicator) return true
   }
 
-  return false
+  // Step 5: empty status or status with no recognized health fields → healthy
+  // (Covers ConfigMap, Secret, ServiceAccount, and other stateless resource types)
+  return true
 }


### PR DESCRIPTION
## Summary

`isItemReady()` previously returned `false` for any collection item with no `status`, empty status, or status without recognized health conditions. This caused the `CollectionBadge` to show `0/9` for a cartesian forEach with 9 ConfigMaps — all successfully created and functional.

### Root cause

```ts
// Old: missing status → false
if (typeof status !== 'object' || status === null) return false
```

ConfigMaps, Secrets, and ServiceAccounts don't emit `status.conditions` or `status.phase` — their existence IS the success signal. The old code penalized them by returning `false`.

### Fix

Invert the default: `isItemReady` now returns `true` when no recognized health indicators are present. Only actively negative signals produce `false`:

- `phase ∈ {Failed, Error, CrashLoopBackOff, Unknown, Terminating, Pending}`
- `conditions: Ready=False` or `Available=False`

Resources with null/undefined status, `{}`, or status with unrecognized fields → `true`.

**Before**: `upstream-cartesian-foreach` with 9 ConfigMaps → badge shows `0/9`
**After**: same instance → badge shows `9/9`

### Tests

20 new unit tests in new `collection.test.ts`. CollectionPanel.test.tsx updated to reflect the corrected semantics (with explanation comment). 1108 total passing.

### Verified on cluster

Clicked the `appConfigs` node in `cartesian-platform-full` instance → CollectionBadge shows `9/9`.