### PR TITLE
fix(web): external ref DAG nodes show alive/reconciling instead of not-found

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,8 @@ All changes go through PRs. Direct push to `main` is blocked.
 | `050-kro-v090-phase2` | #274 | kro v0.9.0 phase 2 — reconcile-paused banner, cluster-scoped namespace display, displayNamespace utility | Merged (PR #281) |
 | `fix/errortab-dedup-chip` | — | ErrorsTab unique-instance dedup in summary; OptimizationAdvisor emoji removed | Merged (PR #282) |
 | `fix/schema-object-type` | — | DocsTab: JSON Schema object fields render as map/array type, not [object Object] | Merged (PR #283) |
-| `fix/collection-item-ready` | — | isItemReady: stateless resources (ConfigMap etc.) are healthy by existence | In progress |
+| `fix/collection-item-ready` | — | isItemReady: stateless resources (ConfigMap etc.) are healthy by existence | Merged (PR #284) |
+| `fix/extref-live-state` | — | External ref DAG nodes show alive/reconciling instead of not-found when CR is healthy | In progress |
 
 ### Worktrunk (required workflow)
 

--- a/web/src/lib/instanceNodeState.test.ts
+++ b/web/src/lib/instanceNodeState.test.ts
@@ -375,4 +375,58 @@ describe('buildNodeStateMap', () => {
       expect(map['state-node']).toBeUndefined()
     })
   })
+
+  // ── T020: External ref nodes use globalState, not 'not-found' ────────────
+  // External refs are pre-existing resources that kro watches but does not
+  // create. They never receive kro.run/node-id labels, so they will always be
+  // absent from the stateMap after step 2. Instead of showing 'not-found' (grey),
+  // external nodes should reflect the CR-level globalState.
+
+  describe('T020 — external ref node state inferred from globalState', () => {
+    const externalNode = makeNode('inputConfig', 'ConfigMap', 'external')
+    const externalCollectionNode = makeNode('teamConfigs', 'ConfigMap', 'externalCollection')
+    const managedNode = makeNode('appOutput', 'ConfigMap', 'resource')
+
+    it('T020-01: external node shows alive when CR is Ready=True (globalState=alive)', () => {
+      const instance = makeInstance([{ type: 'Ready', status: 'True' }])
+      const children = [makeChild('ConfigMap', 'output', 'appOutput')]
+
+      const map = buildNodeStateMap(instance, children, [externalNode, managedNode])
+
+      expect(map['inputConfig']?.state).toBe('alive')
+      expect(map['appOutput']?.state).toBe('alive')
+    })
+
+    it('T020-02: external node shows reconciling when globalState=reconciling', () => {
+      const instance = makeInstance([{ type: 'Progressing', status: 'True' }])
+
+      const map = buildNodeStateMap(instance, [], [externalNode])
+
+      expect(map['inputConfig']?.state).toBe('reconciling')
+    })
+
+    it('T020-03: external node shows not-found when globalState=error (CR failed)', () => {
+      const instance = makeInstance([{ type: 'Ready', status: 'False' }])
+
+      const map = buildNodeStateMap(instance, [], [externalNode])
+
+      expect(map['inputConfig']?.state).toBe('not-found')
+    })
+
+    it('T020-04: externalCollection node follows same rule as external', () => {
+      const instance = makeInstance([{ type: 'Ready', status: 'True' }])
+
+      const map = buildNodeStateMap(instance, [], [externalCollectionNode])
+
+      expect(map['teamConfigs']?.state).toBe('alive')
+    })
+
+    it('T020-05: normal resource node still gets not-found when absent', () => {
+      const instance = makeInstance([{ type: 'Ready', status: 'True' }])
+
+      const map = buildNodeStateMap(instance, [], [managedNode])
+
+      expect(map['appOutput']?.state).toBe('not-found')
+    })
+  })
 })

--- a/web/src/lib/instanceNodeState.ts
+++ b/web/src/lib/instanceNodeState.ts
@@ -236,15 +236,39 @@ export function buildNodeStateMap(
   // ── Step 3: enumerate every non-state, non-instance RGD node ─────────────
   // Absent nodes receive 'pending' when the node has includeWhen expressions
   // (meaning it is actively excluded by a condition), or 'not-found' otherwise.
+  //
+  // Special case — NodeTypeExternal and NodeTypeExternalCollection:
+  // External ref resources are pre-existing and never created (or labelled)
+  // by kro. GetInstanceChildren only returns kro-labelled resources, so
+  // external nodes will always be absent from the stateMap after step 2.
+  // Showing 'not-found' (grey) for them is misleading when the CR is
+  // Ready=True — if the instance is healthy, the external ref was successfully
+  // accessed. Map external nodes to globalState instead so they reflect the
+  // actual CR health:
+  //   globalState=alive       → 'alive'  (green  — ref was accessed, instance ready)
+  //   globalState=reconciling → 'reconciling'  (amber — kro is resolving the ref)
+  //   globalState=error       → 'not-found'    (grey  — unknown if ref is reachable)
   for (const node of rgdNodes) {
     if (node.nodeType === 'instance' || node.nodeType === 'state') continue
     const nodeId = node.id  // use the RGD resource id, matching kro.run/node-id
     if (!nodeId) continue
     if (nodeId in result) continue // already set by an observed child
 
-    const hasIncludeWhen = node.includeWhen.some((e) => e.trim() !== '')
+    const isExternalNode =
+      node.nodeType === 'external' || node.nodeType === 'externalCollection'
+
+    let nodeState: NodeLiveState
+    if (isExternalNode) {
+      // External refs are watched, not created — their health is inferred from
+      // the CR-level state rather than from a kro.run/node-id label on the resource.
+      nodeState = globalState === 'error' ? 'not-found' : globalState
+    } else {
+      const hasIncludeWhen = node.includeWhen.some((e) => e.trim() !== '')
+      nodeState = hasIncludeWhen ? 'pending' : 'not-found'
+    }
+
     result[nodeId] = {
-      state: hasIncludeWhen ? 'pending' : 'not-found',
+      state: nodeState,
       kind: node.kind || node.label || nodeId,
       name: '',
       namespace: '',


### PR DESCRIPTION
## Summary

External ref nodes (`NodeTypeExternal`, `NodeTypeExternalCollection`) were always showing grey `not-found` rings in the live DAG overlay, even when the instance was `ACTIVE / Ready=True`.

### Root cause

External refs are pre-existing Kubernetes resources that kro *watches* but does not create. They never receive `kro.run/node-id` labels, so `GetInstanceChildren` never returns them. After step 2 of `buildNodeStateMap`, they are absent from the stateMap. Step 3 then assigned `state = 'not-found'` (grey ring) — the same state as a managed resource that hasn't been created yet.

This was incorrect: `not-found` implies the resource is missing. An external ref showing grey when the CR is healthy implies something is wrong.

### Fix

In step 3 of `buildNodeStateMap`, detect `nodeType === 'external'` or `'externalCollection'` and infer state from `globalState`:

| globalState | External ref state | Meaning |
|-------------|-------------------|---------|
| `alive` | `alive` (green) | CR is Ready=True → external ref was successfully accessed |
| `reconciling` | `reconciling` (amber) | kro is actively resolving the external ref |
| `error` | `not-found` (grey) | CR failed → unknown if external ref is reachable |

Normal managed/collection nodes that are absent continue to show `not-found` (unchanged).

### Before / After

| | Before | After |
|---|---|---|
| `echo-prod` `inputConfig` (external ref) | grey "Not found" | green "Alive" |
| CHILDREN telemetry | `1/2` | `2/2` |

### Tests

5 new unit tests (T020-01 through T020-05) covering all globalState branches for both NodeTypeExternal and NodeTypeExternalCollection. 1113 total passing.