### PR TITLE
fix(web): ErrorsTab dedup for IN_PROGRESS; CollectionPanel forEach expr; stuck reconcile escalation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,7 @@ All changes go through PRs. Direct push to `main` is blocked.
 | `fix/schema-object-type` | — | DocsTab: JSON Schema object fields render as map/array type, not [object Object] | Merged (PR #283) |
 | `fix/collection-item-ready` | — | isItemReady: stateless resources (ConfigMap etc.) are healthy by existence | Merged (PR #284) |
 | `fix/extref-live-state` | — | External ref DAG nodes show alive/reconciling instead of not-found when CR is healthy | Merged (PR #285) |
+| `fix/ux-polish-round2` | — | ErrorsTab skips IN_PROGRESS instances; CollectionPanel empty state shows forEach expr; stuck reconciliation escalation banner | In progress |
 
 ### Worktrunk (required workflow)
 
@@ -392,7 +393,7 @@ Always read the spec before writing code. Always run `go vet ./...` and
 - Stress-test fixture RGDs on kind cluster: `never-ready`, `invalid-cel-rgd`, `typed-schema`, `optimization-candidate`, `triple-config`, `crashloop-app`, `multi-ns-app`
 
 ## Recent Changes
-- v0.4.7 (cutting): isItemReady stateless-resource fix — ConfigMap/Secret collections now show 9/9 not 0/9 (PR #284); external ref DAG nodes show alive/reconciling not not-found when CR is healthy (PR #285)
+- v0.4.7: isItemReady stateless-resource fix (PR #284); external ref DAG nodes show alive/reconciling not not-found (PR #285)
 - v0.4.6: kro v0.9.0 upgrade (PR #275); RGD Designer validation (PR #273); degraded health state + health bar + copy YAML (PR #277); state map node-id keying + IN_PROGRESS fix (PR #278); 26-gap UI polish (PR #279); refresh button + Designer CEL help (PR #280); reconcile-paused banner + cluster-scoped namespace (PR #281); ErrorsTab dedup + optimizer emoji (PR #282); DocsTab JSON Schema object types (PR #283)
 - v0.4.5: degraded health state (6th InstanceHealthState) + multi-segment HealthChip bar (✗/⚠/↻ counts) + copy instance YAML button; state map keyed by kro.run/node-id (fixes two-Deployment node collision, EndpointSlice pollution); IN_PROGRESS kro state → reconciling pill+banner; items:null→[] on zero children; GraphProgressing compat (kro v0.8.x)
 - v0.4.4: RGD Designer full kro feature coverage — all 5 node types, includeWhen, readyWhen CEL, schema field editor

--- a/web/src/components/CollectionPanel.css
+++ b/web/src/components/CollectionPanel.css
@@ -191,7 +191,19 @@
   text-align: center;
   font-size: 13px;
   color: var(--color-text-muted);
+}
+
+.collection-empty-state p {
+  margin: 0 0 6px;
   font-style: italic;
+}
+
+.collection-empty-state p:last-child {
+  margin-bottom: 0;
+}
+
+.collection-empty-state__expr {
+  font-style: normal;
 }
 
 /* ── Legacy fallback ──────────────────────────────────────────────────────── */

--- a/web/src/components/CollectionPanel.tsx
+++ b/web/src/components/CollectionPanel.tsx
@@ -390,8 +390,13 @@ export default function CollectionPanel({
             data-testid="collection-empty-state"
             className="collection-empty-state"
           >
-            Empty collection — the forEach expression evaluated to an empty list.
-            Verify that the spec field referenced in the forEach expression is non-empty for this instance.
+            <p>Empty collection — the <code>forEach</code> expression evaluated to an empty list.</p>
+            {forEachExpr && (
+              <p className="collection-empty-state__expr">
+                Expression: <code className="collection-panel-foreach-expr">{forEachExpr}</code>
+              </p>
+            )}
+            <p>Verify that the spec field this expression references is non-empty for this instance.</p>
           </div>
         ) : (
           <div className="collection-table-wrapper">

--- a/web/src/components/ErrorsTab.test.ts
+++ b/web/src/components/ErrorsTab.test.ts
@@ -155,3 +155,82 @@ describe('groupErrorPatterns', () => {
     expect(groups[1].count).toBe(1)
   })
 })
+
+// ── IN_PROGRESS skip ────────────────────────────────────────────────────────
+
+describe('groupErrorPatterns — IN_PROGRESS instances are not aggregated', () => {
+  function makeInProgressInstance(name: string): K8sObject {
+    return {
+      metadata: { name, namespace: 'default' },
+      status: {
+        state: 'IN_PROGRESS',
+        conditions: [
+          { type: 'InstanceManaged', status: 'True', reason: 'Managed' },
+          { type: 'GraphResolved',   status: 'True', reason: 'Resolved' },
+          { type: 'ResourcesReady',  status: 'False', reason: 'NotReady', message: 'awaiting resource readiness' },
+          { type: 'Ready',           status: 'False', reason: 'NotReady', message: 'awaiting resource readiness' },
+        ],
+      },
+    }
+  }
+
+  function makeProgressingInstance(name: string): K8sObject {
+    return {
+      metadata: { name, namespace: 'default' },
+      status: {
+        conditions: [
+          { type: 'Progressing', status: 'True', reason: 'NewReplicaSet' },
+          { type: 'Ready',       status: 'False', reason: 'Progressing' },
+        ],
+      },
+    }
+  }
+
+  it('skips instances with status.state=IN_PROGRESS (never-ready pattern)', () => {
+    const instances = [
+      makeInProgressInstance('never-ready-prod'),
+      makeInProgressInstance('never-ready-staging'),
+      makeInProgressInstance('never-ready-dev'),
+    ]
+    const groups = groupErrorPatterns(instances)
+    expect(groups).toHaveLength(0)
+  })
+
+  it('skips instances with Progressing=True condition', () => {
+    const instances = [makeProgressingInstance('rolling-update')]
+    const groups = groupErrorPatterns(instances)
+    expect(groups).toHaveLength(0)
+  })
+
+  it('includes genuinely errored instances (no IN_PROGRESS state, no Progressing)', () => {
+    const instances = [
+      makeInProgressInstance('reconciling-1'),  // skipped
+      {
+        metadata: { name: 'broken', namespace: 'default' },
+        status: {
+          state: 'FAILED',
+          conditions: [
+            { type: 'Ready', status: 'False', reason: 'CrashLoopBackOff' },
+          ],
+        },
+      } as K8sObject,
+    ]
+    const groups = groupErrorPatterns(instances)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].instances[0].name).toBe('broken')
+  })
+
+  it('skips GraphProgressing=True instances (kro v0.8.x compat)', () => {
+    const instances = [{
+      metadata: { name: 'old-kro', namespace: 'default' },
+      status: {
+        conditions: [
+          { type: 'GraphProgressing', status: 'True', reason: 'Reconciling' },
+          { type: 'Ready',            status: 'False', reason: 'Reconciling' },
+        ],
+      },
+    } as K8sObject]
+    const groups = groupErrorPatterns(instances)
+    expect(groups).toHaveLength(0)
+  })
+})

--- a/web/src/components/ErrorsTab.tsx
+++ b/web/src/components/ErrorsTab.tsx
@@ -69,6 +69,23 @@ export function groupErrorPatterns(instances: K8sObject[]): ErrorGroup[] {
     if (!name || !namespace) continue
 
     const status = instance.status as Record<string, unknown> | undefined
+
+    // Skip instances that are actively reconciling (IN_PROGRESS kro state or
+    // Progressing=True condition). Their Ready=False is an expected transient
+    // state — not an actionable error pattern. Showing them in the Errors tab
+    // produces false positives (e.g. never-ready shows "2 error patterns"
+    // while the instance list correctly shows "Reconciling").
+    if (status?.state === 'IN_PROGRESS') continue
+    const rawConds = status?.conditions
+    if (Array.isArray(rawConds)) {
+      const isProgressing = (rawConds as Array<Record<string, unknown>>).some(
+        (c) =>
+          (c.type === 'Progressing' || c.type === 'GraphProgressing') &&
+          c.status === 'True',
+      )
+      if (isProgressing) continue
+    }
+
     const rawConditions = status?.conditions
     if (!Array.isArray(rawConditions)) continue
 

--- a/web/src/pages/InstanceDetail.css
+++ b/web/src/pages/InstanceDetail.css
@@ -168,6 +168,17 @@
   color: var(--color-reconciling);
 }
 
+/* Escalated variant — shown when reconciling for > 5 minutes */
+.reconciling-banner--stuck {
+  background: var(--node-error-bg);
+  border-color: var(--node-error-border);
+  color: var(--color-error);
+}
+
+.reconciling-banner--stuck .reconciling-banner-pulse {
+  animation-duration: 0.8s;
+}
+
 .reconciling-banner-pulse {
   animation: reconciling-pulse 1.5s ease-in-out infinite;
   font-size: 10px;

--- a/web/src/pages/InstanceDetail.tsx
+++ b/web/src/pages/InstanceDetail.tsx
@@ -110,6 +110,29 @@ function isReconcilePaused(instance: K8sObject | null): boolean {
   return (annotations as Record<string, unknown>)['kro.run/reconcile'] === 'disabled'
 }
 
+// ── Reconciling duration ──────────────────────────────────────────────────
+// Returns the number of minutes the instance has been in a non-Ready state,
+// derived from the earliest failing condition's lastTransitionTime.
+// Returns null when the transition time is unavailable.
+
+function reconcilingSinceMinutes(instance: K8sObject | null): number | null {
+  if (!instance) return null
+  const status = instance.status as Record<string, unknown> | undefined
+  if (!status) return null
+  const conditions = status.conditions
+  if (!Array.isArray(conditions)) return null
+  let oldest: number | null = null
+  for (const c of conditions as Array<Record<string, unknown>>) {
+    if (c.status !== 'False' && c.status !== 'Unknown') continue
+    const t = c.lastTransitionTime
+    if (typeof t !== 'string') continue
+    const ms = Date.parse(t)
+    if (!isNaN(ms) && (oldest === null || ms < oldest)) oldest = ms
+  }
+  if (oldest === null) return null
+  return Math.floor((Date.now() - oldest) / 60_000)
+}
+
 // ── Reconciling banner ─────────────────────────────────────────────────────
 
 function isReconciling(instance: K8sObject | null): boolean {
@@ -391,17 +414,24 @@ export default function InstanceDetail() {
       )}
 
       {/* Reconciling banner (FR-003) — only when NOT terminating */}
-      {fastData && !isTerminating(fastData.instance) && isReconciling(fastData.instance) && (
-        <div
-          className="reconciling-banner"
-          role="status"
-          aria-live="polite"
-          title="kro is actively applying changes to this instance's managed resources. This is normal during creation and after spec changes. If this persists, check the Conditions panel for details."
-        >
-          <span className="reconciling-banner-pulse" aria-hidden="true">●</span>
-          kro is reconciling this instance
-        </div>
-      )}
+      {fastData && !isTerminating(fastData.instance) && isReconciling(fastData.instance) && (() => {
+        const mins = reconcilingSinceMinutes(fastData.instance)
+        const isStuck = mins !== null && mins >= 5
+        return (
+          <div
+            className={`reconciling-banner${isStuck ? ' reconciling-banner--stuck' : ''}`}
+            role="status"
+            aria-live="polite"
+            title="kro is actively applying changes to this instance's managed resources. This is normal during creation and after spec changes. If this persists, check the Conditions panel for details."
+          >
+            <span className="reconciling-banner-pulse" aria-hidden="true">●</span>
+            {isStuck
+              ? <>kro has been reconciling this instance for {mins}m — check the Conditions panel and <code>kubectl describe</code> the child resources for errors.</>
+              : 'kro is reconciling this instance'
+            }
+          </div>
+        )
+      })()}
 
       {/* Instance deleted banner */}
       {instanceGoneRef.current && (


### PR DESCRIPTION
## Summary

Three UX improvements found during PDCA audit — all discovered by navigating the app with real cluster fixtures and cross-checking expectations against what I knew the fixtures would produce.

### Fix 1 — ErrorsTab: skip reconciling instances (false positives)

**Problem**: The `never-ready` RGD has 3 instances stuck with `status.state=IN_PROGRESS` (readyWhen never satisfied). The instance list correctly shows them as "Reconciling". But the Errors tab showed "2 error patterns across 3 instances" because `groupErrorPatterns` was aggregating their `Ready=False` and `ResourcesReady=False` conditions — even though these are expected transient states, not actionable errors.

**Fix**: `groupErrorPatterns` now skips instances where `status.state === 'IN_PROGRESS'` or where `Progressing=True` / `GraphProgressing=True` is present. These instances are actively reconciling; their failing conditions are expected.

**Result**: `never-ready` Errors tab now shows "✓ All instances are healthy".

4 new unit tests.

### Fix 2 — CollectionPanel: empty forEach state shows the actual expression

**Problem**: When a forEach collection has 0 items (e.g. `chain-empty` with `values: []`), the empty state said "Verify that the spec field referenced in the forEach expression is non-empty" — but didn't show *which* expression. Users had to scroll up to find the forEach expression to know what to check.

**Fix**: The empty state now includes the actual forEach expression:
```
Expression: val: ${has(baseConfig.data.enabled) ? schema.spec.values : []}
```

Implements F-10 from issue #276.

### Fix 3 — Reconciling banner: escalation after 5 minutes

**Problem**: The amber "kro is reconciling" banner shows for both freshly-reconciling instances (normal) and instances stuck for hours (problem). No differentiation — both look identical.

**Fix**: When the earliest failing condition's `lastTransitionTime` is ≥ 5 minutes ago, the banner turns red with an escalated message:
> "● kro has been reconciling this instance for 678m — check the Conditions panel and `kubectl describe` the child resources for errors."

- Normal reconciliation (< 5m): amber banner, standard text
- Stuck reconciliation (≥ 5m): red banner with duration and actionable hint

## Tests
1117 tests passing. TypeScript strict: 0 errors.

## Verified on cluster
- `never-ready` Errors tab: "✓ All instances are healthy" ✓
- `chain-empty` CollectionPanel: forEach expression shown in empty state ✓  
- `never-ready-prod` banner: red "678m" escalation with `--stuck` class ✓