### PR TITLE
feat(web): stuck finalizer escalation — kubectl patch command when deletion blocked > 5 minutes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,8 @@ All changes go through PRs. Direct push to `main` is blocked.
 | `fix/schema-object-type` | — | DocsTab: JSON Schema object fields render as map/array type, not [object Object] | Merged (PR #283) |
 | `fix/collection-item-ready` | — | isItemReady: stateless resources (ConfigMap etc.) are healthy by existence | Merged (PR #284) |
 | `fix/extref-live-state` | — | External ref DAG nodes show alive/reconciling instead of not-found when CR is healthy | Merged (PR #285) |
-| `fix/ux-polish-round2` | — | ErrorsTab skips IN_PROGRESS instances; CollectionPanel empty state shows forEach expr; stuck reconciliation escalation banner | In progress |
+| `fix/ux-polish-round2` | — | ErrorsTab skips IN_PROGRESS instances; CollectionPanel empty state shows forEach expr; stuck reconciliation escalation banner | Merged (PR #286) |
+| `fix/finalizer-escalation` | #289 | Terminating banner shows kubectl patch command when finalizers block deletion > 5 minutes | In progress |
 
 ### Worktrunk (required workflow)
 

--- a/web/src/components/TerminatingBanner.css
+++ b/web/src/components/TerminatingBanner.css
@@ -1,11 +1,12 @@
 /* TerminatingBanner.css — styles for the Terminating state banner.
  * All colour values use named tokens from tokens.css (no raw hex or rgba).
  * Spec: .specify/specs/031-deletion-debugger/ FR-001
+ * GH #289: stuck finalizer escalation styles
  */
 
 .terminating-banner {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 8px;
   padding: 8px 16px;
   background: var(--node-error-bg);
@@ -19,10 +20,44 @@
   font-size: 14px;
   font-weight: 700;
   flex-shrink: 0;
-  line-height: 1;
+  line-height: 1.5;
 }
 
 .terminating-banner-text {
   flex: 1;
   min-width: 0;
+  line-height: 1.6;
+}
+
+/* Escalation section shown when finalizers block deletion > 5 minutes */
+.terminating-banner-escalation {
+  display: block;
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--color-error);
+  opacity: 0.9;
+}
+
+.terminating-banner-finalizers {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  background: var(--color-surface-2);
+  border-radius: var(--radius-sm);
+  padding: 0 4px;
+}
+
+/* The kubectl patch command — monospace, user-selectable */
+.terminating-banner-cmd {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 2px 6px;
+  color: var(--color-text);
+  margin-top: 2px;
+  user-select: all;
+  cursor: text;
+  word-break: break-all;
 }

--- a/web/src/components/TerminatingBanner.tsx
+++ b/web/src/components/TerminatingBanner.tsx
@@ -1,12 +1,11 @@
 // TerminatingBanner.tsx — Rose banner shown when a kro instance is Terminating.
 //
-// Displays "⊗ Terminating since {relative time}" with the full ISO timestamp
-// accessible via the title attribute on hover.
-//
-// The `tick` prop is used as a useMemo dependency so the relative time label
-// updates each poll cycle (every 5s) without any separate setInterval.
+// Shows "⊗ Terminating since {relative time}" plus, when finalizers are
+// present for > 5 minutes, an escalation section with a ready-to-copy
+// kubectl patch command for force-removal.
 //
 // Spec: .specify/specs/031-deletion-debugger/ FR-001
+// GH #289: stuck finalizer escalation (kubectl patch command)
 
 import { useMemo } from 'react'
 import { formatRelativeTime } from '@/lib/k8s'
@@ -18,28 +17,64 @@ interface TerminatingBannerProps {
   /**
    * Poll tick counter from usePolling — used as a useMemo dependency so the
    * relative time label updates with each data refresh cycle.
-   * Do NOT introduce a setInterval — use the polling tick instead.
    */
   tick: number
+  /** Kubernetes Kind of the instance (e.g. "AutoscaledApp"). Used for kubectl command. */
+  instanceKind?: string
+  /** Name of the instance. Used for kubectl command. */
+  instanceName?: string
+  /** Namespace of the instance. Empty string for cluster-scoped. */
+  instanceNamespace?: string
+  /** Current finalizer list. When non-empty and stuck > 5m, shows escalation. */
+  finalizers?: string[]
+}
+
+/** Minutes elapsed since a given ISO timestamp. Returns null if unparseable. */
+function minutesSince(iso: string): number | null {
+  const ms = Date.parse(iso)
+  if (isNaN(ms)) return null
+  return Math.floor((Date.now() - ms) / 60_000)
 }
 
 /**
  * TerminatingBanner — displays a prominent rose banner while an instance
  * is in Terminating state (deletionTimestamp set, not yet gone).
  *
- * Takes precedence over the Reconciling banner (caller is responsible for
- * ensuring mutual exclusivity — render this instead of reconciling banner
- * when isTerminating() is true).
+ * When finalizers are present and the instance has been terminating for
+ * >= 5 minutes, shows an escalation section with the exact kubectl command
+ * to force-remove all finalizers. (GH #289)
  */
-export default function TerminatingBanner({ deletionTimestamp, tick }: TerminatingBannerProps) {
-  // Recompute relative time on every poll tick.
-  // tick is declared in deps to silence the exhaustive-deps lint rule —
-  // its value changing is exactly the signal we want to re-compute.
+export default function TerminatingBanner({
+  deletionTimestamp,
+  tick,
+  instanceKind,
+  instanceName,
+  instanceNamespace,
+  finalizers = [],
+}: TerminatingBannerProps) {
   const relativeTime = useMemo(
     () => formatRelativeTime(deletionTimestamp),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [deletionTimestamp, tick],
   )
+
+  const mins = useMemo(
+    () => minutesSince(deletionTimestamp),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [deletionTimestamp, tick],
+  )
+
+  const isStuck = finalizers.length > 0 && mins !== null && mins >= 5
+
+  // Build the kubectl patch command to force-remove all finalizers
+  const kubectlCmd = useMemo(() => {
+    if (!isStuck || !instanceKind || !instanceName) return null
+    const nsFlag = instanceNamespace
+      ? ` -n ${instanceNamespace}`
+      : ''
+    const resourceType = instanceKind.toLowerCase()
+    return `kubectl patch ${resourceType} ${instanceName}${nsFlag} --type=json -p='[{"op":"remove","path":"/metadata/finalizers"}]'`
+  }, [isStuck, instanceKind, instanceName, instanceNamespace])
 
   return (
     <div
@@ -51,6 +86,21 @@ export default function TerminatingBanner({ deletionTimestamp, tick }: Terminati
       <span className="terminating-banner-icon" aria-hidden="true">⊗</span>
       <span className="terminating-banner-text">
         Terminating since {relativeTime}
+        {isStuck && (
+          <span className="terminating-banner-escalation">
+            {' '}— blocked by {finalizers.length === 1 ? 'finalizer' : `${finalizers.length} finalizers`}{' '}
+            <code className="terminating-banner-finalizers">
+              {finalizers.join(', ')}
+            </code>
+            {' '}for {mins}m.
+            {kubectlCmd && (
+              <>
+                {' '}To force remove:{' '}
+                <code className="terminating-banner-cmd">{kubectlCmd}</code>
+              </>
+            )}
+          </span>
+        )}
       </span>
     </div>
   )

--- a/web/src/pages/InstanceDetail.tsx
+++ b/web/src/pages/InstanceDetail.tsx
@@ -395,6 +395,10 @@ export default function InstanceDetail() {
         <TerminatingBanner
           deletionTimestamp={getDeletionTimestamp(fastData.instance) ?? ''}
           tick={pollTick}
+          instanceKind={typeof fastData.instance.kind === 'string' ? fastData.instance.kind : undefined}
+          instanceName={instanceName}
+          instanceNamespace={namespace === '_' ? '' : namespace}
+          finalizers={getFinalizers(fastData.instance)}
         />
       )}
 


### PR DESCRIPTION
## Summary

Implements GH #289. When a kro instance has been in Terminating state for ≥ 5 minutes and still has finalizers, the `TerminatingBanner` now shows an escalation section with the exact `kubectl patch` command to force-remove them.

### Before

```
⊗ Terminating since 8m ago
```

### After (when stuck ≥ 5 minutes with a finalizer)

```
⊗ Terminating since 8m ago — blocked by finalizer kro.run/delete-protection for 8m.
  To force remove: kubectl patch myapp my-instance -n kro-ui-demo --type=json
    -p='[{"op":"remove","path":"/metadata/finalizers"}]'
```

- The command `<code>` element has `user-select: all` — triple-click to select the whole command
- Kind, name, and namespace are substituted from the live instance data  
- `-n` flag is omitted for cluster-scoped instances (empty/`_` namespace)
- Only shown when: finalizers present AND elapsed time ≥ 5 minutes
- All new props on `TerminatingBanner` are optional — banner renders exactly as before when props are absent

### Implementation

- `TerminatingBanner.tsx`: new optional props (`instanceKind`, `instanceName`, `instanceNamespace`, `finalizers`). Adds `minutesSince()` helper and `kubectlCmd` memo.
- `TerminatingBanner.css`: new `.terminating-banner-escalation`, `.terminating-banner-finalizers`, `.terminating-banner-cmd` classes
- `InstanceDetail.tsx`: passes all new props from `fastData.instance`

### Tests

1117 tests passing. TypeScript strict: 0 errors.