### PR TITLE
fix(web): GenerateTab: map/object fields use {} not ""; yaml.ts {} and [] unquoted

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,8 @@ All changes go through PRs. Direct push to `main` is blocked.
 | `fix/extref-live-state` | — | External ref DAG nodes show alive/reconciling instead of not-found when CR is healthy | Merged (PR #285) |
 | `fix/ux-polish-round2` | — | ErrorsTab skips IN_PROGRESS instances; CollectionPanel empty state shows forEach expr; stuck reconciliation escalation banner | Merged (PR #286) |
 | `fix/finalizer-escalation` | #289 | Terminating banner shows kubectl patch command when finalizers block deletion > 5 minutes | Merged (PR #290) |
-| `fix/yaml-clean-display` | — | YAML tab: strip managedFields, last-applied-configuration, resourceVersion, uid from displayed YAML | In progress |
+| `fix/yaml-clean-display` | — | YAML tab: strip managedFields, last-applied-configuration, resourceVersion, uid from displayed YAML | Merged (PR #291) |
+| `fix/schema-object-type-generate` | — | GenerateTab: map/object fields initialize with {} not "" | In progress |
 
 ### Worktrunk (required workflow)
 

--- a/web/src/components/GenerateTab.tsx
+++ b/web/src/components/GenerateTab.tsx
@@ -41,10 +41,19 @@ function buildInitialFormState(
     const pt = field.parsedType
     const isArray = pt?.type === 'array'
     // Use key-existence check for default detection (issue #61 guard)
-    const defaultVal = ('default' in (pt ?? {})) ? (pt!.default ?? '') : ''
+    const hasDefault = 'default' in (pt ?? {})
+    const defaultVal = hasDefault ? (pt!.default ?? '') : ''
+
+    // For map/object types with no explicit default, use '{}' as the
+    // placeholder — an empty string would produce `labels: ""` in the manifest
+    // which is invalid YAML for a map field. Using '{}' is the correct
+    // empty-map YAML literal. See: fix/schema-object-type-generate.
+    const isMap = pt?.type === 'map' || pt?.type === 'object'
+    const initValue = isArray ? '' : isMap && !hasDefault ? '{}' : defaultVal
+
     return {
       name: field.name,
-      value: isArray ? '' : defaultVal,
+      value: initValue,
       items: [],
       isArray,
     }

--- a/web/src/lib/yaml.test.ts
+++ b/web/src/lib/yaml.test.ts
@@ -34,6 +34,13 @@ describe('toYaml', () => {
     expect(toYaml('# comment')).toBe('"# comment"')
   })
 
+  it('renders {} and [] as unquoted YAML collection literals (not as strings)', () => {
+    // {} as a string would be quoted as "{}" — but {} as an empty-map literal
+    // should serialize unquoted so kubectl/kro parse it as an empty map.
+    expect(toYaml('{}')).toBe('{}')
+    expect(toYaml('[]')).toBe('[]')
+  })
+
   it('renders empty string as ""', () => {
     expect(toYaml('')).toBe('""')
   })

--- a/web/src/lib/yaml.ts
+++ b/web/src/lib/yaml.ts
@@ -113,6 +113,11 @@ export function toYaml(value: unknown, indent: number = 0): string {
 function formatString(s: string): string {
   if (s === "") return '""'
 
+  // Empty YAML collection literals — emit unquoted so they parse as actual
+  // empty mappings/sequences rather than as literal strings.
+  if (s === "{}") return '{}'
+  if (s === "[]") return '[]'
+
   // Values containing special chars or that look like other YAML types need quoting
   if (
     s.includes(": ") ||


### PR DESCRIPTION
## Summary

Two related fixes discovered while auditing the Generate tab for `typed-schema` (which has a `labels: map[string]string` field using JSON Schema syntax).

### Fix 1 — GenerateTab: map/object form fields initialize correctly

The Generate tab form was initializing `map[string]string` and other object-type fields with `value: ''` (empty string), which produced invalid YAML: `labels: ""`. An empty string is not a valid map field value.

**Fix**: When `parsedType.type === 'map'` or `'object'` and there is no explicit default, initialize with `'{}'` — the correct empty-map YAML literal.

### Fix 2 — yaml.ts: `{}` and `[]` strings emit as unquoted YAML collection literals

`formatString()` was quoting any string starting with `{` or `[`, so the value `'{}'` was serialized as `"{}"`. When used as a field value (`labels: "{}"`) this is invalid — it's a string, not an empty map.

**Fix**: `{}` and `[]` are pre-checked before the special-char quoting rules. They emit unquoted so `kubectl apply` and kro parse them as empty collections.

### Before / After

| | Before | After |
|---|---|---|
| `typed-schema` Generate tab | `labels: ""` | `labels: {}` |

### Tests

2 new tests: `toYaml('{}')` and `toYaml('[]')` return unquoted literals. 1128 total passing.