### PR TITLE
test(web): TerminatingBanner unit tests for escalation logic; AGENTS.md updated

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ All changes go through PRs. Direct push to `main` is blocked.
 | `fix/yaml-clean-display` | — | YAML tab: strip managedFields, last-applied-configuration, resourceVersion, uid from displayed YAML | Merged (PR #291) |
 | `fix/schema-object-type-generate` | — | GenerateTab: map/object fields initialize with {} not "" | Merged (PR #292) |
 | `051-instance-diff` | #287 | Instance spec diff — select 2 instances and compare spec fields side-by-side | Merged (PR #293) |
+| `fix/ux-polish-round2-continued` | — | TerminatingBanner unit tests; CollectionPanel escalation improvements | In progress |
 
 ### Worktrunk (required workflow)
 
@@ -397,7 +398,7 @@ Always read the spec before writing code. Always run `go vet ./...` and
 - Stress-test fixture RGDs on kind cluster: `never-ready`, `invalid-cel-rgd`, `typed-schema`, `optimization-candidate`, `triple-config`, `crashloop-app`, `multi-ns-app`
 
  ## Recent Changes
-- v0.4.10 (cutting): instance spec diff — select 2 instances, compare spec fields side-by-side (PR #293); GenerateTab map/object fields initialize with {} not "" (PR #292)
+- v0.4.10: instance spec diff (PR #293); GenerateTab map/object fields {} fix (PR #292)
 - v0.4.9: YAML tab strips managedFields, last-applied-configuration, resourceVersion, uid (PR #291)
 - v0.4.8: ErrorsTab skips IN_PROGRESS instances (PR #286); CollectionPanel empty state shows forEach expression (PR #286); stuck reconcile escalation banner >5m (PR #286); stuck finalizer kubectl patch command >5m (PR #290)
 - v0.4.7: isItemReady stateless-resource fix (PR #284); external ref DAG nodes show alive/reconciling not not-found (PR #285)

--- a/web/src/components/TerminatingBanner.test.tsx
+++ b/web/src/components/TerminatingBanner.test.tsx
@@ -1,0 +1,119 @@
+// TerminatingBanner.test.tsx — unit tests for TerminatingBanner component.
+//
+// Covers:
+//   - Basic rendering with deletionTimestamp
+//   - No escalation section when < 5 minutes
+//   - Escalation section shown when finalizers present for >= 5 minutes
+//   - kubectl patch command correctly constructed
+
+import { render, screen } from '@testing-library/react'
+import TerminatingBanner from './TerminatingBanner'
+
+describe('TerminatingBanner', () => {
+  const PAST_NOW = new Date(Date.now() - 2 * 60 * 1000).toISOString() // 2 min ago
+  const PAST_OLD = new Date(Date.now() - 10 * 60 * 1000).toISOString() // 10 min ago
+
+  it('renders the basic terminating banner with relative time', () => {
+    render(
+      <TerminatingBanner
+        deletionTimestamp={PAST_NOW}
+        tick={0}
+      />
+    )
+    const banner = screen.getByRole('status')
+    expect(banner).toBeInTheDocument()
+    expect(banner.textContent).toMatch(/Terminating since/)
+  })
+
+  it('does NOT show escalation when no finalizers', () => {
+    render(
+      <TerminatingBanner
+        deletionTimestamp={PAST_OLD}
+        tick={0}
+        finalizers={[]}
+      />
+    )
+    expect(screen.queryByText(/To force remove/)).not.toBeInTheDocument()
+  })
+
+  it('does NOT show escalation when finalizers present but < 5 minutes', () => {
+    render(
+      <TerminatingBanner
+        deletionTimestamp={PAST_NOW}
+        tick={0}
+        finalizers={['kro.run/finalizer']}
+        instanceKind="AutoscaledApp"
+        instanceName="my-app"
+        instanceNamespace="default"
+      />
+    )
+    expect(screen.queryByText(/To force remove/)).not.toBeInTheDocument()
+  })
+
+  it('shows escalation section when finalizers blocked for >= 5 minutes', () => {
+    render(
+      <TerminatingBanner
+        deletionTimestamp={PAST_OLD}
+        tick={0}
+        finalizers={['kro.run/finalizer']}
+        instanceKind="AutoscaledApp"
+        instanceName="my-app"
+        instanceNamespace="kro-ui-demo"
+      />
+    )
+    // Should show the "To force remove" escalation
+    expect(screen.getByText(/To force remove/)).toBeInTheDocument()
+  })
+
+  it('includes kubectl patch command with correct kind/name/namespace', () => {
+    render(
+      <TerminatingBanner
+        deletionTimestamp={PAST_OLD}
+        tick={0}
+        finalizers={['kro.run/finalizer']}
+        instanceKind="AutoscaledApp"
+        instanceName="autoscaled-proxy"
+        instanceNamespace="kro-ui-demo"
+      />
+    )
+    const cmd = document.querySelector('.terminating-banner-cmd')
+    expect(cmd?.textContent).toContain('autoscaledapp')
+    expect(cmd?.textContent).toContain('autoscaled-proxy')
+    expect(cmd?.textContent).toContain('-n kro-ui-demo')
+    expect(cmd?.textContent).toContain('--type=json')
+  })
+
+  it('omits -n flag for cluster-scoped instances (empty namespace)', () => {
+    render(
+      <TerminatingBanner
+        deletionTimestamp={PAST_OLD}
+        tick={0}
+        finalizers={['kro.run/finalizer']}
+        instanceKind="ClusterApp"
+        instanceName="my-cluster-app"
+        instanceNamespace=""
+      />
+    )
+    const cmd = document.querySelector('.terminating-banner-cmd')
+    expect(cmd?.textContent).not.toContain('-n ')
+    expect(cmd?.textContent).toContain('clusterapp')
+    expect(cmd?.textContent).toContain('my-cluster-app')
+  })
+
+  it('shows "blocked" message but no kubectl command when instanceKind is absent', () => {
+    render(
+      <TerminatingBanner
+        deletionTimestamp={PAST_OLD}
+        tick={0}
+        finalizers={['kro.run/finalizer']}
+        // no instanceKind
+        instanceName="my-app"
+        instanceNamespace="default"
+      />
+    )
+    // Escalation text shows (blocked Nm) but no kubectl command without kind
+    const banner = document.querySelector('.terminating-banner')
+    expect(banner?.textContent).toMatch(/blocked/)
+    expect(document.querySelector('.terminating-banner-cmd')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Adds unit tests for the `TerminatingBanner` component's escalation feature (PR #290). The finalizer escalation feature was shipped without unit tests — this closes that gap.

### Tests added

7 new tests in `TerminatingBanner.test.tsx`:
- Basic banner renders with relative time
- No escalation when no finalizers provided
- No escalation when finalizers present but < 5 minutes elapsed
- Escalation section shown when blocked >= 5 minutes
- kubectl patch command includes correct `kind`, `name`, `-n namespace`
- Cluster-scoped instances omit the `-n` flag (empty namespace)
- Missing `instanceKind` shows blocked text but no kubectl command

### Also

- AGENTS.md spec table updated through PR #293 (instance diff)
- v0.4.10 `(cutting)` marker replaced with final version line