### PR TITLE
fix(web): remove CollectionPanel legacy kro < 0.8.0 warning (dead code)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,8 @@ All changes go through PRs. Direct push to `main` is blocked.
 | `fix/yaml-clean-display` | — | YAML tab: strip managedFields, last-applied-configuration, resourceVersion, uid from displayed YAML | Merged (PR #291) |
 | `fix/schema-object-type-generate` | — | GenerateTab: map/object fields initialize with {} not "" | Merged (PR #292) |
 | `051-instance-diff` | #287 | Instance spec diff — select 2 instances and compare spec fields side-by-side | Merged (PR #293) |
-| `fix/ux-polish-round2-continued` | — | TerminatingBanner unit tests; CollectionPanel escalation improvements | In progress |
+| `fix/ux-polish-round2-continued` | — | TerminatingBanner unit tests; CollectionPanel escalation improvements | Merged (PR #294) |
+| `fix/collection-legacy-remove` | — | CollectionPanel legacy kro < 0.8.0 warning removed; allChildrenLabelless dead code cleaned up | In progress |
 
 ### Worktrunk (required workflow)
 

--- a/web/src/components/CollectionPanel.test.tsx
+++ b/web/src/components/CollectionPanel.test.tsx
@@ -269,7 +269,11 @@ describe('CollectionPanel', () => {
     expect(screen.queryByTestId('collection-yaml-view')).not.toBeInTheDocument()
   })
 
-  it('shows legacy fallback when kro.run/node-id labels are absent', () => {
+  it('shows empty-collection state when no items match the current node-id (legacy kro < 0.8.0 path)', () => {
+    // With kro < 0.8.0, children had no kro.run/node-id labels so items array is empty.
+    // Previously this showed a "Legacy collection" warning. Now it shows the empty state.
+    // The legacy warning was removed in fix/collection-legacy-remove since kro >= 0.8.0
+    // always sets kro.run/node-id labels.
     const legacyItem: K8sObject = {
       kind: 'Pod',
       metadata: { name: 'legacy-pod', namespace: 'default', labels: {} },
@@ -284,8 +288,9 @@ describe('CollectionPanel', () => {
       />,
     )
 
-    // All children have no kro.run/node-id label → legacy notice is shown
-    expect(screen.getByText(/Legacy collection — labels unavailable/)).toBeInTheDocument()
+    // Legacy notice removed — shows empty-collection state instead
+    expect(screen.queryByText(/Legacy collection/)).not.toBeInTheDocument()
+    expect(screen.getByTestId('collection-empty-state')).toBeInTheDocument()
   })
 
   it('shows index, name, kind, status, age columns in table', () => {

--- a/web/src/components/CollectionPanel.tsx
+++ b/web/src/components/CollectionPanel.tsx
@@ -297,17 +297,9 @@ export default function CollectionPanel({
       ? parseInt(getLabels(items[0])[LABEL_COLL_SIZE] ?? String(items.length), 10)
       : 0
 
-  // Issue #257: the legacy notice should fire when THIS node's items are
-  // completely unlabelled. The original code checked `children.every(...)` which
-  // caused a false-negative in mixed-label clusters (other nodes' labelled children
-  // made `every` return false for a node whose children truly lack labels).
-  //
-  // Correct fix: check whether there are any children that have NO kro.run/node-id
-  // label at all AND items (filtered by this node's id) is empty.
-  // This handles both the pure-legacy case (all children unlabelled) and the
-  // mixed case (some children for other nodes are labelled; this node's are not).
-  const unlabelledChildren = children.filter((child) => !getLabels(child)[LABEL_NODE_ID])
-  const allChildrenLabelless = items.length === 0 && unlabelledChildren.length > 0
+  // Issue #257: the legacy notice was for kro < 0.8.0 which lacked kro.run/node-id labels.
+  // kro >= 0.8.0 (all supported versions) sets this label — the legacy path is unreachable.
+  // Removed in fix/collection-legacy-remove to reduce dead code.
 
   const forEachExpr = node.forEach ?? ''
 
@@ -379,12 +371,6 @@ export default function CollectionPanel({
             namespace={namespace}
             onBack={handleBack}
           />
-        ) : allChildrenLabelless ? (
-          /* Legacy: kro < 0.8.0 — no kro.run/node-id labels */
-          <div className="collection-legacy-notice">
-            <span className="collection-legacy-icon" aria-hidden="true">⚠</span>
-            <span>Legacy collection — labels unavailable. kro &lt; 0.8.0 lacks <code>kro.run/node-id</code> labels — upgrade kro to enable collection drill-down.</span>
-          </div>
         ) : items.length === 0 ? (
           <div
             data-testid="collection-empty-state"


### PR DESCRIPTION
## Summary

The `CollectionPanel` had a "Legacy collection — labels unavailable. kro < 0.8.0 lacks `kro.run/node-id` labels" warning path that fired when all children had no `kro.run/node-id` labels. kro < 0.8.0 is not supported and our cluster (kro v0.8.5+) always sets these labels. The code path is dead.

### Removed

- `allChildrenLabelless` computed variable (~8 lines of logic)
- The legacy notice JSX branch
- `unlabelledChildren` filter

### Why this is safe

Verified with `kubectl get configmap -l kro.run/instance-name=upstream-cartesian-foreach -o jsonpath='{.items[0].metadata.labels}'` — kro v0.8.5 sets `kro.run/node-id` on all managed resources.

When the legacy path would have fired (unlabelled children), the existing empty-collection state now shows instead — which is more accurate.

### Test updated

`CollectionPanel.test.tsx`: updated the legacy-fallback test to assert the legacy notice is ABSENT and the empty-state IS present.