### PR TITLE
fix(api): ListInstances returns empty list (not 500) for Inactive RGDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,8 @@ All changes go through PRs. Direct push to `main` is blocked.
 | `fix/schema-object-type-generate` | — | GenerateTab: map/object fields initialize with {} not "" | Merged (PR #292) |
 | `051-instance-diff` | #287 | Instance spec diff — select 2 instances and compare spec fields side-by-side | Merged (PR #293) |
 | `fix/ux-polish-round2-continued` | — | TerminatingBanner unit tests; CollectionPanel escalation improvements | Merged (PR #294) |
-| `fix/collection-legacy-remove` | — | CollectionPanel legacy kro < 0.8.0 warning removed; allChildrenLabelless dead code cleaned up | In progress |
+| `fix/collection-legacy-remove` | — | CollectionPanel legacy kro < 0.8.0 warning removed; allChildrenLabelless dead code cleaned up | Merged (PR #295) |
+| `fix/instances-inactive-rgd` | — | ListInstances returns empty list (not 500) for inactive RGDs; health chip now shows "no instances" | In progress |
 
 ### Worktrunk (required workflow)
 

--- a/internal/api/handlers/rgds.go
+++ b/internal/api/handlers/rgds.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/rs/zerolog"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -109,6 +110,16 @@ func (h *Handler) ListInstances(w http.ResponseWriter, r *http.Request) {
 		list, err = h.factory.Dynamic().Resource(gvr).List(r.Context(), metav1.ListOptions{})
 	}
 	if err != nil {
+		// Graceful degradation: when the CRD does not exist (RGD Inactive — KindReady=False),
+		// the Kubernetes API returns a "no kind ... is registered for version" or a 404 error.
+		// Return an empty list instead of 500 so the UI shows "no instances" not a broken chip.
+		// Constitution §XII: graceful degradation — absent data renders as safe empty state.
+		if k8serrors.IsNotFound(err) || k8serrors.IsMethodNotSupported(err) {
+			log.Debug().Str("rgd", name).Str("kind", kind).Msg("CRD not registered — returning empty instance list")
+			respond(w, http.StatusOK, map[string]interface{}{"items": []interface{}{}})
+			return
+		}
+		// For other errors (auth failure, network, etc.) still return 500.
 		log.Error().Err(err).Str("rgd", name).Str("kind", kind).Msg("failed to list instances")
 		respondError(w, http.StatusInternalServerError, err.Error())
 		return


### PR DESCRIPTION
## Summary

When an RGD is Inactive (KindReady=False — its CRD is not provisioned), calling `GET /api/v1/rgds/{name}/instances` returned HTTP 500 because the Kubernetes dynamic client returned an error when trying to list a resource type that doesn't exist.

This caused the Overview page RGD cards for inactive RGDs to show **no health chip at all** — the `Promise.allSettled` result was rejected, so `healthSummaries` never got an entry for that RGD, and `HealthChip` rendered null.

### Fix

Detect `k8serrors.IsNotFound` and `k8serrors.IsMethodNotSupported` errors from the dynamic client list call and return `200 OK {"items":[]}` instead of 500. Other errors (auth failures, network errors) still return 500.

### Before / After

| | Before | After |
|---|---|---|
| `GET /api/v1/rgds/cel-functions/instances` | HTTP 500 | HTTP 200 `{"items":[]}` |
| Overview card for `cel-functions` | [blank — no chip] | "no instances" |

### Constitution compliance

§XII: graceful degradation — absent data renders as a safe empty state, not as a 500 error propagated to the UI.