### PR TITLE
docs: E2E lessons → constitution §XIV, AGENTS anti-patterns, pdca command

### DIFF
--- a/.opencode/command/pdca-improvements.md
+++ b/.opencode/command/pdca-improvements.md
@@ -433,6 +433,10 @@ Common CI failure patterns and fixes:
 - Test failure → fix the code or the test, don't delete the test
 - `items:null` in Go handler → init slice with `make([]T, 0)`
 - Hardcoded rgba/hex in CSS → move to `tokens.css` as a named token
+- **E2E `SyntaxError: Unexpected token` at line N** → missing `})` closing a `test.describe` block. Verify all `.spec.ts` files have brace depth = 0. Crashes the entire runner before any test runs.
+- **E2E test navigates to nonexistent SPA route then times out** → `page.goto()` always returns HTTP 200 on a SPA. Use `page.request.get(apiUrl)` to check if the resource exists, then `test.skip()` + `return` if not OK, then `page.goto()` to navigate. See constitution §XIV.
+- **E2E `locator.or().toBeVisible()` throws "strict mode violation"** → both elements in the `.or()` are visible simultaneously. Replace with `page.waitForFunction(() => document.querySelector(...) !== null || ...)`.
+- **E2E journey file silently skipped** → the file's number prefix (e.g. `047-`) doesn't match any `testMatch` in `playwright.config.ts`. Add a new chunk or extend an existing one.
 
 ### A-5. Merge
 

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -427,6 +427,126 @@ from the API, or make the value configurable with a documented fallback.
 
 ---
 
+---
+
+## XIV. E2E Journey Standards (NON-NEGOTIABLE)
+
+E2E journeys run against a hermetic kind cluster. They are a required CI check
+that blocks merge. These rules prevent the class of failures discovered in
+PR #310 (lessons from 4 rounds of CI failures on a single PR).
+
+### SPA route detection — NEVER use HTTP status to detect nonexistent routes
+
+kro-ui is a single-page application (React Router). The server returns
+`HTTP 200` for **every** route regardless of whether the resource exists —
+the app shell loads and the React app decides what to render client-side.
+
+**`page.goto()` response status is unreliable for checking whether a Kubernetes
+resource (RGD, instance) exists on the cluster. It always returns 200.**
+
+❌ WRONG — `resp.status() >= 400` never fires on a SPA:
+```typescript
+const resp = await page.goto(`${BASE}/rgds/my-rgd/instances/ns/my-instance`)
+if (!resp || resp.status() >= 400) {
+  test.skip(true, 'fixture not available')  // ← never reached
+}
+// assertions run even when the RGD/instance does not exist → timeout
+```
+
+✓ CORRECT — check the API before navigating the UI:
+```typescript
+const rgdCheck = await page.request.get(`${BASE}/api/v1/rgds/my-rgd`)
+if (!rgdCheck.ok()) {
+  test.skip(true, 'my-rgd not present on this cluster')
+  return
+}
+const instCheck = await page.request.get(
+  `${BASE}/api/v1/instances/ns/my-instance?rgd=my-rgd`,
+)
+if (!instCheck.ok()) {
+  test.skip(true, 'my-instance not present on this cluster')
+  return
+}
+await page.goto(`${BASE}/rgds/my-rgd/instances/ns/my-instance`)
+// now safe to assert on UI
+```
+
+### Cluster-conditional steps: always gate with API check + `return` after skip
+
+Any step requiring a fixture only present on certain clusters (demo cluster,
+`kro-ui-demo` namespace, stress-test RGDs like `crashloop-app`, `never-ready`)
+MUST use `page.request.get()` API checks AND must `return` immediately after
+`test.skip()`. Without `return`, Playwright continues executing the step body
+in some contexts.
+
+The hermetic E2E kind cluster only has fixtures from `test/e2e/fixtures/`.
+Stress-test fixtures (`test/e2e/fixtures/stress-test-*.yaml`) are only on the
+demo cluster (`kind-kro-ui-demo`). The E2E cluster has no `kro-ui-demo` namespace.
+
+### Brace balance — verify after every journey edit
+
+A missing `})` for a `test.describe` block causes a `SyntaxError` that crashes
+the Playwright runner **before any tests run**, failing the entire CI chunk with
+no clear indication of which test failed. Always verify:
+```bash
+python3 -c "
+content = open('journey.spec.ts').read()
+d = 0
+for c in content:
+    if c == '{': d += 1
+    elif c == '}': d -= 1
+print('brace depth:', d)  # MUST be 0
+"
+```
+
+### `locator.or()` with `toBeVisible` — avoid when both elements may coexist
+
+`await expect(locA.or(locB)).toBeVisible()` fails when **both** elements are
+visible simultaneously because Playwright cannot resolve the ambiguity. Use
+`waitForFunction` instead:
+```typescript
+// ❌ Ambiguity error when both btn and result are visible
+await expect(page.getByTestId('btn').or(page.getByTestId('result'))).toBeVisible()
+
+// ✓ Unambiguous — polls the DOM directly
+await page.waitForFunction(() =>
+  document.querySelector('[data-testid="btn"]') !== null ||
+  document.querySelector('[data-testid="result"]') !== null,
+{ timeout: 10000 })
+```
+
+### New journey files MUST be added to a `testMatch` chunk in `playwright.config.ts`
+
+Journey files that don't match any chunk's `testMatch` pattern are **silently
+skipped** by the runner — no error, no warning. This means new E2E tests appear
+to pass while actually never running.
+
+When adding journeys with new number prefixes (e.g. `047-*.spec.ts`), you MUST:
+1. Add or update a chunk in `playwright.config.ts` with a matching regex
+2. Add the new chunk to the `serial` chunk's `dependencies` list
+
+Verify a file is matched: `grep testMatch test/e2e/playwright.config.ts` and
+confirm your file's prefix appears in a pattern.
+
+### Skeleton/loading-state assertions — use `waitForFunction`, not `toHaveCount(0)`
+
+Assertions like `await expect(skeleton).toHaveCount(0, { timeout: 15000 })` are
+fragile on slow CI runners. The skeleton counts as `1` until the async fetch
+resolves, and 15s may not be enough under load. Use `waitForFunction` polling
+the actual resolved content instead:
+```typescript
+// ❌ Fragile — times out on slow runners
+await expect(card.locator('.skeleton')).toHaveCount(0, { timeout: 15000 })
+
+// ✓ Resilient — polls the actual text that proves loading is done
+await page.waitForFunction(() => {
+  const el = document.querySelector('[data-testid="my-data"]')
+  return el !== null && /\d+/.test(el.textContent ?? '')
+}, { timeout: 25000 })
+```
+
+---
+
 ## Governance
 
 This constitution supersedes all other documentation when there is a conflict.
@@ -435,7 +555,11 @@ Amendments:
 2. Bump the version number (MINOR for new principles, PATCH for clarifications)
 3. Reference the amendment in the relevant spec or commit message
 
-**Version**: 1.4.0 | **Ratified**: 2026-03-22 | **Last Amended**: 2026-03-22
+**Version**: 1.5.0 | **Ratified**: 2026-03-22 | **Last Amended**: 2026-03-27
 
 **Amendment log**:
-- 1.4.0 (2026-03-22): §XIII Scale requirements updated from 100+ to 5,000+ RGDs for Home page and Catalog; virtualized rendering (spec `024-rgd-list-virtualization`) is now the required strategy.
+- 1.5.0 (2026-03-27): §XIV E2E Journey Standards added — SPA HTTP-200 pitfall,
+  API-first existence checks, brace balance verification, `locator.or()` ambiguity,
+  chunk registration requirement, `waitForFunction` over `toHaveCount(0)`.
+  All lessons from PR #310 (4 rounds of CI failures).
+- 1.4.0 (2026-03-22): §XIII Scale requirements updated from 100+ to 5,000+ RGDs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,9 @@ All changes go through PRs. Direct push to `main` is blocked.
 | `fix/ux-polish-round2-continued` | — | TerminatingBanner unit tests; CollectionPanel escalation improvements | Merged (PR #294) |
 | `fix/collection-legacy-remove` | — | CollectionPanel legacy kro < 0.8.0 warning removed; allChildrenLabelless dead code cleaned up | Merged (PR #295) |
 | `fix/instances-inactive-rgd` | — | ListInstances returns empty list (not 500) for inactive RGDs; health chip now shows "no instances" | Merged (PR #296) |
-| `fix/e2e-journey-backfill` | — | E2E journeys for PRs #277-#296: 047-ux-improvements, 047b-live-dag-state-map, updates to 028/031/011/002 + playwright chunk-7 | In progress |
+| `fix/e2e-journey-backfill` | — | E2E journeys for PRs #277-#296: 047-ux-improvements, 047b-live-dag-state-map, updates to 028/031/011/002 + playwright chunk-7 | Merged (PR #297) |
+| `fix/e2e-journey-syntax` | — | E2E syntax fixes: missing }), SPA HTTP-200 pitfall, locator.or() ambiguity, skeleton timeout | Merged (PR #310) |
+| `docs/learned-lessons` | — | Constitution §XIV E2E standards; AGENTS anti-patterns +6 E2E rows; pdca-improvements CI failure guide | In progress |
 
 ### Worktrunk (required workflow)
 
@@ -203,6 +205,15 @@ These were discovered in production QA. Every one produced a GitHub issue.
 | Hardcoded `rgba()` / hex in component CSS (e.g. `box-shadow`) | #77 review | Define a named token in `tokens.css` (`--shadow-tooltip`, etc.) and reference via `var()` |
 | Portal tooltip without viewport boundary clamping | #77 review | Measure bounding box with `getBoundingClientRect()` in `useEffect`; flip left/top when tooltip overflows right or bottom edge. Apply to ALL portal tooltip components |
 | Duplicating `nodeTypeLabel` / `tokenClass` across component files | #77 review | Define once in `@/lib/dag.ts` (or appropriate `@/lib/` module) and import — never copy-paste graph helpers |
+| State map keyed by `kind` instead of `kro.run/node-id` label | #278 | Key `buildNodeStateMap` by `kro.run/node-id`; skip children without this label (kube-generated resources) |
+| `IN_PROGRESS` kro state not mapped to reconciling | #278 | Check `status.state === 'IN_PROGRESS'` BEFORE checking conditions in `extractInstanceHealth` and `isReconciling()` |
+| `items:null` in Go API responses | #278 | Init slices with `make([]T, 0)` not `var items []T`; coerce nil to `[]` before responding |
+| External ref DAG nodes showing `not-found` when instance is healthy | #285 | In `buildNodeStateMap` step 3, map `external`/`externalCollection` nodes to `globalState` not `not-found` |
+| Using `page.goto()` HTTP status to detect nonexistent SPA routes in E2E | #310 | SPA always returns 200. Use `page.request.get(apiUrl)` to check if the resource exists before navigating |
+| E2E journey files not assigned to any Playwright chunk | #310 | Every journey file prefix MUST appear in a `testMatch` pattern in `playwright.config.ts`. Files without a match are silently skipped. |
+| Missing `})` closing `test.describe` in E2E journey | #310 | Crashes the Playwright runner before any test runs. Always verify brace depth = 0 after editing journeys |
+| `locator.or().toBeVisible()` when both elements may be visible | #310 | Use `waitForFunction()` polling the DOM; `locator.or()` throws when multiple elements match |
+| `toHaveCount(0, {timeout:15000})` for skeleton removal | #310 | Use `waitForFunction()` polling the resolved text content; more resilient on slow CI runners |
 
 ### Upstream kro node types (5 real types, from `pkg/graph/node.go`)
 
@@ -400,8 +411,9 @@ Always read the spec before writing code. Always run `go vet ./...` and
 - kro v0.9.0 API: GraphRevision CRD, scope badge, capabilities baseline (`hasGraphRevisions`, `hasExternalRefSelector`, `hasCELOmitFunction`)
 - Stress-test fixture RGDs on kind cluster: `never-ready`, `invalid-cel-rgd`, `typed-schema`, `optimization-candidate`, `triple-config`, `crashloop-app`, `multi-ns-app`
 
- ## Recent Changes
-- v0.4.12 (cutting): ListInstances returns empty list (not 500) for Inactive RGDs; health chip now shows "no instances" (PR #296)
+## Recent Changes
+- v0.4.13 (in progress): constitution §XIV E2E journey standards (SPA HTTP-200, brace balance, chunk registration, locator.or); AGENTS anti-patterns +6 E2E rows; pdca-improvements.md CI failure guide updated
+- v0.4.12: ListInstances returns empty list (not 500) for Inactive RGDs; health chip now shows "no instances" (PR #296)
 - v0.4.11: TerminatingBanner unit tests (PR #294); CollectionPanel legacy kro < 0.8.0 warning removed (PR #295)
 - v0.4.10: instance spec diff (PR #293); GenerateTab map/object fields {} fix (PR #292)
 - v0.4.9: YAML tab strips managedFields, last-applied-configuration, resourceVersion, uid (PR #291)


### PR DESCRIPTION
## Summary

Documents the five concrete lessons learned from PR #310 (E2E journey backfill that required 4 rounds of CI fixes). Makes the knowledge permanently available to every future session.

### constitution.md — new §XIV: E2E Journey Standards (v1.4.0 → v1.5.0)

Five rules with wrong/correct code examples:

1. **SPA HTTP-200 pitfall** — `page.goto()` always returns 200 on a SPA. Use `page.request.get(apiUrl)` to check resource existence before asserting on the UI.
2. **Cluster-conditional steps** — steps needing demo-cluster fixtures must use API check + `test.skip()` + `return`.
3. **Brace balance** — missing `})` crashes the entire Playwright runner before any test runs. Always verify `python3 -c "... print(depth)"` = 0.
4. **`locator.or().toBeVisible()` ambiguity** — fails when both elements are visible. Use `waitForFunction()`.
5. **Journey files must be in a `testMatch` chunk** — files without a matching chunk are silently skipped (no error, no warning).

### AGENTS.md — 6 new anti-pattern rows

Added to the Known Anti-Patterns table:
- State map keyed by `kind` not `kro.run/node-id` (#278)
- `IN_PROGRESS` not mapped to reconciling (#278)  
- `items:null` in Go API responses (#278)
- External ref nodes showing `not-found` when healthy (#285)
- Using `page.goto()` status to detect nonexistent SPA routes (#310)
- E2E journey files not assigned to Playwright chunk (#310)
- Missing `})` closing `test.describe` (#310)
- `locator.or().toBeVisible()` with multiple matches (#310)
- `toHaveCount(0)` for skeleton removal (#310)

### `.opencode/command/pdca-improvements.md`

Four new E2E-specific patterns added to the "Common CI failure patterns" section.

No code changes — documentation only.