### PR TITLE
feat(web): omit() designer help, collection limit badge 900/1000, condition-transition events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,8 @@ All changes go through PRs. Direct push to `main` is blocked.
 | `fix/e2e-journey-backfill` | — | E2E journeys for PRs #277-#296: 047-ux-improvements, 047b-live-dag-state-map, updates to 028/031/011/002 + playwright chunk-7 | Merged (PR #297) |
 | `fix/e2e-journey-syntax` | — | E2E syntax fixes: missing }), SPA HTTP-200 pitfall, locator.or() ambiguity, skeleton timeout | Merged (PR #310) |
 | `docs/learned-lessons` | — | Constitution §XIV E2E standards; AGENTS anti-patterns +6 E2E rows; pdca-improvements CI failure guide | Merged (PR #311) |
-| `fix/e2e-journey-syntax-fix2` | — | fixture-state.ts: lazy Proxy read per access (fixes fixture-state race causing 043 journeys to skip) | In progress |
+| `fix/e2e-journey-syntax-fix2` | — | fixture-state.ts: lazy Proxy read per access (fixes fixture-state race causing 043 journeys to skip) | Merged (PR #312) |
+| `fix/ux-polish-round2-continued` | #274 | omit() designer help text; collection limit badge (900/1000 warning); condition-transition event visual category | In progress |
 
 ### Worktrunk (required workflow)
 

--- a/web/src/components/CollectionBadge.css
+++ b/web/src/components/CollectionBadge.css
@@ -4,6 +4,7 @@
  * All colors from tokens.css only — no hardcoded hex values.
  *
  * Spec: .specify/specs/011-collection-explorer/
+ * kro v0.9.0: limit-warn (≥900) and limit-max (=1000) states added.
  */
 
 .collection-badge {
@@ -23,4 +24,14 @@
 
 .collection-badge--none-ready {
   fill: var(--color-error);
+}
+
+/* Approaching kro 1000-item limit — amber warning */
+.collection-badge--limit-warn {
+  fill: var(--color-status-warning);
+}
+
+/* At kro 1000-item limit — rose error (reconciliation will fail) */
+.collection-badge--limit-max {
+  fill: var(--color-status-error);
 }

--- a/web/src/components/CollectionBadge.tsx
+++ b/web/src/components/CollectionBadge.tsx
@@ -5,6 +5,8 @@
 //   all ready   → --color-alive (emerald)
 //   partial     → --color-reconciling (amber)
 //   none ready  → --color-error (rose)
+// kro v0.9.0: collections are limited to 1,000 items. Badge warns at ≥ 900
+// (amber "limit" state) and shows "max" at 1,000 (rose "at-limit" state).
 //
 // Spec: .specify/specs/011-collection-explorer/
 
@@ -12,6 +14,13 @@ import { isItemReady } from '@/lib/collection'
 import type { K8sObject } from '@/lib/api'
 import { LABEL_NODE_ID, LABEL_COLL_SIZE } from '@/lib/kro'
 import './CollectionBadge.css'
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+/** kro v0.9.0 hard limit on collection items per forEach node. */
+const COLL_LIMIT = 1000
+/** Warn when approaching the limit. */
+const COLL_WARN_THRESHOLD = 900
 
 // ── Props ──────────────────────────────────────────────────────────────────
 
@@ -29,9 +38,11 @@ export interface CollectionBadgeProps {
 
 // ── Badge state derivation ─────────────────────────────────────────────────
 
-type BadgeState = 'all-ready' | 'partial' | 'none-ready'
+type BadgeState = 'all-ready' | 'partial' | 'none-ready' | 'limit-warn' | 'limit-max'
 
 function badgeState(ready: number, total: number): BadgeState {
+  if (total >= COLL_LIMIT) return 'limit-max'
+  if (total >= COLL_WARN_THRESHOLD) return 'limit-warn'
   if (total === 0) return 'none-ready'
   if (ready === total) return 'all-ready'
   if (ready > 0) return 'partial'
@@ -82,7 +93,22 @@ export default function CollectionBadge({
   )
   const ready = items.filter(isItemReady).length
   const state = badgeState(ready, total)
-  const label = `${ready}/${total}`
+
+  // Label: "N/M" for health view, "N (max)" or "N ⚠" for limit view
+  const isAtLimit = total >= COLL_LIMIT
+  const isNearLimit = total >= COLL_WARN_THRESHOLD && total < COLL_LIMIT
+  const label = isAtLimit
+    ? `${total} (max)`
+    : isNearLimit
+      ? `${ready}/${total} ⚠`
+      : `${ready}/${total}`
+
+  // Title attribute for accessibility and tooltip
+  const ariaLabel = isAtLimit
+    ? `Collection at kro limit: ${total}/1000 items`
+    : isNearLimit
+      ? `Collection health: ${ready}/${total} ready — approaching 1000-item limit`
+      : `Collection health: ${ready}/${total} ready`
 
   // Position: centered horizontally, near the bottom of the node
   const x = nodeX + nodeWidth / 2
@@ -95,7 +121,7 @@ export default function CollectionBadge({
       x={x}
       y={y}
       textAnchor="middle"
-      aria-label={`Collection health: ${label}`}
+      aria-label={ariaLabel}
     >
       {label}
     </text>

--- a/web/src/components/EventRow.css
+++ b/web/src/components/EventRow.css
@@ -29,6 +29,16 @@
   border-left-color: var(--color-border);
 }
 
+/* Condition-transition events (kro v0.9.0 HasInstanceConditionEvents):
+ * distinct blue-ish border to indicate state machine transitions.
+ * Uses --color-primary (same as the interactive link color) for a recognizable
+ * "informational state change" visual that is distinct from both warning (amber)
+ * and normal (gray). */
+.event-stream-row--condition {
+  border-left-color: var(--color-alive);
+  background: var(--node-alive-bg);
+}
+
 .event-stream-row__body {
   flex: 1;
   padding: 8px 12px;
@@ -67,6 +77,13 @@
   background: transparent;
   border-color: var(--color-border-subtle);
   color: var(--color-text-faint);
+}
+
+/* Condition-transition badge — teal/alive color to indicate state change */
+.event-stream-row__type-badge--condition {
+  background: var(--node-alive-bg);
+  border-color: var(--color-alive);
+  color: var(--color-alive);
 }
 
 .event-stream-row__reason {

--- a/web/src/components/EventRow.tsx
+++ b/web/src/components/EventRow.tsx
@@ -2,8 +2,11 @@
 // timestamp, reason, message, and source.
 //
 // Spec: .specify/specs/019-smart-event-stream/
+// kro v0.9.0: condition-transition events get a distinct visual category
+// (blue left border + state-change icon) when HasInstanceConditionEvents is active.
 
 import type { KubeEvent } from '@/lib/events'
+import { isConditionTransitionEvent } from '@/lib/events'
 import './EventRow.css'
 
 interface EventRowProps {
@@ -40,18 +43,33 @@ function sourceLabel(event: KubeEvent): string {
  */
 export default function EventRow({ event }: EventRowProps) {
   const isWarning = event.type === 'Warning'
+  const isConditionTransition = !isWarning && isConditionTransitionEvent(event)
   const src = sourceLabel(event)
+
+  const rowClass = isWarning
+    ? 'event-stream-row event-stream-row--warning'
+    : isConditionTransition
+      ? 'event-stream-row event-stream-row--condition'
+      : 'event-stream-row event-stream-row--normal'
+
+  const badgeClass = isWarning
+    ? 'event-stream-row__type-badge event-stream-row__type-badge--warning'
+    : isConditionTransition
+      ? 'event-stream-row__type-badge event-stream-row__type-badge--condition'
+      : 'event-stream-row__type-badge event-stream-row__type-badge--normal'
 
   return (
     <div
-      className={`event-stream-row ${isWarning ? 'event-stream-row--warning' : 'event-stream-row--normal'}`}
+      className={rowClass}
       data-testid="event-row"
       data-event-type={event.type}
+      data-event-category={isConditionTransition ? 'condition-transition' : undefined}
     >
       <div className="event-stream-row__body">
         <div className="event-stream-row__header">
           <span
-            className={`event-stream-row__type-badge ${isWarning ? 'event-stream-row__type-badge--warning' : 'event-stream-row__type-badge--normal'}`}
+            className={badgeClass}
+            title={isConditionTransition ? 'Condition state transition (kro v0.9.0)' : undefined}
           >
             {isWarning ? (
               <svg width="10" height="10" viewBox="0 0 16 16" fill="none" aria-hidden="true">
@@ -64,6 +82,12 @@ export default function EventRow({ event }: EventRowProps) {
                 />
                 <line x1="8" y1="6" x2="8" y2="10" stroke="currentColor" strokeWidth="1.5" />
                 <circle cx="8" cy="12.5" r="0.75" fill="currentColor" />
+              </svg>
+            ) : isConditionTransition ? (
+              // State-change icon for condition-transition events (kro v0.9.0)
+              <svg width="10" height="10" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.5" />
+                <path d="M5 8h6M9 6l2 2-2 2" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
               </svg>
             ) : (
               <svg width="10" height="10" viewBox="0 0 16 16" fill="none" aria-hidden="true">

--- a/web/src/components/RGDAuthoringForm.tsx
+++ b/web/src/components/RGDAuthoringForm.tsx
@@ -1051,10 +1051,10 @@ export default function RGDAuthoringForm({ state, onChange, staticIssues }: RGDA
                 <div className="rgd-authoring-form__advanced-section">
                   {/* US3: includeWhen */}
                   <div className="rgd-authoring-form__advanced-row">
-                    <label
-                      className="rgd-authoring-form__sublabel"
-                      title="includeWhen — a CEL expression that controls whether this resource is created at all. When false, the resource is excluded (shown as violet in the DAG). Example: ${schema.spec.enableCache}"
-                    >includeWhen</label>
+                     <label
+                       className="rgd-authoring-form__sublabel"
+                       title="includeWhen — a CEL expression that controls whether this resource is created at all. When false, the resource is excluded (shown as violet in the DAG). Example: ${schema.spec.enableCache}. kro v0.9.0+: use omit() to conditionally remove fields instead of whole resources."
+                     >includeWhen</label>
                     <div className="rgd-authoring-form__cel-wrap">
                       <input
                         type="text"
@@ -1078,7 +1078,7 @@ export default function RGDAuthoringForm({ state, onChange, staticIssues }: RGDA
                   <div className="rgd-authoring-form__advanced-row">
                     <label
                       className="rgd-authoring-form__sublabel"
-                      title="readyWhen — one or more CEL expressions that must ALL evaluate to true before kro considers this resource Ready. The instance stays in 'Reconciling' state until all readyWhen conditions pass. Example: ${web.status.availableReplicas} >= 1"
+                      title="readyWhen — one or more CEL expressions that must ALL evaluate to true before kro considers this resource Ready. The instance stays in 'Reconciling' state until all readyWhen conditions pass. Example: ${web.status.availableReplicas} >= 1. kro v0.9.0+: omit() is available to conditionally remove fields from managed resources."
                     >readyWhen</label>
                     <div className="rgd-authoring-form__readywhen-rows">
                       {(res.readyWhen ?? []).map((rw, i) => (

--- a/web/src/lib/events.ts
+++ b/web/src/lib/events.ts
@@ -88,7 +88,33 @@ export function toKubeEvent(obj: K8sObject): KubeEvent | null {
   }
 }
 
-// ── Sort ─────────────────────────────────────────────────────────────
+// ── Condition-transition event detection ─────────────────────────────
+
+/**
+ * isConditionTransitionEvent — returns true when a kro event represents a
+ * condition-status change (kro v0.9.0 HasInstanceConditionEvents feature).
+ *
+ * kro v0.9.0 emits condition-transition events with a reason like:
+ *   "ResourcesReady"        (condition type becoming True)
+ *   "ConditionChanged"      (generic condition transition)
+ *   "Ready"/"NotReady"      (top-level Ready condition change)
+ *   "Progressing"           (Progressing condition transitions)
+ *
+ * These events always have type "Normal" (not "Warning") and their
+ * reason starts with an uppercase letter without spaces — unlike
+ * operational reasons like "FailedCreate" or "BackOff".
+ *
+ * Heuristic: type=Normal AND reason matches a known kro condition name.
+ */
+const CONDITION_REASONS = new Set([
+  'Ready', 'NotReady', 'ResourcesReady', 'GraphResolved', 'InstanceManaged',
+  'ControllerReady', 'KindReady', 'ResourceGraphAccepted', 'ConditionChanged',
+  'Progressing', 'Available', 'Synced', 'ReconcileSucceeded',
+])
+
+export function isConditionTransitionEvent(event: KubeEvent): boolean {
+  return event.type === 'Normal' && CONDITION_REASONS.has(event.reason)
+}
 
 /** Sorts events newest-first by lastTimestamp. */
 export function sortEvents(events: KubeEvent[]): KubeEvent[] {


### PR DESCRIPTION
## Summary

Three remaining items from GH #274 (kro v0.9.0 upgrade — Phase 3 new feature surface).

### 1. `omit()` CEL function in designer help text

The `includeWhen` and `readyWhen` label tooltips in the RGD Designer now mention the `omit()` function available in kro v0.9.0+. Previously the tooltips only showed basic examples without referencing the new function.

### 2. Collection limit badge — warn at ≥900, error at 1000

kro v0.9.0 enforces a hard 1,000-item limit per forEach collection node. `CollectionBadge` now shows:
- Normal: `N/M` (existing behavior)
- **Approaching limit (≥900)**: `N/M ⚠` in amber
- **At limit (=1000)**: `N (max)` in rose — reconciliation will fail at this point

The `badgeState` enum adds `limit-warn` and `limit-max` states with corresponding CSS classes.

### 3. Condition-transition events (kro v0.9.0 HasInstanceConditionEvents)

kro v0.9.0 with `HasInstanceConditionEvents` emits Kubernetes Events on condition transitions. `EventRow` now detects these events and applies a distinct **green/alive** visual:
- Green left border (`.event-stream-row--condition`)
- Green badge with state-change arrow icon
- `data-event-category="condition-transition"` attribute for targeting

New `isConditionTransitionEvent()` in `events.ts` detects: `type=Normal` AND `reason` in a known set of kro condition names (`ResourcesReady`, `GraphResolved`, `Ready`, `Progressing`, etc.).

Gracefully degrades: when the capability is not active or no condition-transition events are present, the visual is unchanged.

## Issue
Closes partial items in GH #274 (Phase 3). Remaining: Graph Revisions tab, `upstream-cel-comprehensions` fixture (kro v0.9.0 CEL comprehension feature gate).