### PR TITLE
feat(web): DocsTab required fields sorted first; Graph tab resource complexity hint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ All changes go through PRs. Direct push to `main` is blocked.
 | `fix/ux-polish-round2-continued` | #303 #299 #298 #308 #309 | ValidateRGD PATCH→static; Fleet degraded color; ContextSwitcher subtitle; require.Nil; AGENTS/constitution docs | Merged (PR #316) |
 | `fix/e2e-journey-syntax-fix2` | — | #301 errors.New sentinels; #300 handler timeout comment; #302 README features; #304 #305 #306 component tests | Merged (PR #317) |
 | `051-instance-diff` | #276 #13 | F-8 snooze error DAG nodes; GraphRevision side-by-side YAML diff foundation (spec 009) | Merged (PR #318) |
+| `fix/ux-polish-round2` | — | DocsTab required fields sorted first + summary banner; Graph tab resource complexity hint; advanced stress-test fixtures | In progress |
 
 ### Worktrunk (required workflow)
 

--- a/web/src/components/FieldTable.css
+++ b/web/src/components/FieldTable.css
@@ -109,6 +109,20 @@
   color: var(--color-text-faint);
 }
 
+/* Required fields summary banner at top of spec field table */
+.field-table__required-summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: var(--node-error-bg);
+  border: 1px solid var(--color-border);
+  border-bottom: none;
+  border-radius: var(--radius) var(--radius) 0 0;
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
 /* ── Default value ───────────────────────────────────────────────────── */
 
 .field-table__default-cell {

--- a/web/src/components/FieldTable.tsx
+++ b/web/src/components/FieldTable.tsx
@@ -85,8 +85,22 @@ export default function FieldTable({ fields, variant }: FieldTableProps) {
   }
 
   // variant === 'spec'
+  const requiredFields = fields.filter(
+    (f) => f.parsedType?.required === true || !('default' in (f.parsedType ?? {})),
+  )
   return (
     <div className="field-table" data-testid="field-table">
+      {/* Required fields summary banner — only shown when ≥1 required field exists
+          and there are multiple fields total (trivial schemas don't need this). */}
+      {requiredFields.length > 0 && fields.length > 1 && (
+        <div className="field-table__required-summary" data-testid="field-table-required-summary">
+          <span className="field-table__required-dot field-table__required-dot--required" aria-hidden="true" />
+          {requiredFields.length === 1
+            ? `1 required field: ${requiredFields[0].name}`
+            : `${requiredFields.length} required fields: ${requiredFields.map((f) => f.name).join(', ')}`}
+          {' '}— must be provided when creating an instance.
+        </div>
+      )}
       <table className="field-table__table">
         <thead>
           <tr>
@@ -97,7 +111,15 @@ export default function FieldTable({ fields, variant }: FieldTableProps) {
           </tr>
         </thead>
         <tbody>
-          {fields.map((field) => {
+          {/* Sort required fields first so users immediately see what they must fill in.
+              This is particularly important for RGDs with many spec fields (e.g. 15+). */}
+          {[...fields].sort((a, b) => {
+            const aRequired = a.parsedType?.required === true || !('default' in (a.parsedType ?? {}))
+            const bRequired = b.parsedType?.required === true || !('default' in (b.parsedType ?? {}))
+            if (aRequired && !bRequired) return -1
+            if (!aRequired && bRequired) return 1
+            return 0
+          }).map((field) => {
             // Use key existence (not `!== undefined`) so that falsy defaults like
             // default=0, default=false, default="" are correctly detected as present.
             // See: https://github.com/pnz1990/kro-ui/issues/61

--- a/web/src/pages/RGDDetail.css
+++ b/web/src/pages/RGDDetail.css
@@ -144,6 +144,14 @@
   text-align: right;
 }
 
+/* Inline resource complexity breakdown (e.g. "· 5 resources (2×Deployment, 2×HPA, ConfigMap)") */
+.rgd-graph-complexity-hint {
+  margin-left: 8px;
+  font-size: 11px;
+  color: var(--color-text-faint);
+  cursor: default;
+}
+
 .rgd-graph-area {
   flex: 1;
   overflow: auto;

--- a/web/src/pages/RGDDetail.tsx
+++ b/web/src/pages/RGDDetail.tsx
@@ -514,6 +514,30 @@ export default function RGDDetail() {
             {rgdLastFetched && (
               <div className="rgd-graph-refresh-hint" aria-live="polite">
                 refreshed {formatAgo(rgdLastFetched)}
+                {/* Resource kind breakdown — shows complexity at a glance when ≥2 resources */}
+                {rgd && (() => {
+                  const resources = (rgd.spec as Record<string, unknown>)?.resources
+                  if (!Array.isArray(resources) || resources.length < 2) return null
+                  const kindCounts = new Map<string, number>()
+                  for (const r of resources) {
+                    const rObj = r as Record<string, unknown>
+                    const tmpl = rObj?.template as Record<string, unknown> | undefined
+                    const kind = tmpl?.kind as string | undefined
+                    if (kind) kindCounts.set(kind, (kindCounts.get(kind) ?? 0) + 1)
+                  }
+                  const parts: string[] = []
+                  kindCounts.forEach((count, kind) => {
+                    parts.push(count > 1 ? `${count}×${kind}` : kind)
+                  })
+                  return (
+                    <span
+                      className="rgd-graph-complexity-hint"
+                      title={`${resources.length} resource${resources.length === 1 ? '' : 's'}: ${parts.join(', ')}`}
+                    >
+                      · {resources.length} resources ({parts.join(', ')})
+                    </span>
+                  )
+                })()}
               </div>
             )}
             <div


### PR DESCRIPTION
## Summary

Three UX improvements found by stress-testing with new complex RGDs (deep-dependency-chain, large-schema with 15 fields, multi-hpa-app with 5 resources).

### 1. DocsTab: required fields sorted first + summary banner

When browsing `large-schema` (15 spec fields, 1 required: `serviceName`), users had to scroll through 14 optional fields to find the 1 they must provide. 

**Fix**: Spec fields in the DocsTab FieldTable are now sorted **required fields first**. Also adds a summary banner: `● 1 required field: serviceName — must be provided when creating an instance.`

### 2. Graph tab: resource kind breakdown in header

When looking at `multi-hpa-app` (5 resources: 2×Deployment, 2×HPA, ConfigMap), there was no quick way to understand RGD complexity. The "refreshed X ago" hint in the Graph tab now appends:

```
refreshed 2m ago · 5 resources (2×Deployment, 2×HorizontalPodAutoscaler, ConfigMap)
```

Only shown when ≥2 resources. Tooltip shows full breakdown.

### 3. Advanced stress-test fixtures installed on demo cluster

New RGDs exercising complex scenarios:
- `deep-dependency-chain`: 4-level linear CEL chain A→B→C→D (each ConfigMap references previous one's name)  
- `large-schema`: 15 spec fields (string/integer/boolean), 1 required field, 3 resources
- `multi-hpa-app`: 5 resources (2×Deployment + 2×HPA + ConfigMap), optimizer advisor fires on both Deployment and HPA pairs

## Tests

1169 tests passing. TypeScript strict: 0 errors.