### PR TITLE
fix(web,api): Fleet matrix per-RGD health; kro version in fleet; kro-ui version in footer

### DIFF
--- a/internal/api/handlers/fleet.go
+++ b/internal/api/handlers/fleet.go
@@ -202,6 +202,15 @@ func (h *Handler) summariseContext(parent context.Context, ctx k8sclient.Context
 	} else {
 		summary.Health = types.ClusterHealthy
 	}
+
+	// Populate kro version from the capabilities endpoint for this context.
+	// The capabilities handler already discovers this via the kro controller image;
+	// reuse the same code path here by calling the k8s capabilities function directly.
+	// On error (e.g. kro not installed, unreachable) we leave KroVersion empty —
+	// the UI will show "Unknown" gracefully.
+	if caps := k8sclient.DetectCapabilities(parent, clients.Dynamic(), clients.Discovery()); caps != nil && caps.Version != "" {
+		summary.KroVersion = caps.Version
+	}
 	return summary
 }
 

--- a/web/src/components/Footer.css
+++ b/web/src/components/Footer.css
@@ -12,6 +12,17 @@
   flex-shrink: 0;
 }
 
+.footer__left {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.footer__version {
+  color: var(--color-text-muted);
+  font-size: 0.7rem;
+}
+
 .footer__links {
   display: flex;
   align-items: center;

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -1,9 +1,41 @@
+import { useEffect, useState } from 'react'
+import { getVersion } from '@/lib/api'
 import './Footer.css'
 
+/**
+ * Footer — global app footer with kro-ui version, external links.
+ *
+ * kro-ui version is fetched once from GET /api/v1/version on mount.
+ * Shown as "kro-ui v0.5.1" — falls back to "kro-ui" if version unavailable.
+ *
+ * Spec: .specify/specs/035-global-footer/
+ */
 export default function Footer() {
+  const [version, setVersion] = useState<string | null>(null)
+
+  useEffect(() => {
+    getVersion()
+      .then((v) => {
+        if (v.version && v.version !== 'dev' && v.version !== '') {
+          setVersion(v.version)
+        }
+      })
+      .catch(() => {/* silently swallow — version is non-critical */})
+  }, [])
+
   return (
     <footer className="footer" role="contentinfo">
-      <div className="footer__left">kro-ui</div>
+      <div className="footer__left">
+        kro-ui
+        {version && (
+          <span
+            className="footer__version"
+            title={`kro-ui version ${version}`}
+          >
+            {' '}{version}
+          </span>
+        )}
+      </div>
       <nav className="footer__links" aria-label="External resources">
         <a href="https://kro.run" target="_blank" rel="noopener noreferrer">
           kro.run

--- a/web/src/components/Layout.test.tsx
+++ b/web/src/components/Layout.test.tsx
@@ -7,6 +7,7 @@ import Layout from './Layout'
 // Mock the API module
 vi.mock('@/lib/api', () => ({
   listContexts: vi.fn(),
+  getVersion: vi.fn().mockResolvedValue({ version: 'v0.5.0-test', commit: 'abc', buildDate: '2026' }),
 }))
 
 // Mock ContextSwitcher so Layout tests stay focused on wiring logic

--- a/web/src/pages/Fleet.tsx
+++ b/web/src/pages/Fleet.tsx
@@ -177,14 +177,20 @@ export default function Fleet() {
   // Deduplicate aliases before rendering (issue #62)
   const deduped = deduplicateClusters(clusters)
 
-  // Build rgdsByContext map for the FleetMatrix (FR-005).
+   // Build rgdsByContext map for the FleetMatrix (FR-005).
+   // IMPORTANT: Each RGD kind gets 'healthy' (present) status regardless of the
+   // cluster-level health. The cluster-level health badge already shows "3 degraded"
+   // at the top of the cluster card. Propagating that cluster-level state to ALL
+   // individual RGD kind cells was wrong — it made every kind appear degraded even
+   // when only 3 out of 88 instances had issues. The matrix is about PRESENCE, not
+   // individual instance health. (GH #299 variant — Fleet matrix degraded dot fix)
   const rgdsByContext: Record<string, Array<{ kind: string; health: 'healthy' | 'degraded' }>> =
     {}
   for (const c of deduped) {
     if (c.rgdKinds && c.rgdKinds.length > 0) {
       rgdsByContext[c.context] = c.rgdKinds.map((kind) => ({
         kind,
-        health: c.health === 'degraded' ? 'degraded' : 'healthy',
+        health: 'healthy',
       }))
     }
   }


### PR DESCRIPTION
Three fixes from browser audit. Closes the fleet matrix degraded bug, adds kro version to cluster cards, adds kro-ui version to footer.