### PR TITLE
feat(web): RGD card error hint — one-line compile error on error-state cards (spec 056)

### DIFF
--- a/.specify/specs/056-rgd-status-tooltip/spec.md
+++ b/.specify/specs/056-rgd-status-tooltip/spec.md
@@ -1,0 +1,73 @@
+# Feature Specification: RGD Card Error Hint
+
+**Feature Branch**: `056-rgd-status-tooltip`
+**Created**: 2026-03-28
+**Status**: In Progress
+
+---
+
+## Context
+
+The Overview page shows RGD cards with a status dot (green = ready, red = error,
+grey = unknown). When the dot is red, users currently have no way to know WHY
+without clicking through to the RGD detail page's Validation tab.
+
+During PDCA sweep: `cel-functions` (red dot, `InvalidResourceGraph: references
+unknown identifiers: [j]`), `chain-cycle-a/b` (red dot, cycle detection errors),
+`invalid-cel-rgd` (red dot, CEL parse error) all show identical red dots with
+no actionable information on the card.
+
+The `StatusDot` component has a `title` attribute tooltip, but HTML `title`
+tooltips are: invisible on mobile, not keyboard-accessible, and give no visual
+affordance that there's more information.
+
+## Design
+
+For RGD cards in `error` state, add a one-line error hint directly on the card
+between the meta row and the health chip. The hint shows:
+- The `reason` value (e.g., "InvalidResourceGraph")
+- Truncated `message` (first 80 chars, with ellipsis if truncated)
+
+This is a **read-only, informational display** — no mutation, no expansion.
+Full error details are still in the Validation tab.
+
+## Requirements
+
+### FR-001: Error hint on error-state cards
+
+When `state === 'error'` and `reason` is non-empty, render a `<p>` element with
+class `rgd-card__error-hint` and `data-testid="rgd-card-error-hint"`.
+
+Content format: `{reason}: {message}` — truncated to 80 characters with `…` suffix.
+If only `reason` exists (empty message), show just the reason.
+
+### FR-002: Style
+
+The error hint:
+- font-size: 11px
+- color: `var(--color-status-error)`
+- Truncated with `text-overflow: ellipsis; overflow: hidden; white-space: nowrap`
+- Max-width: 100% of card width
+- No additional padding beyond the existing card padding
+
+### FR-003: No rendering for ready/unknown state
+
+Only rendered when `state === 'error'`. Ready and unknown state cards are
+unchanged.
+
+### FR-004: title attribute preserves full message
+
+The hint `<p>` MUST have a `title` attribute with the full (untruncated) error
+message for accessibility and desktop hover.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Error-state RGD cards show a one-line error hint
+- [ ] Hint is truncated at 80 chars with ellipsis
+- [ ] Ready/unknown cards have no hint
+- [ ] `title` attribute carries full message
+- [ ] No hardcoded colors (uses `--color-status-error`)
+- [ ] RGDCard unit tests updated
+- [ ] `tsc --noEmit` and `go vet` pass

--- a/test/e2e/journeys/056-rgd-status-tooltip.spec.ts
+++ b/test/e2e/journeys/056-rgd-status-tooltip.spec.ts
@@ -1,0 +1,93 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Journey 056: RGD Card Error Hint
+ *
+ * Spec: .specify/specs/056-rgd-status-tooltip/spec.md
+ *
+ * Verifies:
+ *   A) Error-state RGD cards show a one-line error hint
+ *   B) Hint text contains the error reason
+ *   C) Ready-state cards have no error hint
+ *   D) Error hint has a title attribute with the full message
+ *
+ * Cluster pre-conditions:
+ * - kind cluster running kro >= v0.8.0
+ * - At least one Inactive/error RGD (invalid-cel-rgd or cel-functions applied)
+ * - kro-ui binary running at KRO_UI_BASE_URL
+ */
+
+import { test, expect } from '@playwright/test'
+
+const BASE = process.env.KRO_UI_BASE_URL || 'http://localhost:40107'
+
+test.describe('Journey 056: RGD Card Error Hint', () => {
+
+  // ── A+B: Error-state card shows hint ────────────────────────────────────────
+
+  test('Step 1: Error-state RGD cards show an error hint on the Overview', async ({ page }) => {
+    await page.goto(BASE)
+    await page.waitForSelector('[data-testid^="rgd-card-"]', { timeout: 15000 })
+
+    // Check for any error hint elements — there should be at least one
+    // (invalid-cel-rgd, cel-functions, chain-cycle-a/b all have error states)
+    const hints = page.locator('[data-testid="rgd-card-error-hint"]')
+    const count = await hints.count()
+    expect(count).toBeGreaterThan(0)
+  })
+
+  // ── B: Hint text is non-empty and contains reason ──────────────────────────
+
+  test('Step 2: Error hint text is non-empty and contains a reason', async ({ page }) => {
+    await page.goto(BASE)
+    await page.waitForSelector('[data-testid="rgd-card-error-hint"]', { timeout: 15000 })
+
+    const hints = page.locator('[data-testid="rgd-card-error-hint"]')
+    const count = await hints.count()
+    for (let i = 0; i < Math.min(count, 3); i++) {
+      const text = await hints.nth(i).textContent()
+      expect(text?.trim().length).toBeGreaterThan(0)
+      // Should not contain raw JS artifacts
+      expect(text).not.toContain('undefined')
+      expect(text).not.toContain('[object')
+    }
+  })
+
+  // ── C: Ready-state cards have no error hint ────────────────────────────────
+
+  test('Step 3: Ready-state RGD cards do not show an error hint', async ({ page }) => {
+    await page.goto(BASE)
+    await page.waitForSelector('[data-testid^="rgd-card-"]', { timeout: 15000 })
+
+    // Find the test-app card (known to be Ready) and verify no error hint
+    const testAppCard = page.locator('[data-testid="rgd-card-test-app"]')
+    if (await testAppCard.count() > 0) {
+      const hint = testAppCard.locator('[data-testid="rgd-card-error-hint"]')
+      await expect(hint).not.toBeVisible()
+    }
+  })
+
+  // ── D: Error hint has title attribute ─────────────────────────────────────
+
+  test('Step 4: Error hint has a title attribute for accessibility', async ({ page }) => {
+    await page.goto(BASE)
+    await page.waitForSelector('[data-testid="rgd-card-error-hint"]', { timeout: 15000 })
+
+    const firstHint = page.locator('[data-testid="rgd-card-error-hint"]').first()
+    const title = await firstHint.getAttribute('title')
+    expect(title).toBeTruthy()
+    expect(title!.trim().length).toBeGreaterThan(0)
+  })
+})

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -130,10 +130,10 @@ export default defineConfig({
       fullyParallel: true,
     },
     {
-      // chunk-8 covers journeys added in specs 051–055
-      // (instance diff, response cache, multi-version kro, ux-gaps-round3, overview-health-summary)
+      // chunk-8 covers journeys added in specs 051–056
+      // (instance diff, response cache, multi-version kro, ux-gaps, overview health, rgd error hint)
       name: 'chunk-8',
-      testMatch: /(051|052|053|054|055)-.*\.spec\.ts/,
+      testMatch: /(051|052|053|054|055|056)-.*\.spec\.ts/,
       ...PARALLEL_OPTS,
       workers: 4,
       fullyParallel: true,

--- a/web/src/components/RGDCard.css
+++ b/web/src/components/RGDCard.css
@@ -15,14 +15,27 @@
 
 /* Reserved row for the health chip — always the same height whether the chip
    is a skeleton, "no instances", "3 ready", or null (fetch failed).
-   Without this fixed height the card body collapses when HealthChip returns
-   null, making that card shorter than its neighbours in the same grid row. */
+    Without this fixed height the card body collapses when HealthChip returns
+    null, making that card shorter than its neighbours in the same grid row. */
 .rgd-card__chip-row {
   min-height: 24px;
   display: flex;
   align-items: center;
   margin-bottom: 8px;
 }
+
+/* FR-001 (spec 056): one-line error hint for error-state RGDs.
+   Rendered between the meta row and health chip. */
+.rgd-card__error-hint {
+  margin: 0 0 4px;
+  font-size: 11px;
+  color: var(--color-status-error);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
 
 .rgd-card:hover {
   border-color: var(--color-border-focus);

--- a/web/src/components/RGDCard.test.tsx
+++ b/web/src/components/RGDCard.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import RGDCard from './RGDCard'
+import RGDCard, { buildErrorHint } from './RGDCard'
 import type { K8sObject } from '@/lib/api'
 
 // Prevent real network calls; keep the promise pending so we can inspect
@@ -123,3 +123,90 @@ describe('RGDCard', () => {
     expect(container.querySelector('.health-chip--skeleton')).toBeInTheDocument()
   })
 })
+
+// ── buildErrorHint unit tests (spec 056) ───────────────────────────────────────
+
+describe('buildErrorHint', () => {
+  it('returns empty string when both reason and message are empty', () => {
+    expect(buildErrorHint('', '')).toBe('')
+  })
+
+  it('returns reason alone when message is empty', () => {
+    expect(buildErrorHint('InvalidResourceGraph', '')).toBe('InvalidResourceGraph')
+  })
+
+  it('returns message alone when reason is empty', () => {
+    expect(buildErrorHint('', 'something went wrong')).toBe('something went wrong')
+  })
+
+  it('combines reason and message with colon', () => {
+    expect(buildErrorHint('SomethingFailed', 'details here')).toBe('SomethingFailed: details here')
+  })
+
+  it('truncates combined text at 80 characters', () => {
+    const long = 'a'.repeat(90)
+    const result = buildErrorHint('Reason', long)
+    expect(result).toHaveLength(81) // 80 chars + ellipsis
+    expect(result.endsWith('…')).toBe(true)
+  })
+
+  it('does not truncate text at exactly 80 characters', () => {
+    const reason = 'R'
+    const message = 'a'.repeat(77) // "R: " + 77 = 80 chars total
+    const result = buildErrorHint(reason, message)
+    expect(result).toHaveLength(80)
+    expect(result.endsWith('…')).toBe(false)
+  })
+})
+
+// ── RGDCard error hint rendering tests ─────────────────────────────────────────
+
+describe('RGDCard error hint', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-20T12:00:00Z'))
+  })
+  afterEach(() => { vi.useRealTimers() })
+
+  function makeErrorRGD(reason: string, message: string): K8sObject {
+    return {
+      metadata: { name: 'broken', creationTimestamp: '2026-03-15T10:00:00Z' },
+      spec: { schema: { kind: 'BrokenApp' }, resources: [{}] },
+      status: {
+        conditions: [
+          { type: 'Ready', status: 'False', reason, message },
+        ],
+      },
+    }
+  }
+
+  it('shows error hint on error-state card', () => {
+    render(
+      <MemoryRouter>
+        <RGDCard rgd={makeErrorRGD('InvalidResourceGraph', 'references unknown identifiers: [j]')} />
+      </MemoryRouter>
+    )
+    const hint = screen.getByTestId('rgd-card-error-hint')
+    expect(hint).toBeInTheDocument()
+    expect(hint.textContent).toContain('InvalidResourceGraph')
+  })
+
+  it('does not show error hint on ready-state card', () => {
+    render(
+      <MemoryRouter>
+        <RGDCard rgd={makeErrorHint_ready()} />
+      </MemoryRouter>
+    )
+    expect(screen.queryByTestId('rgd-card-error-hint')).not.toBeInTheDocument()
+  })
+})
+
+function makeErrorHint_ready(): K8sObject {
+  return {
+    metadata: { name: 'ok-app', creationTimestamp: '2026-03-15T10:00:00Z' },
+    spec: { schema: { kind: 'OkApp' }, resources: [{}] },
+    status: {
+      conditions: [{ type: 'Ready', status: 'True', reason: 'Ready', message: '' }],
+    },
+  }
+}

--- a/web/src/components/RGDCard.tsx
+++ b/web/src/components/RGDCard.tsx
@@ -16,6 +16,19 @@ import StatusDot from './StatusDot'
 import HealthChip from './HealthChip'
 import './RGDCard.css'
 
+/** Maximum characters shown in the error hint before truncation. */
+const ERROR_HINT_MAX = 80
+
+/**
+ * Build a truncated error hint string from a reason + message.
+ * Returns empty string when both are absent.
+ */
+export function buildErrorHint(reason: string, message: string): string {
+  const raw = reason && message ? `${reason}: ${message}` : reason || message
+  if (!raw) return ''
+  return raw.length > ERROR_HINT_MAX ? raw.slice(0, ERROR_HINT_MAX) + '…' : raw
+}
+
 interface RGDCardProps {
   rgd: K8sObject
   /**
@@ -126,6 +139,16 @@ export default function RGDCard({ rgd, terminatingCount, healthSummary: healthSu
           </span>
           <span className="rgd-card__age">{formatAge(createdAt)}</span>
         </div>
+        {/* FR-001 (spec 056): error hint — one-line error reason for error-state RGDs */}
+        {state === 'error' && (reason || message) && (
+          <p
+            className="rgd-card__error-hint"
+            data-testid="rgd-card-error-hint"
+            title={reason && message ? `${reason}: ${message}` : reason || message}
+          >
+            {buildErrorHint(reason, message)}
+          </p>
+        )}
         {/* Health chip wrapper — fixed height so cards are uniform regardless
             of chip state (loading / null / "no instances" / "N ready").
             Without this, cards where the fetch returns null render shorter


### PR DESCRIPTION
## Summary

Error-state RGD cards on the Overview page now show a one-line error hint directly on the card. Previously, a red status dot gave no indication of *why* the RGD was broken without clicking through to the Validation tab.

### Observation

The demo cluster has 5+ broken RGDs (`cel-functions`, `chain-cycle-a/b`, `invalid-cel-rgd`, `chain-parent`) all showing identical red dots. The error varies: CEL identifier errors, cycle detection failures, invalid graph structures. None of this was visible on the card.

### Change

`RGDCard.tsx` renders a `<p class="rgd-card__error-hint">` when `state === 'error'` and a reason/message is available. Example:

```
InvalidResourceGraph: failed to build dependency graph: references unknown identifiers: [j…
```

- Truncated at 80 characters with ellipsis
- `title` attribute carries the full message for desktop hover / screen reader
- Color: `var(--color-status-error)` — no hardcoded hex
- `buildErrorHint(reason, message)` is exported for unit testing

### Tests

- 6 unit tests for `buildErrorHint` — truncation boundaries, empty inputs, combined format
- 2 component tests for hint rendering (error state shows hint, ready state does not)
- E2E journey `056-rgd-status-tooltip.spec.ts` (4 steps): chunk-8
- All 1177 unit tests pass