### PR TITLE
fix(cache): flush all entries on context switch — prevent stale cluster data (spec 057)

### DIFF
--- a/.specify/specs/057-cache-context-invalidation/spec.md
+++ b/.specify/specs/057-cache-context-invalidation/spec.md
@@ -1,0 +1,68 @@
+# Feature Specification: Cache Flush on Context Switch
+
+**Feature Branch**: `057-cache-context-invalidation`
+**Created**: 2026-03-28
+**Status**: In Progress
+
+---
+
+## Context
+
+The response cache (spec 052) caches API responses with TTLs:
+- RGD list/detail: 30s
+- Instance list: 10s
+- Capabilities: 5 minutes
+- Graph revisions: 30s
+
+When a user switches from cluster-A to cluster-B via the context switcher,
+the `ClientFactory.SwitchContext()` reloads the dynamic/discovery clients.
+However, the response cache was not flushed on context switch — meaning
+the next request after switching could return a cached response from the
+**previous cluster** for up to 5 minutes (capabilities TTL).
+
+This is particularly problematic for:
+- `/kro/capabilities` — cluster-A may have GraphRevisions, cluster-B may not
+- `/rgds` — shows cluster-A's RGDs on cluster-B
+- `/kro/graph-revisions` — completely wrong cluster
+
+## Fix
+
+Add a `Flush()` method to `ResponseCache` that atomically clears all entries
+(regardless of expiry). Register it as a `ContextSwitchHook` in `server.go`
+so it fires immediately after every successful context switch.
+
+`ClientFactory.RegisterContextSwitchHook(rc.Flush)` — already has the hook
+infrastructure for MetricsDiscoverer; reuse it for cache invalidation.
+
+---
+
+## Requirements
+
+### FR-001: Flush() method on ResponseCache
+
+`internal/cache/cache.go` MUST add a `Flush()` method that:
+- Acquires the write lock
+- Replaces the entries map with a new empty map (GC-friendly)
+- Returns immediately (synchronous, O(1) amortized via map replacement)
+
+### FR-002: Cache flushed on context switch
+
+`internal/server/server.go` MUST call `factory.RegisterContextSwitchHook(rc.Flush)`
+after creating the response cache singleton. This ensures every `POST
+/api/v1/contexts/switch` that succeeds causes a full cache flush before the
+200 response is returned.
+
+### FR-003: Test coverage
+
+- Unit test in `cache_test.go`: Flush() removes all entries including non-expired ones
+- `go test -race ./internal/cache/...` must pass
+
+---
+
+## Acceptance Criteria
+
+- [ ] `ResponseCache.Flush()` method added
+- [ ] `factory.RegisterContextSwitchHook(rc.Flush)` called in server.go
+- [ ] Unit test for Flush() including non-expired entries
+- [ ] `go vet` and `go test -race` pass
+- [ ] No frontend changes needed (flush happens server-side on switch)

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -112,6 +112,16 @@ func (c *ResponseCache) InvalidatePrefix(prefix string) int {
 	return count
 }
 
+// Flush removes ALL entries from the cache regardless of expiry.
+// Call when the cluster context changes so that stale responses from the
+// previous cluster are not served on the new one.
+// Spec: .specify/specs/057-cache-context-invalidation/spec.md
+func (c *ResponseCache) Flush() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = make(map[string]*entry)
+}
+
 // Size returns the number of entries currently in the cache (including expired ones).
 func (c *ResponseCache) Size() int {
 	c.mu.RLock()

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -94,6 +94,42 @@ func TestResponseCache_Purge(t *testing.T) {
 	assert.Equal(t, 1, c.Size())
 }
 
+// TestResponseCache_Flush verifies that Flush removes ALL entries including
+// non-expired ones (spec 057-cache-context-invalidation FR-001).
+func TestResponseCache_Flush(t *testing.T) {
+	c := New()
+	c.set("a", []byte("a"), "application/json", 200, time.Minute)
+	c.set("b", []byte("b"), "application/json", 200, time.Minute)
+	c.set("c", []byte("c"), "application/json", 200, time.Minute)
+	require.Equal(t, 3, c.Size(), "setup: 3 entries before flush")
+
+	c.Flush()
+
+	assert.Equal(t, 0, c.Size(), "all entries removed by Flush")
+
+	// Verify entries are gone on get
+	_, hit := c.get("a")
+	assert.False(t, hit, "entry 'a' should be absent after Flush")
+}
+
+// TestResponseCache_Flush_ConcurrentSafety ensures Flush is race-free.
+func TestResponseCache_Flush_ConcurrentSafety(t *testing.T) {
+	c := New()
+	for i := 0; i < 10; i++ {
+		c.set(string(rune('a'+i)), []byte("v"), "application/json", 200, time.Minute)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		c.Flush()
+		close(done)
+	}()
+	// Concurrent get while flush is in progress
+	c.get("a")
+	<-done
+	// No panic = test passes (go test -race verifies data-race freedom)
+}
+
 // ── Integration tests for Middleware ──────────────────────────────────────────
 
 func TestMiddleware_CachesOnMiss(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -105,12 +105,18 @@ func NewRouter(factory *k8sclient.ClientFactory) (chi.Router, error) {
 			// Response cache (spec 052-response-cache).
 			// Singleton shared across all cacheable routes.
 			// Purge expired entries every 2 minutes to prevent unbounded growth.
+			// Flush (purge ALL) on context switch — prevents stale entries from the
+			// previous cluster being served on the new cluster (spec 057).
 			rc := responsecache.New()
 			go func() {
 				for range time.Tick(2 * time.Minute) {
 					rc.Purge()
 				}
 			}()
+			// Register a hook so every context switch immediately flushes the entire cache.
+			// This ensures that after switching from cluster-A to cluster-B, the next request
+			// always hits the new cluster and not a cached response from cluster-A.
+			factory.RegisterContextSwitchHook(rc.Flush)
 
 			// Cache TTLs per spec:
 			//   RGD list/detail:   30s  — rarely changes mid-session

--- a/test/e2e/journeys/057-cache-context-invalidation.spec.ts
+++ b/test/e2e/journeys/057-cache-context-invalidation.spec.ts
@@ -1,0 +1,91 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Journey 057: Cache Flush on Context Switch
+ *
+ * Spec: .specify/specs/057-cache-context-invalidation/spec.md
+ *
+ * Verifies:
+ *   A) GET /api/v1/kro/capabilities returns X-Cache: MISS on first request
+ *   B) GET /api/v1/kro/capabilities returns X-Cache: HIT on second request (cached)
+ *   C) After context switch (POST /api/v1/contexts/switch), next capabilities
+ *      request returns X-Cache: MISS (cache was flushed by context switch)
+ *
+ * Note: Step C runs a context switch to the SAME context (same cluster).
+ * The cache should still flush — the flush logic doesn't inspect whether the
+ * target context is different from the current one. This is the correct
+ * behavior: any switch event flushes.
+ *
+ * Cluster pre-conditions:
+ * - kind cluster running kro >= v0.8.0
+ * - kro-ui binary running at KRO_UI_BASE_URL
+ */
+
+import { test, expect } from '@playwright/test'
+
+const BASE = process.env.KRO_UI_BASE_URL || 'http://localhost:40107'
+
+test.describe('Journey 057: Cache flush on context switch', () => {
+
+  // ── A: First request is a cache MISS ────────────────────────────────────────
+
+  test('Step 1: First GET /kro/capabilities returns X-Cache: MISS', async ({ page }) => {
+    // Force a miss by using ?refresh=true (bypasses cache and populates it)
+    const res = await page.request.get(`${BASE}/api/v1/kro/capabilities?refresh=true`)
+    expect(res.status()).toBe(200)
+    // ?refresh=true always bypasses cache — X-Cache should be MISS
+    expect(res.headers()['x-cache']).toBe('MISS')
+  })
+
+  // ── B: Second request hits the cache ────────────────────────────────────────
+
+  test('Step 2: Second GET /kro/capabilities returns X-Cache: HIT (cached)', async ({ page }) => {
+    // First, ensure the cache is populated
+    await page.request.get(`${BASE}/api/v1/kro/capabilities`)
+    // Second request should be a cache hit
+    const res = await page.request.get(`${BASE}/api/v1/kro/capabilities`)
+    expect(res.status()).toBe(200)
+    expect(res.headers()['x-cache']).toBe('HIT')
+  })
+
+  // ── C: Context switch flushes the cache ─────────────────────────────────────
+
+  test('Step 3: After context switch, GET /kro/capabilities returns X-Cache: MISS', async ({ page }) => {
+    // First populate the cache
+    await page.request.get(`${BASE}/api/v1/kro/capabilities`)
+    const hitRes = await page.request.get(`${BASE}/api/v1/kro/capabilities`)
+    expect(hitRes.headers()['x-cache']).toBe('HIT')
+
+    // Get current context name to switch to the same context
+    const ctxRes = await page.request.get(`${BASE}/api/v1/contexts`)
+    expect(ctxRes.status()).toBe(200)
+    const ctxData = await ctxRes.json()
+    const activeCtx = ctxData.active as string
+    expect(typeof activeCtx).toBe('string')
+    expect(activeCtx.length).toBeGreaterThan(0)
+
+    // Perform context switch (to the same context — still flushes the cache)
+    const switchRes = await page.request.post(`${BASE}/api/v1/contexts/switch`, {
+      data: { context: activeCtx },
+      headers: { 'Content-Type': 'application/json' },
+    })
+    expect(switchRes.status()).toBe(200)
+
+    // Cache should now be flushed — next request is a MISS
+    const missRes = await page.request.get(`${BASE}/api/v1/kro/capabilities`)
+    expect(missRes.status()).toBe(200)
+    expect(missRes.headers()['x-cache']).toBe('MISS')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes a cache correctness bug: after switching kubeconfig contexts, the response cache was not flushed, allowing stale responses from the previous cluster to be served for up to 5 minutes (capabilities TTL).

### Root Cause

The response cache (spec 052) caches `/kro/capabilities` for 5 minutes. When a user switches from cluster-A to cluster-B, the cache still contains cluster-A's capabilities, RGD list, and instance list. The next request returns cluster-A data without ever hitting cluster-B.

### Fix

1. **`ResponseCache.Flush()`** (`internal/cache/cache.go`) — new method that atomically clears all entries by replacing the entries map (GC-friendly, O(1))

2. **`factory.RegisterContextSwitchHook(rc.Flush)`** (`internal/server/server.go`) — registers the flush as a context switch hook. `ClientFactory.RegisterContextSwitchHook` already existed (used by MetricsDiscoverer); we reuse the same infrastructure.

### Behavior after fix

```
GET /kro/capabilities   → X-Cache: HIT  (fast path from cache)
POST /contexts/switch   → 200 OK        (rc.Flush() called as hook)
GET /kro/capabilities   → X-Cache: MISS (cache was flushed, hits new cluster)
```

### Tests

- `TestResponseCache_Flush` — verifies all non-expired entries are removed
- `TestResponseCache_Flush_ConcurrentSafety` — no data races under `go test -race`
- E2E journey `057-cache-context-invalidation.spec.ts` (3 steps): verifies MISS→HIT→switch→MISS flow; chunk-8