### PR TITLE
feat(web): clickable OverviewHealthBar chips — filter Overview by health state (spec 060)

### DIFF
--- a/.specify/specs/060-health-filter/spec.md
+++ b/.specify/specs/060-health-filter/spec.md
@@ -1,0 +1,26 @@
+# Feature Specification: OverviewHealthBar Clickable Filter
+
+**Feature Branch**: `060-namespace-overview-filter`
+**Created**: 2026-03-28
+**Status**: In Progress
+
+## Context
+
+The OverviewHealthBar (spec 055) shows aggregate health counts (e.g. "3 reconciling").
+When an operator sees "3 reconciling", they need to scroll 27 RGD cards to find which
+3 RGDs have reconciling instances. The chips should be clickable to filter the grid.
+
+## Design
+
+Clicking a chip filters the card grid to show only RGDs with instances in that state.
+Clicking the active chip clears the filter.
+The count display shows "N of M" and a × clear button.
+
+## Acceptance criteria
+
+- [ ] OverviewHealthBar chips become buttons when onFilter is provided
+- [ ] Active chip has --active modifier class (filled background)
+- [ ] Clicking active chip clears filter
+- [ ] Card grid shows only matching RGDs when filter active
+- [ ] × button clears the filter
+- [ ] `tsc --noEmit` clean

--- a/test/e2e/journeys/060-health-filter.spec.ts
+++ b/test/e2e/journeys/060-health-filter.spec.ts
@@ -1,0 +1,121 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Journey 060: OverviewHealthBar clickable filter
+ *
+ * Spec: .specify/specs/060-health-filter/spec.md
+ *
+ * Verifies:
+ *   A) OverviewHealthBar chips are rendered as buttons (clickable)
+ *   B) Clicking a chip filters the card grid
+ *   C) A clear filter button appears when filter is active
+ *   D) Clicking the × button restores all cards
+ */
+
+import { test, expect } from '@playwright/test'
+
+const BASE = process.env.KRO_UI_BASE_URL || 'http://localhost:40107'
+
+test.describe('Journey 060: OverviewHealthBar clickable filter', () => {
+
+  // ── A: Chips are buttons ──────────────────────────────────────────────────────
+
+  test('Step 1: OverviewHealthBar chips are rendered as buttons', async ({ page }) => {
+    await page.goto(BASE)
+    await page.waitForSelector('[data-testid="overview-health-bar"]', { timeout: 20000 })
+
+    const chips = page.locator('.overview-health-bar__chip--clickable')
+    const count = await chips.count()
+    expect(count).toBeGreaterThan(0)
+
+    // All clickable chips should be <button> elements
+    for (let i = 0; i < Math.min(count, 3); i++) {
+      const tag = await chips.nth(i).evaluate((el) => el.tagName.toLowerCase())
+      expect(tag).toBe('button')
+    }
+  })
+
+  // ── B: Clicking a chip filters cards ─────────────────────────────────────────
+
+  test('Step 2: Clicking a health chip filters the RGD card grid', async ({ page }) => {
+    await page.goto(BASE)
+    await page.waitForSelector('[data-testid="overview-health-bar"]', { timeout: 20000 })
+    await page.waitForSelector('[data-testid^="rgd-card-"]', { timeout: 10000 })
+
+    const allCards = page.locator('[data-testid^="rgd-card-"]')
+    const initialCount = await allCards.count()
+
+    // Find a chip with a known filter state (e.g. "ready")
+    const readyChip = page.locator('[data-testid="health-filter-ready"]')
+    if (await readyChip.count() === 0) {
+      // No ready chip visible — skip test
+      return
+    }
+
+    await readyChip.click()
+
+    // Wait for grid to update — count should change (less or equal)
+    await page.waitForFunction(
+      () => {
+        const cards = document.querySelectorAll('[data-testid^="rgd-card-"]')
+        return cards.length > 0
+      },
+      { timeout: 5000 }
+    )
+
+    const filteredCount = await allCards.count()
+    // Filtered grid should have fewer or equal cards
+    expect(filteredCount).toBeLessThanOrEqual(initialCount)
+
+    // aria-pressed should be true on the active chip
+    const pressed = await readyChip.getAttribute('aria-pressed')
+    expect(pressed).toBe('true')
+  })
+
+  // ── C+D: Clear filter button ──────────────────────────────────────────────────
+
+  test('Step 3: Clear filter button restores all cards', async ({ page }) => {
+    await page.goto(BASE)
+    await page.waitForSelector('[data-testid="overview-health-bar"]', { timeout: 20000 })
+    await page.waitForSelector('[data-testid^="rgd-card-"]', { timeout: 10000 })
+
+    const allCards = page.locator('[data-testid^="rgd-card-"]')
+    const initialCount = await allCards.count()
+
+    // Click any available chip to activate filter
+    const anyChip = page.locator('.overview-health-bar__chip--clickable').first()
+    await anyChip.click()
+
+    // Clear filter button should appear
+    const clearBtn = page.locator('[data-testid="clear-health-filter"]')
+    await expect(clearBtn).toBeVisible({ timeout: 3000 })
+
+    // Click clear
+    await clearBtn.click()
+
+    // Grid should restore to initial count
+    await page.waitForFunction(
+      (expected: number) => {
+        const cards = document.querySelectorAll('[data-testid^="rgd-card-"]')
+        return cards.length >= expected
+      },
+      initialCount,
+      { timeout: 5000 }
+    )
+
+    const restoredCount = await allCards.count()
+    expect(restoredCount).toBe(initialCount)
+  })
+})

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -130,10 +130,9 @@ export default defineConfig({
       fullyParallel: true,
     },
     {
-      // chunk-8 covers journeys added in specs 051–056
-      // (instance diff, response cache, multi-version kro, ux-gaps, overview health, rgd error hint)
+      // chunk-8 covers journeys added in specs 051–060
       name: 'chunk-8',
-      testMatch: /(051|052|053|054|055|056)-.*\.spec\.ts/,
+      testMatch: /(051|052|053|054|055|056|057|058|059|060)-.*\.spec\.ts/,
       ...PARALLEL_OPTS,
       workers: 4,
       fullyParallel: true,

--- a/web/src/components/OverviewHealthBar.css
+++ b/web/src/components/OverviewHealthBar.css
@@ -1,5 +1,6 @@
 /* OverviewHealthBar — aggregate instance health summary for Overview page.
  * Spec: .specify/specs/055-overview-health-summary/spec.md
+ * Filter interaction: spec .specify/specs/060-health-filter/spec.md
  */
 
 .overview-health-bar {
@@ -19,6 +20,25 @@
   border-radius: 10px;
   border: 1px solid var(--color-border);
   white-space: nowrap;
+  /* Reset button styles when rendered as <button> */
+  background: none;
+  font-family: inherit;
+  line-height: inherit;
+}
+
+/* Clickable chips show pointer cursor and hover affordance */
+.overview-health-bar__chip--clickable {
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.overview-health-bar__chip--clickable:hover {
+  opacity: 0.8;
+}
+
+/* Active (selected) chips get a filled background */
+.overview-health-bar__chip--active {
+  opacity: 1 !important;
 }
 
 .overview-health-bar__chip--ready {
@@ -26,9 +46,19 @@
   border-color: var(--color-alive);
 }
 
+.overview-health-bar__chip--ready.overview-health-bar__chip--active {
+  background: var(--color-alive);
+  color: var(--color-bg);
+}
+
 .overview-health-bar__chip--reconciling {
   color: var(--color-reconciling);
   border-color: var(--color-reconciling);
+}
+
+.overview-health-bar__chip--reconciling.overview-health-bar__chip--active {
+  background: var(--color-reconciling);
+  color: var(--color-bg);
 }
 
 .overview-health-bar__chip--degraded {
@@ -36,9 +66,19 @@
   border-color: var(--color-status-degraded);
 }
 
+.overview-health-bar__chip--degraded.overview-health-bar__chip--active {
+  background: var(--color-status-degraded);
+  color: var(--color-bg);
+}
+
 .overview-health-bar__chip--error {
   color: var(--color-status-error);
   border-color: var(--color-status-error);
+}
+
+.overview-health-bar__chip--error.overview-health-bar__chip--active {
+  background: var(--color-status-error);
+  color: var(--color-bg);
 }
 
 .overview-health-bar__chip--pending {
@@ -46,9 +86,19 @@
   border-color: var(--color-status-pending);
 }
 
+.overview-health-bar__chip--pending.overview-health-bar__chip--active {
+  background: var(--color-status-pending);
+  color: var(--color-bg);
+}
+
 .overview-health-bar__chip--empty {
   color: var(--color-text-faint);
   border-color: var(--color-border-subtle);
+}
+
+.overview-health-bar__chip--empty.overview-health-bar__chip--active {
+  background: var(--color-border-subtle);
+  color: var(--color-text);
 }
 
 /* ── Partial load indicator ────────────────────────────────────────────────── */

--- a/web/src/components/OverviewHealthBar.tsx
+++ b/web/src/components/OverviewHealthBar.tsx
@@ -3,16 +3,28 @@
 // Consumes the already-fetched healthSummaries map from Home.tsx
 // (no additional API calls).
 //
+// Chips are clickable when onFilter is provided — clicking a chip filters the
+// Overview card grid to show only RGDs with instances in that health state.
+// Clicking the active chip clears the filter.
+//
 // Spec: .specify/specs/055-overview-health-summary/spec.md
+// Filter interaction: spec .specify/specs/060-health-filter/spec.md
 
 import type { HealthSummary } from '@/lib/format'
 import './OverviewHealthBar.css'
+
+/** Health state keys that can be used as filter values. */
+export type HealthFilterState = 'ready' | 'reconciling' | 'degraded' | 'error' | 'pending' | 'noInstances'
 
 interface OverviewHealthBarProps {
   /** Map from rgdName → HealthSummary. Populated progressively as background fetches resolve. */
   summaries: Map<string, HealthSummary>
   /** Total RGD count — used to show "M of N RGDs loaded" while loading */
   totalRGDs: number
+  /** Currently active filter state — chip is highlighted when set. */
+  activeFilter?: HealthFilterState | null
+  /** Called when a chip is clicked. Passes null to clear. */
+  onFilter?: (state: HealthFilterState | null) => void
 }
 
 /**
@@ -45,7 +57,7 @@ export function aggregateSummaries(summaries: Map<string, HealthSummary>): {
   return { ready, reconciling, degraded, error, pending, noInstances }
 }
 
-export default function OverviewHealthBar({ summaries, totalRGDs }: OverviewHealthBarProps) {
+export default function OverviewHealthBar({ summaries, totalRGDs, activeFilter, onFilter }: OverviewHealthBarProps) {
   // Don't render until we have at least some summaries
   if (summaries.size === 0) return null
 
@@ -54,47 +66,54 @@ export default function OverviewHealthBar({ summaries, totalRGDs }: OverviewHeal
 
   const isPartialLoad = summaries.size < totalRGDs
 
+  /** Renders one chip — as a button when onFilter is provided, span otherwise. */
+  function Chip({ state, count, label }: { state: HealthFilterState; count: number; label: string }) {
+    const isActive = activeFilter === state
+    const className = [
+      'overview-health-bar__chip',
+      `overview-health-bar__chip--${state === 'noInstances' ? 'empty' : state}`,
+      isActive ? 'overview-health-bar__chip--active' : '',
+      onFilter ? 'overview-health-bar__chip--clickable' : '',
+    ].filter(Boolean).join(' ')
+
+    if (onFilter) {
+      return (
+        <button
+          type="button"
+          className={className}
+          onClick={() => onFilter(isActive ? null : state)}
+          aria-pressed={isActive}
+          title={isActive ? `Clear filter: ${label}` : `Filter to RGDs with ${label} instances`}
+          data-testid={`health-filter-${state}`}
+        >
+          {count} {label}
+        </button>
+      )
+    }
+    return (
+      <span className={className}>
+        {count} {label}
+      </span>
+    )
+  }
+
   return (
     <div
       className="overview-health-bar"
       data-testid="overview-health-bar"
       aria-label="Fleet instance health summary"
-      role="status"
+      role={onFilter ? 'group' : 'status'}
     >
       {total > 0 && (
         <>
-          {ready > 0 && (
-            <span className="overview-health-bar__chip overview-health-bar__chip--ready">
-              {ready} ready
-            </span>
-          )}
-          {reconciling > 0 && (
-            <span className="overview-health-bar__chip overview-health-bar__chip--reconciling">
-              {reconciling} reconciling
-            </span>
-          )}
-          {degraded > 0 && (
-            <span className="overview-health-bar__chip overview-health-bar__chip--degraded">
-              {degraded} degraded
-            </span>
-          )}
-          {error > 0 && (
-            <span className="overview-health-bar__chip overview-health-bar__chip--error">
-              {error} error
-            </span>
-          )}
-          {pending > 0 && (
-            <span className="overview-health-bar__chip overview-health-bar__chip--pending">
-              {pending} pending
-            </span>
-          )}
+          {ready > 0 && <Chip state="ready" count={ready} label="ready" />}
+          {reconciling > 0 && <Chip state="reconciling" count={reconciling} label="reconciling" />}
+          {degraded > 0 && <Chip state="degraded" count={degraded} label="degraded" />}
+          {error > 0 && <Chip state="error" count={error} label="error" />}
+          {pending > 0 && <Chip state="pending" count={pending} label="pending" />}
         </>
       )}
-      {noInstances > 0 && (
-        <span className="overview-health-bar__chip overview-health-bar__chip--empty">
-          {noInstances} no instances
-        </span>
-      )}
+      {noInstances > 0 && <Chip state="noInstances" count={noInstances} label="no instances" />}
       {isPartialLoad && (
         <span className="overview-health-bar__loading" aria-live="polite">
           ({summaries.size} of {totalRGDs} loaded)

--- a/web/src/pages/Home.css
+++ b/web/src/pages/Home.css
@@ -38,6 +38,26 @@
   font-size: 13px;
   color: var(--color-text-muted);
   white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* × button to clear the health filter (spec 060) */
+.home__clear-filter {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 2px;
+  border-radius: var(--radius-sm);
+}
+
+.home__clear-filter:hover {
+  color: var(--color-text);
+  background: var(--color-bg-subtle);
 }
 
 /* VirtualGrid container — fills viewport below header */

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -21,6 +21,7 @@ import SearchBar from '@/components/SearchBar'
 import SkeletonCard from '@/components/SkeletonCard'
 import VirtualGrid from '@/components/VirtualGrid'
 import OverviewHealthBar from '@/components/OverviewHealthBar'
+import type { HealthFilterState } from '@/components/OverviewHealthBar'
 import './Home.css'
 
 // RGDCard renders at a fixed ~130px height (header + meta + actions, no-wrap text).
@@ -33,6 +34,10 @@ export default function Home() {
   const [error, setError] = useState<string | null>(null)
   const [query, setQuery] = useState('')
   const debouncedQuery = useDebounce(query, 300)
+
+  // Health filter — set by clicking OverviewHealthBar chips (spec 060-health-filter).
+  // When set, the card grid shows only RGDs with instances in that health state.
+  const [healthFilter, setHealthFilter] = useState<HealthFilterState | null>(null)
 
   // FR-007: Map from rgdName → terminating instance count.
   // Fetched in the background after the RGD list loads; absent = not yet fetched.
@@ -101,10 +106,23 @@ export default function Home() {
 
   // Client-side filter — reuses matchesSearch from catalog lib (no reimplementation).
   // Runs only after the debounce fires, not on every keystroke.
-  const filteredItems = useMemo(
-    () => items.filter((rgd) => matchesSearch(rgd, debouncedQuery)),
-    [items, debouncedQuery],
-  )
+  // Also applies the healthFilter when a chip is active.
+  const filteredItems = useMemo(() => {
+    let result = items.filter((rgd) => matchesSearch(rgd, debouncedQuery))
+
+    // Health filter (spec 060): show only RGDs with instances in the selected state.
+    if (healthFilter !== null) {
+      result = result.filter((rgd) => {
+        const name = extractRGDName(rgd)
+        const summary = healthSummaries.get(name)
+        if (!summary) return false // not yet loaded — hide until resolved
+        if (healthFilter === 'noInstances') return summary.total === 0
+        return (summary[healthFilter as keyof typeof summary] as number) > 0
+      })
+    }
+
+    return result
+  }, [items, debouncedQuery, healthFilter, healthSummaries])
 
   const emptyState =
     debouncedQuery.trim() !== '' ? (
@@ -176,6 +194,17 @@ export default function Home() {
             {!isLoading && items.length > 0 && (
               <span className="home__count">
                 {filteredItems.length} of {items.length}
+                {healthFilter !== null && (
+                  <button
+                    type="button"
+                    className="home__clear-filter"
+                    onClick={() => setHealthFilter(null)}
+                    title="Clear health filter"
+                    data-testid="clear-health-filter"
+                  >
+                    ×
+                  </button>
+                )}
               </span>
             )}
           </div>
@@ -200,7 +229,12 @@ export default function Home() {
       )}
 
       {!isLoading && error === null && healthSummaries.size > 0 && (
-        <OverviewHealthBar summaries={healthSummaries} totalRGDs={items.length} />
+        <OverviewHealthBar
+          summaries={healthSummaries}
+          totalRGDs={items.length}
+          activeFilter={healthFilter}
+          onFilter={(state) => { setHealthFilter(state); }}
+        />
       )}
 
       {!isLoading && error === null && (


### PR DESCRIPTION
## Summary

Makes the OverviewHealthBar chips (spec 055) interactive. Clicking a chip filters the Overview card grid to show only RGDs that have instances in that health state.

### UX flow

1. Overview loads, OverviewHealthBar shows: **[36 ready] [3 reconciling] [5 no instances]**
2. Operator clicks **[3 reconciling]** → grid shows only 3 RGDs with reconciling instances
3. Count badge shows "3 of 27" with a **×** button
4. Clicking × or clicking the active chip again restores all 27 cards

### Changes

**`OverviewHealthBar.tsx`**:
- Adds `activeFilter?: HealthFilterState | null` and `onFilter?` callback props
- Chips render as `<button>` elements when `onFilter` is provided
- Active chip gets `--active` CSS modifier (filled background)
- `aria-pressed` reflects active state

**`OverviewHealthBar.css`**: `--clickable` cursor/hover; `--active` filled chip styles

**`Home.tsx`**:
- `healthFilter` state (null = no filter)
- `filteredItems` useMemo: combines text search + health filter
- `OverviewHealthBar` receives `activeFilter` + `onFilter` props
- Count badge shows × clear button when filter is active

### Tests

- 1177 existing tests pass
- `tsc --noEmit` clean
- E2E journey `060-health-filter.spec.ts` (3 steps): chunk-8