### PR TITLE
chore(helm): security context hardening — runAsNonRoot, readOnlyRootFilesystem, drop ALL (spec 061)

### DIFF
--- a/.specify/specs/061-helm-security/spec.md
+++ b/.specify/specs/061-helm-security/spec.md
@@ -1,0 +1,23 @@
+# Feature Specification: Helm Chart Security Hardening
+
+**Feature Branch**: `061-helm-security`
+**Created**: 2026-03-28
+**Status**: In Progress
+
+## Context
+
+The Helm chart was missing Kubernetes security context settings needed for:
+- PodSecurity admission (restricted profile)
+- CIS Kubernetes benchmark compliance
+- Defense-in-depth for a read-only dashboard
+
+## Changes
+
+**values.yaml**:
+- `podSecurityContext`: `runAsNonRoot=true`, `runAsUser/Group=65534` (nobody), `seccompProfile=RuntimeDefault`
+- `containerSecurityContext`: `readOnlyRootFilesystem=true`, `allowPrivilegeEscalation=false`, `capabilities.drop=[ALL]`
+
+**deployment.yaml**: Uses `{{- with .Values.podSecurityContext }}` and `{{- with .Values.containerSecurityContext }}` blocks.
+
+The kro-ui binary makes no disk writes at runtime — `readOnlyRootFilesystem=true` is safe.
+The distroless base image ships nobody (UID 65534) — `runAsNonRoot=true` works without modification.

--- a/helm/kro-ui/templates/deployment.yaml
+++ b/helm/kro-ui/templates/deployment.yaml
@@ -15,10 +15,18 @@ spec:
         {{- include "kro-ui.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "kro-ui.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: kro-ui
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             - serve
             - --port={{ .Values.service.port }}

--- a/helm/kro-ui/values.yaml
+++ b/helm/kro-ui/values.yaml
@@ -32,6 +32,30 @@ resources:
     cpu: 200m
     memory: 128Mi
 
+# Pod-level security context.
+# runAsNonRoot=true and a non-zero UID are enforced by default to comply with
+# PodSecurity admission (restricted profile) and CIS Kubernetes benchmarks.
+# The distroless base image ships nobody (UID 65534); override if your cluster
+# requires a specific UID.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  fsGroup: 65534
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level security context.
+# readOnlyRootFilesystem: true — the binary writes nothing to disk at runtime.
+# allowPrivilegeEscalation: false — prevents setuid/setgid attacks.
+# capabilities.drop: [ALL] — drops all Linux capabilities.
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
 # Run mode: "incluster" (default) or "kubeconfig"
 runMode: incluster
 


### PR DESCRIPTION
## Summary

Adds Kubernetes security context settings to the Helm chart for PodSecurity admission (restricted profile) compliance and CIS Kubernetes benchmark alignment.

### Changes

**`helm/kro-ui/values.yaml`** — two new sections:

```yaml
podSecurityContext:
  runAsNonRoot: true
  runAsUser: 65534       # nobody (distroless default)
  runAsGroup: 65534
  fsGroup: 65534
  seccompProfile:
    type: RuntimeDefault

containerSecurityContext:
  readOnlyRootFilesystem: true
  allowPrivilegeEscalation: false
  capabilities:
    drop: [ALL]
```

**`helm/kro-ui/templates/deployment.yaml`** — uses `{{- with .Values.podSecurityContext }}` / `{{- with .Values.containerSecurityContext }}` blocks (override-friendly; set to `{}` to disable).

### Safety

- `readOnlyRootFilesystem: true` is safe — the `kro-ui serve` binary makes zero disk writes at runtime (only reads from embedded `go:embed` FS and serves HTTP)
- `runAsNonRoot: true` / UID 65534 works without modification — the distroless base image ships `nobody` at UID 65534
- `seccompProfile: RuntimeDefault` enables the default seccomp profile without requiring cluster-specific configuration

### Verification

```
helm lint helm/kro-ui/    # 0 failures
helm template kro-ui helm/kro-ui/   # shows securityContext fields in rendered Deployment
```