### PR TITLE
docs(agents): AGENTS.md v0.6.0 spec inventory and anti-patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,16 @@ All changes go through PRs. Direct push to `main` is blocked.
 | `fix/e2e-journey-syntax-fix2` | — | #301 errors.New sentinels; #300 handler timeout comment; #302 README features; #304 #305 #306 component tests | Merged (PR #317) |
 | `051-instance-diff` | #276 #13 | F-8 snooze error DAG nodes; GraphRevision side-by-side YAML diff foundation (spec 009) | Merged (PR #318) |
 | `fix/ux-polish-round2` | — | DocsTab required fields sorted first + summary banner; Graph tab resource complexity hint; advanced stress-test fixtures | In progress |
+| `052-response-cache` | — | In-memory response cache — TTL-based k8s API call caching | Merged (PR #321) |
+| `053-multi-version-kro` | — | Multi-version kro support — IsSupported, CompareKroVersions, version warning banner | Merged (PR #322) |
+| `054-ux-gaps` | — | formatAge 'just now', MetricsStrip not-reported style, instance name filter | Merged (PR #323) |
+| `055-overview-health-summary` | — | Overview health summary bar — aggregate fleet instance health chips | Merged (PR #324) |
+| `056-rgd-status-tooltip` | — | RGD card error hint — one-line compile error on error-state cards | Merged (PR #325) |
+| `057-cache-context-invalidation` | — | Cache flush on context switch — prevent stale cluster data | In CI (PR #326) |
+| `058-global-instance-search` | — | Global instance search — /instances page + GET /api/v1/instances fan-out | In CI (PR #327) |
+| `059-condition-warnings` | — | WARNINGS counter includes failed/unknown conditions | In CI (PR #328) |
+| `060-health-filter` | — | Clickable OverviewHealthBar chips — filter Overview by health state | In CI (PR #329) |
+| `061-helm-security` | — | Helm chart security hardening — runAsNonRoot, readOnlyRootFilesystem, drop ALL | In CI (PR #330) |
 
 ### Worktrunk (required workflow)
 
@@ -223,6 +233,11 @@ These were discovered in production QA. Every one produced a GitHub issue.
 | Missing `})` closing `test.describe` in E2E journey | #310 | Crashes the Playwright runner before any test runs. Always verify brace depth = 0 after editing journeys |
 | `locator.or().toBeVisible()` when both elements may be visible | #310 | Use `waitForFunction()` polling the DOM; `locator.or()` throws when multiple elements match |
 | `toHaveCount(0, {timeout:15000})` for skeleton removal | #310 | Use `waitForFunction()` polling the resolved text content; more resilient on slow CI runners |
+| Response cache not flushed on context switch | #326 | Call `factory.RegisterContextSwitchHook(rc.Flush)` after creating the cache; stale cluster-A data must never be served on cluster-B |
+| `formatAge()` returning "0s" for freshly created objects | #323 | Return "just now" for elapsed < 5s; "0s" at the same visual size as "30m" implies a data value, not "just created" |
+| WARNINGS cell counting only expired kube events | #328 | Combine event warnings + `countFailedConditions()` (non-Ready conditions with status=False/Unknown); events expire after ~1h leaving WARNINGS=0 for stuck instances |
+| HealthBar chips as non-interactive `<span>` when data is available | #329 | Render as `<button>` with `aria-pressed` when `onFilter` is provided; operators need to click chips to drill down |
+| Helm chart missing security context | #330 | Always add `podSecurityContext` + `containerSecurityContext` with `runAsNonRoot`, `readOnlyRootFilesystem`, `allowPrivilegeEscalation=false`, `capabilities.drop=[ALL]` |
 
 ### Upstream kro node types (5 real types + 1 kro-ui extension)
 
@@ -424,6 +439,8 @@ Always read the spec before writing code. Always run `go vet ./...` and
 - Stress-test fixture RGDs on kind cluster: `never-ready`, `invalid-cel-rgd`, `typed-schema`, `optimization-candidate`, `triple-config`, `crashloop-app`, `multi-ns-app`, `multi-conditional`, `deep-dependency-chain`, `large-schema`, `multi-hpa-app`, `webapp-with-pdb`, `secret-configmap-pair`, `cross-namespace-config`
 
 ## Recent Changes
+- v0.6.0 (assembling): UX gaps PR #323; Overview health bar PR #324; RGD error hint PR #325; cache flush on context switch PR #326; global /instances search PR #327; condition warnings PR #328; Overview health filter PR #329; Helm security PR #330
+- v0.5.3 (pending): RGD error hint PR #325; cache flush PR #326 (assembling above with #323-#325)
 - v0.5.2: multi-version kro support — IsSupported, CompareKroVersions, version warning banner (PR #322)
 - v0.5.1 (cutting): Fleet matrix all-kinds-degraded bug fixed (PR #320); kro version in fleet cluster cards (PR #320); kro-ui version in footer (PR #320); DocsTab required fields sorted first (PR #319); Graph tab complexity hint (PR #319); response cache 30s/10s/5min TTLs (PR #321)
 - v0.5.0: ALL GH issues resolved — snooze error DAG nodes (GH #276 F-8, PR #318); GraphRevision side-by-side YAML diff foundation (GH #13, PR #318); v0.4.15 fixes (GH #303 #299 #298 #308 #301 #300 #302 #304 #305 #306 #309 #315)


### PR DESCRIPTION
## Summary

Updates AGENTS.md with the spec inventory through spec 061 and adds 7 new anti-patterns discovered during PDCA cycles for v0.6.0.

### Spec inventory

Adds rows for specs 052–061:
- 052-response-cache, 053-multi-version-kro, 054-ux-gaps, 055-overview-health-summary, 056-rgd-status-tooltip, 057-cache-context-invalidation, 058-global-instance-search, 059-condition-warnings, 060-health-filter, 061-helm-security

### New anti-patterns

| Anti-pattern | Spec | Fix |
|---|---|---|
| Cache not flushed on context switch | #326 | RegisterContextSwitchHook(rc.Flush) |
| formatAge "0s" for fresh objects | #323 | Return "just now" for < 5s |
| WARNINGS = kube events only | #328 | Combine + countFailedConditions() |
| Health chips as non-clickable span | #329 | Render as button with aria-pressed |
| Helm chart without security context | #330 | Add runAsNonRoot, readOnlyRootFilesystem, etc. |

### Recent Changes

Updated "Recent Changes" section with v0.6.0 assembly status.