### PR TITLE
fix(e2e): 009 Step 7 waitForFunction for RGD cards (throttled E2E cluster)

### DIFF
--- a/test/e2e/journeys/009-virtualization.spec.ts
+++ b/test/e2e/journeys/009-virtualization.spec.ts
@@ -139,7 +139,14 @@ test.describe('Journey 009 — RGD list virtualization', () => {
 
   test('Step 7: home page DOM card count equals total fixture RGD count', async ({ page }) => {
     await page.goto(BASE)
-    await expect(page.getByTestId('virtual-grid-items')).toBeVisible()
+
+    // Wait for at least one RGD card to appear — the API call may take
+    // several seconds on a throttled E2E cluster. Using waitForFunction
+    // gives a 15s window; the default toBeVisible() timeout is only 5s.
+    await page.waitForFunction(
+      () => document.querySelectorAll('[data-testid^="rgd-card-"]').length >= 1,
+      { timeout: 15000 }
+    )
 
     // The fixture set installs 14 RGDs (test-app, test-collection, multi-resource,
     // external-ref, cel-functions, chain-parent, chain-child, chain-cycle-a,


### PR DESCRIPTION
## Summary

Journey 009 Step 7 (`home page DOM card count equals total fixture RGD count`) was failing intermittently because it only waited for the virtual grid container (`virtual-grid-items`) to become visible, then immediately counted cards — before the API response had populated the grid.

### Fix

Replaces `expect(page.getByTestId('virtual-grid-items')).toBeVisible()` (5s default timeout) with `page.waitForFunction(cardCount >= 1, { timeout: 15000 })` — waits up to 15s for the first card to appear before proceeding with the count assertion.

This is the same pattern documented in constitution §XIV (E2E standards) for resolving throttling-related flakiness.