### PR TITLE
fix(api): ListAllInstances skip per-RGD Get — extract kind from already-fetched RGD object

### DIFF
--- a/internal/api/handlers/instances_all.go
+++ b/internal/api/handlers/instances_all.go
@@ -29,6 +29,9 @@ import (
 
 	"github.com/rs/zerolog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	k8sclient "github.com/pnz1990/kro-ui/internal/k8s"
 )
 
 // InstanceSummary is a compact representation of one live instance.
@@ -88,11 +91,28 @@ func (h *Handler) ListAllInstances(w http.ResponseWriter, r *http.Request) {
 			rctx, cancel := context.WithTimeout(r.Context(), perRGDAllInstancesTimeout*1_000_000_000)
 			defer cancel()
 
-			gvr, err := h.resolveInstanceGVR(rctx, rgdName)
-			if err != nil {
-				log.Debug().Err(err).Str("rgd", rgdName).Msg("ListAllInstances: skip RGD — cannot resolve GVR")
+			// Extract kind/group/version from the already-fetched RGD object —
+			// avoids a second per-RGD API call that would re-fetch the RGD.
+			// This halves the number of API calls compared to calling resolveInstanceGVR.
+			kind, _, _ := k8sclient.UnstructuredString(rgd.Object, "spec", "schema", "kind")
+			group, _, _ := k8sclient.UnstructuredString(rgd.Object, "spec", "schema", "group")
+			version, _, _ := k8sclient.UnstructuredString(rgd.Object, "spec", "schema", "apiVersion")
+			if kind == "" {
+				log.Debug().Str("rgd", rgdName).Msg("ListAllInstances: skip RGD — no schema kind")
 				return
 			}
+			if group == "" {
+				group = k8sclient.KroGroup
+			}
+			if version == "" {
+				version = "v1alpha1"
+			}
+
+			plural, err := k8sclient.DiscoverPlural(h.factory, group, version, kind)
+			if err != nil {
+				plural = strings.ToLower(kind) + "s"
+			}
+			gvr := schema.GroupVersionResource{Group: group, Version: version, Resource: plural}
 
 			list, err := h.factory.Dynamic().Resource(gvr).List(rctx, metav1.ListOptions{})
 			if err != nil {


### PR DESCRIPTION
## Summary

`GET /api/v1/instances` (spec 058) was returning empty results on throttled clusters because `resolveInstanceGVR` made a second per-RGD API call (`Get(rgdName)`) even though the RGD data was already available from the initial `List`.

### Root cause

`ListAllInstances` first calls `List` to get all 27 RGDs. Then, for each RGD, it called `resolveInstanceGVR` which:
1. Made another `Get(rgdGVR, rgdName)` — redundant, data already in `rgdList.Items[i]`  
2. Ran `DiscoverPlural(group, version, kind)`

This meant 27 `List` calls + 27 `Get` calls = 54 total API calls in parallel. On a cluster with client-side throttling (1-2s delays), all of them expired within the 2s per-RGD timeout.

### Fix

Extract kind/group/version directly from `rgd.Object` (the already-fetched RGD), skipping the redundant `Get`. Only `DiscoverPlural` remains as a network call per RGD.

Result: 27 `List` calls → 1 (the initial List) + 27 `DiscoverPlural` calls = 28 total instead of 54.

### Tested

Demo cluster with 27 RGDs and client-side throttling (1-2s delays): now returns 80 instances correctly.