### PR TITLE
fix(e2e): 007 Step 7 wait for page stabilization between context switches, 120s timeout

### DIFF
--- a/test/e2e/journeys/007-context-switcher.spec.ts
+++ b/test/e2e/journeys/007-context-switcher.spec.ts
@@ -187,7 +187,7 @@ test.describe('Journey 007 — Context Switcher', () => {
   test('Step 7: all fixture RGD cards visible after switching context and back', async ({ page }) => {
     // Extend per-test timeout — the double context switch + cache flush +
     // throttled API reload can take longer than the default 60s test timeout.
-    test.setTimeout(90_000)
+    test.setTimeout(120_000)
 
     await page.goto(BASE)
 
@@ -197,6 +197,16 @@ test.describe('Journey 007 — Context Switcher', () => {
       .locator('[role="option"]', { hasText: ALT_CONTEXT })
       .click()
     await expect(page.getByTestId('context-dropdown')).not.toBeVisible({ timeout: 10000 })
+
+    // Wait for the page to stabilize after the context switch + cache flush.
+    // The <Outlet key={activeContext}> remount triggers a full page reload.
+    // On throttled E2E clusters, the new context's RGD list may take >10s.
+    // We wait for the top bar to render (it's the first thing that appears)
+    // before attempting the second context switch click.
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="context-switcher-btn"]') !== null,
+      { timeout: 30000 }
+    )
 
     // Switch back to primary
     await page.getByTestId('context-switcher-btn').click()


### PR DESCRIPTION
## Summary

Follow-up to #335. The 90s fix was not enough — the test was still failing because `locator.click()` for the SECOND context switch was timing out.

### Root cause

After the first context switch:
1. `<Outlet key={activeContext}>` remounts the page
2. The cache is flushed (spec 057) — a new RGD list fetch starts
3. The page is temporarily unstable during this reload
4. When Playwright tries to `click()` the `context-switcher-btn` for the SECOND switch, the element might not be actionable yet (being re-rendered), causing `locator.click` to block until the global timeout

### Fix

Adds `page.waitForFunction(() => context-switcher-btn exists)` between the two context switches, ensuring the page has stabilized before clicking. Also increases timeout to 120s to accommodate the extra stabilization wait.

Total worst-case: 2s load + 10s switch1 + 30s stabilize + 10s switch2 + 45s cards = 97s < 120s