### PR TITLE
fix(e2e): 007 Step 7 waitForFunction for dropdown options + 150s timeout

### DIFF
--- a/test/e2e/journeys/007-context-switcher.spec.ts
+++ b/test/e2e/journeys/007-context-switcher.spec.ts
@@ -187,33 +187,60 @@ test.describe('Journey 007 — Context Switcher', () => {
   test('Step 7: all fixture RGD cards visible after switching context and back', async ({ page }) => {
     // Extend per-test timeout — the double context switch + cache flush +
     // throttled API reload can take longer than the default 60s test timeout.
-    test.setTimeout(120_000)
+    test.setTimeout(150_000)
 
     await page.goto(BASE)
 
-    // Switch to alt context
+    // Switch to alt context — wait for the option to be visible (context list loads from API)
     await page.getByTestId('context-switcher-btn').click()
+    // Wait for the dropdown option to appear — the /contexts API call may be slow
+    await page.waitForFunction(
+      (ctx: string) => {
+        const dropdown = document.querySelector('[data-testid="context-dropdown"]')
+        if (!dropdown) return false
+        const options = Array.from(dropdown.querySelectorAll('[role="option"]'))
+        return options.some((o) => o.textContent?.includes(ctx))
+      },
+      ALT_CONTEXT,
+      { timeout: 30000 }
+    )
     await page.getByTestId('context-dropdown')
       .locator('[role="option"]', { hasText: ALT_CONTEXT })
       .click()
     await expect(page.getByTestId('context-dropdown')).not.toBeVisible({ timeout: 10000 })
 
     // Wait for the page to stabilize after the context switch + cache flush.
-    // The <Outlet key={activeContext}> remount triggers a full page reload.
-    // On throttled E2E clusters, the new context's RGD list may take >10s.
-    // We wait for the top bar to render (it's the first thing that appears)
-    // before attempting the second context switch click.
     await page.waitForFunction(
       () => document.querySelector('[data-testid="context-switcher-btn"]') !== null,
       { timeout: 30000 }
     )
 
-    // Switch back to primary
+    // Switch back to primary — wait for option before clicking
     await page.getByTestId('context-switcher-btn').click()
+    await page.waitForFunction(
+      (ctx: string) => {
+        const dropdown = document.querySelector('[data-testid="context-dropdown"]')
+        if (!dropdown) return false
+        const options = Array.from(dropdown.querySelectorAll('[role="option"]'))
+        return options.some((o) => o.textContent?.includes(ctx))
+      },
+      PRIMARY_CONTEXT,
+      { timeout: 30000 }
+    )
     await page.getByTestId('context-dropdown')
       .locator('[role="option"]', { hasText: PRIMARY_CONTEXT })
       .click()
     await expect(page.getByTestId('context-dropdown')).not.toBeVisible({ timeout: 10000 })
+
+    // After context switch the cache is flushed (spec 057) — the RGD list is
+    // refetched from the API. On throttled E2E clusters this may take >5s.
+    // Wait for ALL 5 fixture cards at once (not serially) to stay within budget.
+    await page.waitForFunction(
+      (names: string[]) => names.every((n) => document.querySelector(`[data-testid="rgd-card-${n}"]`) !== null),
+      ['test-app', 'test-collection', 'multi-resource', 'external-ref', 'cel-functions'],
+      { timeout: 45000 }
+    )
+  })
 
     // After context switch the cache is flushed (spec 057) — the RGD list is
     // refetched from the API. On throttled E2E clusters this may take >5s.


### PR DESCRIPTION
## Summary

v4 of the 007 Step 7 fix. Previous attempts (v2/v3, PRs #335 #336) still failed because the test timed out while waiting for the dropdown option element to appear, not while waiting for the RGD cards.

### Root cause

After clicking `context-switcher-btn`, the dropdown opens but the context options take time to load from `/api/v1/contexts`. On a heavily throttled E2E cluster (the serial 007 test runs AFTER all parallel tests have exhausted the API server), the options may take >30s to appear.

### Fix

For BOTH context switches:
- Add `page.waitForFunction(() => dropdown has option with text)` before `.click()` the option
- Each wait has 30s timeout
- Test timeout extended to 150s to accommodate all waits

Total worst-case: 2s + 30s(opt1) + 10s(click) + 10s(close) + 30s(stab) + 30s(opt2) + 10s(click) + 10s(close) + 45s(cards) = 167s — exceeds 150s in absolute worst case, but realistic scenario is much shorter.

If this still fails: we will accept this test as reliably flaky under extreme throttling and gate the PR differently.