### PR TITLE
fix(api): Fleet degraded count excludes IN_PROGRESS instances (consistency fix)

### DIFF
--- a/internal/api/handlers/fleet.go
+++ b/internal/api/handlers/fleet.go
@@ -214,12 +214,29 @@ func (h *Handler) summariseContext(parent context.Context, ctx k8sclient.Context
 	return summary
 }
 
-// isInstanceDegraded returns true if the instance has a Ready=False condition.
+// isInstanceDegraded returns true if the instance has a Ready=False condition
+// AND is not in the IN_PROGRESS reconciling state.
+//
+// Background: the 6-state health model distinguishes "reconciling" (IN_PROGRESS)
+// from "degraded" (Ready but child errors). Fleet's degraded count should only
+// surface instances that are genuinely stuck or broken — not instances that are
+// actively being reconciled toward a healthy state.
+//
+// Without this check, never-ready instances (state=IN_PROGRESS, Ready=False)
+// appear as "degraded" in Fleet while appearing as "reconciling" in Overview,
+// creating an inconsistent and confusing UX.
 func isInstanceDegraded(obj map[string]any) bool {
 	status, ok := obj["status"].(map[string]any)
 	if !ok {
 		return false
 	}
+
+	// If kro reports state=IN_PROGRESS the instance is actively reconciling.
+	// It is not degraded — exclude it from the fleet degraded count.
+	if stateVal, _ := status["state"].(string); stateVal == "IN_PROGRESS" {
+		return false
+	}
+
 	conditions, ok := status["conditions"].([]any)
 	if !ok {
 		return false

--- a/internal/api/handlers/fleet_test.go
+++ b/internal/api/handlers/fleet_test.go
@@ -188,3 +188,76 @@ func TestFleetSummary(t *testing.T) {
 		})
 	}
 }
+
+// ── isInstanceDegraded unit tests ─────────────────────────────────────────────
+
+func TestIsInstanceDegraded(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  map[string]any
+		want bool
+	}{
+		{
+			name: "Ready=True → not degraded",
+			obj: map[string]any{
+				"status": map[string]any{
+					"conditions": []any{
+						map[string]any{"type": "Ready", "status": "True"},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Ready=False → degraded",
+			obj: map[string]any{
+				"status": map[string]any{
+					"conditions": []any{
+						map[string]any{"type": "Ready", "status": "False"},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "state=IN_PROGRESS + Ready=False → NOT degraded (reconciling)",
+			obj: map[string]any{
+				"status": map[string]any{
+					"state": "IN_PROGRESS",
+					"conditions": []any{
+						map[string]any{"type": "Ready", "status": "False"},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "state=ACTIVE + Ready=False → degraded",
+			obj: map[string]any{
+				"status": map[string]any{
+					"state": "ACTIVE",
+					"conditions": []any{
+						map[string]any{"type": "Ready", "status": "False"},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no conditions → not degraded",
+			obj:  map[string]any{"status": map[string]any{}},
+			want: false,
+		},
+		{
+			name: "no status → not degraded",
+			obj:  map[string]any{},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isInstanceDegraded(tt.obj)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Bug

Fleet shows **"3 degraded"** while Overview shows **"3 reconciling"** — both referring to the same 3 `never-ready` instances. This inconsistency confuses operators: are the instances broken or just working?

## Root cause

`isInstanceDegraded()` in `fleet.go` only checked `Ready=False`, missing the `status.state` field. The `never-ready` instances have `state=IN_PROGRESS` (actively reconciling) + `Ready=False`. According to the 6-state health model (PR #278), `IN_PROGRESS` → "reconciling", not "degraded".

## Fix

Check `status.state === "IN_PROGRESS"` first. If true, return `false` immediately — the instance is reconciling, not degraded.

## Effect

Before: Fleet `kind-kro-ui-demo`: "3 degraded" (counting never-ready instances)  
After: Fleet `kind-kro-ui-demo`: "0 degraded, 0 issues" (never-ready are reconciling, not degraded)

Fleet and Overview now agree: the 3 never-ready instances are **reconciling**, not degraded.

## Tests

6 unit tests for `isInstanceDegraded` covering: IN_PROGRESS exclusion, ACTIVE inclusion, no conditions, no status.