### PR TITLE
fix(metrics): ACTIVE WATCHES fallback to handler_count_total for kro v0.8.5+

### DIFF
--- a/internal/k8s/metrics.go
+++ b/internal/k8s/metrics.go
@@ -436,6 +436,12 @@ const (
 	metricWorkqueueDepth = "workqueue_depth"
 	// workqueueNameLabel is the label value that identifies the kro workqueue.
 	workqueueNameLabel = `name="dynamic-controller-queue"`
+
+	// kro v0.8.5 renamed watch_count to handler_count_total{type="child"}.
+	// Use this as a fallback when metricWatchCount is not present.
+	// The child handler count approximates active watches: one child informer
+	// per watched resource type.
+	metricHandlerCountChild = `dynamic_controller_handler_count_total{type="child"}`
 )
 
 // parseMetricLine extracts a value from a single Prometheus text line and writes
@@ -463,6 +469,13 @@ func parseMetricLine(line string, result *ControllerMetrics) {
 	switch {
 	case namePart == metricWatchCount:
 		result.WatchCount = &intVal
+
+	case namePart == metricHandlerCountChild:
+		// kro v0.8.5+ fallback: child handler count ≈ active watches.
+		// Only set if the newer metric name wasn't found yet (avoids double-counting).
+		if result.WatchCount == nil {
+			result.WatchCount = &intVal
+		}
 
 	case namePart == metricGVRCount:
 		result.GVRCount = &intVal

--- a/internal/k8s/metrics_test.go
+++ b/internal/k8s/metrics_test.go
@@ -272,6 +272,18 @@ dynamic_controller_gvr_count 2
 workqueue_depth{name="dynamic-controller-queue"} 3
 `
 
+// kro v0.8.5 removed dynamic_controller_watch_count in favour of
+// dynamic_controller_handler_count_total{type="child"}.
+const metricsProxyBodyV085 = `# HELP dynamic_controller_gvr_count GVRs managed
+# TYPE dynamic_controller_gvr_count gauge
+dynamic_controller_gvr_count 22
+# HELP dynamic_controller_handler_count_total Active handler count
+# TYPE dynamic_controller_handler_count_total gauge
+dynamic_controller_handler_count_total{type="child"} 37
+dynamic_controller_handler_count_total{type="parent"} 22
+workqueue_depth{name="dynamic-controller-queue"} 0
+`
+
 func TestScrapeViaProxy(t *testing.T) {
 	int64p := func(v int64) *int64 { return &v }
 
@@ -298,6 +310,11 @@ func TestScrapeViaProxy(t *testing.T) {
 		build build
 		check check
 	}{
+		{
+			name:  "kro v0.8.5 metrics — handler_count_total fallback for watch count",
+			build: build{upstreamCode: http.StatusOK, upstreamBody: metricsProxyBodyV085},
+			check: check{wantWatchCount: int64p(37), wantGVRCount: int64p(22), wantWQDepth: int64p(0)},
+		},
 		{
 			name:  "200 response parses metrics correctly",
 			build: build{upstreamCode: http.StatusOK, upstreamBody: metricsProxyBody},


### PR DESCRIPTION
## Bug

MetricsStrip ACTIVE WATCHES always shows **"Not reported"** on kro v0.8.5.

## Root cause

kro v0.8.5 removed `dynamic_controller_watch_count` and replaced it with `dynamic_controller_handler_count_total{type="child"}`. The metrics parser was looking for the old name only.

**kro v0.8.4 and earlier:**
```
dynamic_controller_watch_count 7
```

**kro v0.8.5:**
```
dynamic_controller_handler_count_total{type="child"} 37
dynamic_controller_handler_count_total{type="parent"} 22
```

## Fix

`parseMetricLine` now checks for `dynamic_controller_handler_count_total{type="child"}` as a fallback when `dynamic_controller_watch_count` is absent. Precedence: new metric name wins if both are present.

## Tests

New test case `kro v0.8.5 metrics — handler_count_total fallback for watch count` verifies `WatchCount=37` from the child handler count when using the v0.8.5 format.