### PR TITLE
chore(release): prepare v0.5.3

### DIFF
--- a/helm/kro-ui/Chart.yaml
+++ b/helm/kro-ui/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kro-ui
 description: Web dashboard for kro ResourceGraphDefinitions
 type: application
-version: 0.5.1
-appVersion: "0.5.1"
+version: 0.5.3
+appVersion: "0.5.3"
 keywords:
   - kro
   - kubernetes


### PR DESCRIPTION
## v0.5.3 Release

### What's included since v0.5.2

**New features:**
- `054`: formatAge 'just now', MetricsStrip not-reported style, instance name filter
- `055`: Overview aggregate health summary bar (OverviewHealthBar)
- `056`: RGD card one-line error hint for error-state cards
- `057`: Cache flush on context switch (prevents stale cross-cluster data)
- `058`: Global `/instances` page + `GET /api/v1/instances` cross-RGD fan-out
- `059`: WARNINGS counter includes failed/unknown conditions
- `060`: Clickable OverviewHealthBar chips to filter Overview by health state
- `061`: Helm chart security hardening (runAsNonRoot, readOnlyRootFilesystem, drop ALL)
- `062`: /instances namespace dropdown + health state filter chips

**Bug fixes:**
- Fleet degraded count now excludes IN_PROGRESS (reconciling) instances (#343)
- ACTIVE WATCHES metric fallback for kro v0.8.5+ (#344)
- ListAllInstances optimization: skip per-RGD Get call (#334)
- 14 E2E infrastructure fixes (#332-#342)

**Chart change:** version/appVersion bumped from 0.5.1 → 0.5.3