### PR TITLE
feat(api,web): Fleet cluster card shows reconciling instance count (spec 064)

### DIFF
--- a/internal/api/handlers/fleet.go
+++ b/internal/api/handlers/fleet.go
@@ -144,8 +144,9 @@ func (h *Handler) summariseContext(parent context.Context, ctx k8sclient.Context
 	}
 
 	type instanceResult struct {
-		count    int
-		degraded int
+		count       int
+		degraded    int
+		reconciling int
 	}
 	results := make([]instanceResult, len(entries))
 	var mu sync.Mutex
@@ -174,13 +175,16 @@ func (h *Handler) summariseContext(parent context.Context, ctx k8sclient.Context
 			}
 
 			deg := 0
+			rec := 0
 			for _, inst := range instances.Items {
 				if isInstanceDegraded(inst.Object) {
 					deg++
+				} else if isInstanceReconciling(inst.Object) {
+					rec++
 				}
 			}
 			mu.Lock()
-			results[i] = instanceResult{len(instances.Items), deg}
+			results[i] = instanceResult{len(instances.Items), deg, rec}
 			mu.Unlock()
 			return nil
 		})
@@ -189,13 +193,16 @@ func (h *Handler) summariseContext(parent context.Context, ctx k8sclient.Context
 
 	totalInstances := 0
 	degraded := 0
+	reconciling := 0
 	for _, r := range results {
 		totalInstances += r.count
 		degraded += r.degraded
+		reconciling += r.reconciling
 	}
 
 	summary.InstanceCount = totalInstances
 	summary.DegradedInstances = degraded
+	summary.ReconcilingInstances = reconciling
 	summary.RGDKinds = kinds
 	if degraded > 0 {
 		summary.Health = types.ClusterDegraded
@@ -253,6 +260,18 @@ func isInstanceDegraded(obj map[string]any) bool {
 		}
 	}
 	return false
+}
+
+// isInstanceReconciling returns true when the instance is in the IN_PROGRESS state.
+// These instances are actively working toward a healthy state and should NOT be
+// counted as degraded — they are reconciling.
+func isInstanceReconciling(obj map[string]any) bool {
+	status, ok := obj["status"].(map[string]any)
+	if !ok {
+		return false
+	}
+	stateVal, _ := status["state"].(string)
+	return stateVal == "IN_PROGRESS"
 }
 
 // isKroNotInstalled returns true when the error indicates the RGD CRD is absent.

--- a/internal/api/handlers/fleet_test.go
+++ b/internal/api/handlers/fleet_test.go
@@ -261,3 +261,49 @@ func TestIsInstanceDegraded(t *testing.T) {
 		})
 	}
 }
+
+func TestIsInstanceReconciling(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  map[string]any
+		want bool
+	}{
+		{
+			name: "state=IN_PROGRESS → reconciling",
+			obj: map[string]any{
+				"status": map[string]any{"state": "IN_PROGRESS"},
+			},
+			want: true,
+		},
+		{
+			name: "state=ACTIVE → not reconciling",
+			obj: map[string]any{
+				"status": map[string]any{"state": "ACTIVE"},
+			},
+			want: false,
+		},
+		{
+			name: "no status → not reconciling",
+			obj:  map[string]any{},
+			want: false,
+		},
+		{
+			name: "never-ready scenario: IN_PROGRESS → reconciling (not degraded)",
+			obj: map[string]any{
+				"status": map[string]any{
+					"state": "IN_PROGRESS",
+					"conditions": []any{
+						map[string]any{"type": "Ready", "status": "False"},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isInstanceReconciling(tt.obj)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/api/types/response.go
+++ b/internal/api/types/response.go
@@ -91,7 +91,12 @@ type ClusterSummary struct {
 	RGDCount          int           `json:"rgdCount"`
 	InstanceCount     int           `json:"instanceCount"`
 	DegradedInstances int           `json:"degradedInstances"`
-	KroVersion        string        `json:"kroVersion"`
+	// ReconcilingInstances is the count of instances in the IN_PROGRESS state.
+	// These are not degraded — they are actively working toward a healthy state.
+	// Displayed separately from degraded so operators can distinguish stuck
+	// instances from instances that are simply being reconciled.
+	ReconcilingInstances int    `json:"reconcilingInstances"`
+	KroVersion           string `json:"kroVersion"`
 	// RGDKinds lists spec.schema.kind values for each RGD present in this cluster.
 	// Used by the Fleet compare matrix (FR-005).
 	RGDKinds []string `json:"rgdKinds"`

--- a/web/src/components/ClusterCard.css
+++ b/web/src/components/ClusterCard.css
@@ -104,6 +104,16 @@
   border-radius: var(--radius-sm);
 }
 
+/* Reconciling badge — shown on healthy clusters when there are IN_PROGRESS instances */
+.cluster-card__reconciling-badge {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: var(--color-reconciling);
+  padding: 2px 7px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-reconciling);
+}
+
 .cluster-card__status-text {
   font-size: 0.82rem;
   color: var(--color-text-muted);

--- a/web/src/components/ClusterCard.tsx
+++ b/web/src/components/ClusterCard.tsx
@@ -19,7 +19,7 @@ function healthLabel(health: ClusterHealth, degraded: number): string {
 }
 
 export default function ClusterCard({ summary, onSwitch }: ClusterCardProps) {
-  const { context, cluster, health, rgdCount, instanceCount, degradedInstances, kroVersion } = summary
+  const { context, cluster, health, rgdCount, instanceCount, degradedInstances, reconcilingInstances = 0, kroVersion } = summary
 
   return (
     <button
@@ -69,6 +69,16 @@ export default function ClusterCard({ summary, onSwitch }: ClusterCardProps) {
           {health === 'degraded' && (
             <span className="cluster-card__degraded-badge">
               {healthLabel(health, degradedInstances)}
+            </span>
+          )}
+          {/* Show reconciling count when there are IN_PROGRESS instances — even on healthy clusters */}
+          {reconcilingInstances > 0 && (
+            <span
+              className="cluster-card__reconciling-badge"
+              title={`${reconcilingInstances} instance${reconcilingInstances === 1 ? '' : 's'} actively reconciling (IN_PROGRESS state)`}
+              data-testid="cluster-card-reconciling"
+            >
+              {reconcilingInstances} reconciling
             </span>
           )}
           {(health === 'unreachable' || health === 'kro-not-installed' || health === 'auth-failed') && (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -200,6 +200,8 @@ export interface ClusterSummary {
   rgdCount: number
   instanceCount: number
   degradedInstances: number
+  /** Instances in the IN_PROGRESS (reconciling) state — not degraded but pending. Optional: absent on older kro-ui backends. */
+  reconcilingInstances?: number
   kroVersion: string
   rgdKinds: string[]
   error?: string


### PR DESCRIPTION
## Summary

Fleet cluster cards now show a separate **reconciling** count for clusters with actively-reconciling instances, distinct from degraded.

### Before
Fleet showed "Healthy" for a cluster with 3 never-ready (IN_PROGRESS) instances — correct but gave no indication that instances were actively working.

### After
Fleet shows:
- **"Healthy"** status (cluster is fine — no broken instances)
- **"3 reconciling"** outline badge (informational — instances are being reconciled)

### Changes

**Backend** (`ClusterSummary`):
- Added `ReconcilingInstances int` field
- New `isInstanceReconciling(obj)` function: returns true when `status.state=IN_PROGRESS`
- Fan-out now counts both degraded AND reconciling per-RGD
- 4 unit tests for `isInstanceReconciling`

**Frontend** (`ClusterCard.tsx`, `ClusterCard.css`, `api.ts`):
- Added `reconcilingInstances?: number` to `ClusterSummary` (optional for backward compat)
- Renders `<span class="cluster-card__reconciling-badge">3 reconciling</span>` when count > 0
- CSS: outline style (border only, no fill) — distinct from the filled degraded badge