### PR TITLE
feat(api,web): /instances status dot tooltip shows condition message (spec 066)

### DIFF
--- a/internal/api/handlers/instances_all.go
+++ b/internal/api/handlers/instances_all.go
@@ -49,6 +49,9 @@ type InstanceSummary struct {
 	State string `json:"state"`
 	// Ready is the value of the Ready condition: "True", "False", or "Unknown".
 	Ready string `json:"ready"`
+	// Message is the Ready condition's message (empty for healthy instances).
+	// Shown as a tooltip on the status indicator to explain why an instance is not ready.
+	Message string `json:"message,omitempty"`
 	// CreationTimestamp is RFC3339 — used by the frontend for age display.
 	CreationTimestamp string `json:"creationTimestamp"`
 }
@@ -135,6 +138,7 @@ func (h *Handler) ListAllInstances(w http.ResponseWriter, r *http.Request) {
 
 				// Extract ready condition from status.conditions
 				ready := "Unknown"
+				readyMessage := ""
 				stateStr := ""
 				if statusObj, ok := obj.Object["status"].(map[string]any); ok {
 					if s, ok := statusObj["state"].(string); ok {
@@ -146,6 +150,12 @@ func (h *Handler) ListAllInstances(w http.ResponseWriter, r *http.Request) {
 								if cm["type"] == "Ready" {
 									if s, ok := cm["status"].(string); ok {
 										ready = s
+									}
+									// Only surface the message when Ready≠True (failure/unknown)
+									if ready != "True" {
+										if msg, ok := cm["message"].(string); ok && msg != "" {
+											readyMessage = msg
+										}
 									}
 								}
 							}
@@ -168,6 +178,7 @@ func (h *Handler) ListAllInstances(w http.ResponseWriter, r *http.Request) {
 					RGDName:           rgdName,
 					State:             stateStr,
 					Ready:             ready,
+					Message:           readyMessage,
 					CreationTimestamp: createdAt,
 				})
 			}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -77,6 +77,8 @@ export interface InstanceSummary {
   rgdName: string
   state: string
   ready: string
+  /** Ready condition message — non-empty only when Ready≠True. Shown as tooltip on status indicator. */
+  message?: string
   creationTimestamp: string
 }
 

--- a/web/src/pages/Instances.tsx
+++ b/web/src/pages/Instances.tsx
@@ -330,7 +330,11 @@ export default function InstancesPage() {
                     style={{ cursor: 'pointer' }}
                   >
                     <td className="instances-table__td instances-table__td--state">
-                      <StatusDot state={dotState} />
+                      <StatusDot
+                        state={dotState}
+                        message={item.message}
+                        reason={item.message ? (health === 'reconciling' ? 'Reconciling' : 'Not ready') : undefined}
+                      />
                     </td>
                     <td className="instances-table__td instances-table__td--name">
                       <Link to={href} className="instances-table__link" tabIndex={-1}>


### PR DESCRIPTION
## Summary

The `/instances` global search page status dot now shows a tooltip with the Ready condition's message when an instance is not ready.

### Before
- Status dot shows color (amber/red/grey) but no explanation on hover
- Operator must click through to instance detail to see why it's not ready

### After
- Status dot tooltip shows: "Reconciling: awaiting resource readiness" (for IN_PROGRESS)
- Or: "Not ready: {condition message}" (for error states)

### Changes

**Backend** (`instances_all.go`):
- Added `Message string` to `InstanceSummary` (omitempty — empty for healthy instances)
- Extracts `status.conditions[type=Ready].message` when `Ready≠True`

**Frontend** (`Instances.tsx` + `api.ts`):
- Added `message?: string` to `InstanceSummary` TypeScript type
- Passes `message` and `reason` props to `StatusDot` for the tooltip