### PR TITLE
fix(api): ListAllInstances 5s per-RGD timeout — fixes missing instances on throttled clusters

### DIFF
--- a/internal/api/handlers/instances_all.go
+++ b/internal/api/handlers/instances_all.go
@@ -63,8 +63,13 @@ type ListAllInstancesResponse struct {
 }
 
 // perRGDAllInstancesTimeout is the deadline for listing instances of each RGD
-// in the fan-out. Kept short to honour the 5s total handler budget.
-const perRGDAllInstancesTimeout = 2
+// in the fan-out. All goroutines run in parallel so the total handler latency
+// is approximately max(individual_request_latency).
+//
+// Increased to 5s (was 2s): on throttled clusters the DiscoverPlural call alone
+// can take 1-2s, leaving insufficient time for the List call under the 2s limit.
+// Since goroutines run in parallel the overall handler stays within the 5s budget.
+const perRGDAllInstancesTimeout = 5
 
 func (h *Handler) ListAllInstances(w http.ResponseWriter, r *http.Request) {
 	log := zerolog.Ctx(r.Context())


### PR DESCRIPTION
## Bug

The `/instances` page showed fewer instances than the Fleet page. For example:
- Fleet: 106 instances
- /instances: 65 instances
- Actual cluster: 133+ instances

## Root cause

`ListAllInstances` fan-out used a 2s per-RGD timeout. On throttled clusters, `DiscoverPlural()` alone takes 1-2s (client-side rate limiting), leaving no time for the actual `List` call. The goroutine times out and returns 0 instances for that RGD.

## Fix

Increase `perRGDAllInstancesTimeout` from 2s to 5s. This is safe because all goroutines run in **parallel** — the total handler latency is `max(individual_latency)`, not `sum(individual_latency)`. With 33 goroutines running concurrently, a 5s timeout per-goroutine still keeps the total handler within the 5s budget.