### PR TITLE
fix(api): Fleet summary handler 5s per-RGD timeout — consistent with ListAllInstances fix

### DIFF
--- a/internal/api/handlers/fleet.go
+++ b/internal/api/handlers/fleet.go
@@ -117,8 +117,11 @@ func (h *Handler) summariseContext(parent context.Context, ctx k8sclient.Context
 	// For each RGD, build the GVR and fan out instance list calls concurrently.
 	// DiscoverPlural now reads from the TTL cache (issue #192/Bug A) so calling
 	// it once per RGD no longer incurs N sequential API server discovery requests.
-	// The errgroup with a 2s per-resource timeout prevents any single slow resource
+	// The errgroup with a 5s per-resource timeout prevents any single slow resource
 	// from holding up the rest. Constitution §XI.
+	// Increased from 2s to 5s: on throttled clusters DiscoverPlural itself takes
+	// 1-2s, leaving insufficient time for the List call. Goroutines run in parallel
+	// so the total summary handler latency ≈ max(individual) not sum(individual).
 	type rgdEntry struct {
 		kind       string
 		group      string
@@ -156,7 +159,7 @@ func (h *Handler) summariseContext(parent context.Context, ctx k8sclient.Context
 	for i, entry := range entries {
 		i, entry := i, entry // capture
 		g.Go(func() error {
-			rctx, rcancel := context.WithTimeout(gctx, 2*time.Second)
+			rctx, rcancel := context.WithTimeout(gctx, 5*time.Second)
 			defer rcancel()
 
 			plural, err := k8sclient.DiscoverPlural(clients, entry.group, entry.apiVersion, entry.kind)


### PR DESCRIPTION
## Summary

The Fleet summary handler (`FleetSummary`) used a 2s per-RGD timeout for its fan-out — the same issue fixed in `ListAllInstances` (PR #352). The Fleet page showed 95-106 instances while the cluster had 133+.

## Root cause

`fleetSummaryForContext` in `fleet.go` used `context.WithTimeout(gctx, 2*time.Second)` per RGD goroutine. On throttled clusters, `DiscoverPlural` takes 1-2s, leaving no time for the actual List call.

## Fix

Increase to 5s. Same reasoning as PR #352: goroutines run in parallel, so total handler latency ≈ max(individual) not sum(individual). The fleet summary handler has a 30s overall timeout via the route-level middleware.

## Expected result

Fleet "106 instances" → "133 instances" (matching actual cluster count)