### PR TITLE
fix(api): Fleet kro version from RGD annotation — avoids DetectCapabilities delay

### DIFF
--- a/internal/api/handlers/fleet.go
+++ b/internal/api/handlers/fleet.go
@@ -213,13 +213,21 @@ func (h *Handler) summariseContext(parent context.Context, ctx k8sclient.Context
 		summary.Health = types.ClusterHealthy
 	}
 
-	// Populate kro version from the capabilities endpoint for this context.
-	// The capabilities handler already discovers this via the kro controller image;
-	// reuse the same code path here by calling the k8s capabilities function directly.
-	// On error (e.g. kro not installed, unreachable) we leave KroVersion empty —
-	// the UI will show "Unknown" gracefully.
-	if caps := k8sclient.DetectCapabilities(parent, clients.Dynamic(), clients.Discovery()); caps != nil && caps.Version != "" {
-		summary.KroVersion = caps.Version
+	// Populate kro version from the kro.run/kro-version annotation on the first RGD.
+	// This is cheaper than calling DetectCapabilities (which probes the kro Deployment)
+	// since we already have the RGD list. kro sets this annotation on all RGDs.
+	// Falls back to DetectCapabilities only when no annotated RGDs are found.
+	for i := range list.Items {
+		if v, ok := list.Items[i].GetAnnotations()["kro.run/kro-version"]; ok && v != "" {
+			summary.KroVersion = v
+			break
+		}
+	}
+	if summary.KroVersion == "" {
+		// Fallback: probe the kro controller Deployment (slower, throttled)
+		if caps := k8sclient.DetectCapabilities(parent, clients.Dynamic(), clients.Discovery()); caps != nil && caps.Version != "" {
+			summary.KroVersion = caps.Version
+		}
 	}
 	return summary
 }

--- a/internal/api/handlers/fleet_test.go
+++ b/internal/api/handlers/fleet_test.go
@@ -176,6 +176,38 @@ func TestFleetSummary(t *testing.T) {
 				assert.Contains(t, body, string(types.ClusterKroNotInstalled))
 			},
 		},
+		{
+			name: "kro version read from RGD annotation (cheap path, no DetectCapabilities call)",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				ctxStub := &stubClientFactory{
+					contexts: []k8sclient.Context{
+						{Name: "prod", Cluster: "prod-cluster", User: "prod-user"},
+					},
+				}
+
+				rgd := makeRGDObject("webapp", "WebApp", "kro.run", "v1alpha1")
+				rgd.SetAnnotations(map[string]string{
+					"kro.run/kro-version": "v0.9.1",
+				})
+				prodDyn := newStubDynamic()
+				prodDyn.resources[rgdGVR] = &stubNamespaceableResource{
+					items: []unstructured.Unstructured{*rgd},
+				}
+
+				builder := &stubFleetClientBuilder{
+					clients: map[string]*stubK8sClients{
+						"prod": {dyn: prodDyn, disc: newStubDiscovery()},
+					},
+				}
+				return newFleetTestHandler(ctxStub, builder)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				assert.Contains(t, rr.Body.String(), `"v0.9.1"`)
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Fleet cluster cards showed kro version as \"unknown\" because `DetectCapabilities` (which probes the kro Deployment image) ran after a heavy fan-out on throttled clusters, often returning before the image inspection completed
- kro stamps `kro.run/kro-version` on every RGD it manages — use this annotation from the already-fetched RGD list instead
- Falls back to `DetectCapabilities` only when no annotated RGDs are found (e.g. empty cluster, very old kro)

## Changes

- `internal/api/handlers/fleet.go`: extract kro version from `list.Items[i].GetAnnotations()["kro.run/kro-version"]`; call `DetectCapabilities` only as fallback
- `internal/api/handlers/fleet_test.go`: add test case `kro version read from RGD annotation (cheap path, no DetectCapabilities call)` — verifies version `"v0.9.1"` appears in response body when RGD carries the annotation

## Testing

`go test -race ./internal/api/handlers/ -run TestFleetSummary` — all 5 cases pass