### PR TITLE
fix: Fleet kro version from instance labels; Errors tab shows stuck IN_PROGRESS; escalation banner human-readable duration

### DIFF
--- a/internal/api/handlers/fleet.go
+++ b/internal/api/handlers/fleet.go
@@ -150,6 +150,7 @@ func (h *Handler) summariseContext(parent context.Context, ctx k8sclient.Context
 		count       int
 		degraded    int
 		reconciling int
+		kroVersion  string // kro.run/kro-version label from the first instance found
 	}
 	results := make([]instanceResult, len(entries))
 	var mu sync.Mutex
@@ -179,15 +180,23 @@ func (h *Handler) summariseContext(parent context.Context, ctx k8sclient.Context
 
 			deg := 0
 			rec := 0
+			ver := ""
 			for _, inst := range instances.Items {
 				if isInstanceDegraded(inst.Object) {
 					deg++
 				} else if isInstanceReconciling(inst.Object) {
 					rec++
 				}
+				// Capture kro version from the first instance that has the label.
+				// kro stamps kro.run/kro-version on every CR it manages.
+				if ver == "" {
+					if v, ok := inst.GetLabels()["kro.run/kro-version"]; ok && v != "" {
+						ver = v
+					}
+				}
 			}
 			mu.Lock()
-			results[i] = instanceResult{len(instances.Items), deg, rec}
+			results[i] = instanceResult{len(instances.Items), deg, rec, ver}
 			mu.Unlock()
 			return nil
 		})
@@ -213,13 +222,14 @@ func (h *Handler) summariseContext(parent context.Context, ctx k8sclient.Context
 		summary.Health = types.ClusterHealthy
 	}
 
-	// Populate kro version from the kro.run/kro-version annotation on the first RGD.
-	// This is cheaper than calling DetectCapabilities (which probes the kro Deployment)
-	// since we already have the RGD list. kro sets this annotation on all RGDs.
-	// Falls back to DetectCapabilities only when no annotated RGDs are found.
-	for i := range list.Items {
-		if v, ok := list.Items[i].GetAnnotations()["kro.run/kro-version"]; ok && v != "" {
-			summary.KroVersion = v
+	// Populate kro version from the kro.run/kro-version label on CR instances.
+	// kro stamps this label on every CR it manages; it is not present on RGD objects.
+	// We pick the first non-empty value found across all instance fan-out results.
+	// Falls back to DetectCapabilities (which probes the kro Deployment) only when
+	// no instances exist or none carry the label.
+	for _, r := range results {
+		if r.kroVersion != "" {
+			summary.KroVersion = r.kroVersion
 			break
 		}
 	}

--- a/internal/api/handlers/fleet_test.go
+++ b/internal/api/handlers/fleet_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/pnz1990/kro-ui/internal/api/types"
 	k8sclient "github.com/pnz1990/kro-ui/internal/k8s"
@@ -177,7 +178,7 @@ func TestFleetSummary(t *testing.T) {
 			},
 		},
 		{
-			name: "kro version read from RGD annotation (cheap path, no DetectCapabilities call)",
+			name: "kro version read from instance label (kro stamps kro.run/kro-version on CRs, not RGDs)",
 			build: func(t *testing.T) *Handler {
 				t.Helper()
 				ctxStub := &stubClientFactory{
@@ -187,12 +188,26 @@ func TestFleetSummary(t *testing.T) {
 				}
 
 				rgd := makeRGDObject("webapp", "WebApp", "kro.run", "v1alpha1")
-				rgd.SetAnnotations(map[string]string{
-					"kro.run/kro-version": "v0.9.1",
-				})
+				// Instance GVR: DiscoverPlural falls back to naive "webapps"
+				instanceGVR := schema.GroupVersionResource{Group: "kro.run", Version: "v1alpha1", Resource: "webapps"}
+				instance := &unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "kro.run/v1alpha1",
+					"kind":       "WebApp",
+					"metadata": map[string]any{
+						"name":      "my-webapp",
+						"namespace": "default",
+						"labels": map[string]any{
+							"kro.run/kro-version": "v0.9.1",
+						},
+					},
+				}}
+
 				prodDyn := newStubDynamic()
 				prodDyn.resources[rgdGVR] = &stubNamespaceableResource{
 					items: []unstructured.Unstructured{*rgd},
+				}
+				prodDyn.resources[instanceGVR] = &stubNamespaceableResource{
+					items: []unstructured.Unstructured{*instance},
 				}
 
 				builder := &stubFleetClientBuilder{

--- a/web/src/components/ErrorsTab.test.ts
+++ b/web/src/components/ErrorsTab.test.ts
@@ -186,14 +186,21 @@ describe('groupErrorPatterns — IN_PROGRESS instances are not aggregated', () =
     }
   }
 
-  it('skips instances with status.state=IN_PROGRESS (never-ready pattern)', () => {
+  it('includes IN_PROGRESS instances with Ready=False — stuck reconciliation is actionable', () => {
+    // Previously these were skipped (PR #286), but operators need to see
+    // stuck instances (e.g. never-ready running for days) in the Errors tab.
     const instances = [
       makeInProgressInstance('never-ready-prod'),
       makeInProgressInstance('never-ready-staging'),
       makeInProgressInstance('never-ready-dev'),
     ]
     const groups = groupErrorPatterns(instances)
-    expect(groups).toHaveLength(0)
+    // All 3 instances have Ready=False/NotReady — they appear in the Errors tab.
+    expect(groups.length).toBeGreaterThan(0)
+    const allNames = groups.flatMap((g) => g.instances.map((i) => i.name))
+    expect(allNames).toContain('never-ready-prod')
+    expect(allNames).toContain('never-ready-staging')
+    expect(allNames).toContain('never-ready-dev')
   })
 
   it('skips instances with Progressing=True condition', () => {
@@ -202,9 +209,9 @@ describe('groupErrorPatterns — IN_PROGRESS instances are not aggregated', () =
     expect(groups).toHaveLength(0)
   })
 
-  it('includes genuinely errored instances (no IN_PROGRESS state, no Progressing)', () => {
+  it('includes genuinely errored instances (no Progressing condition); IN_PROGRESS instances also included now', () => {
     const instances = [
-      makeInProgressInstance('reconciling-1'),  // skipped
+      makeInProgressInstance('reconciling-1'),  // included (stuck reconciling = actionable)
       {
         metadata: { name: 'broken', namespace: 'default' },
         status: {
@@ -216,8 +223,10 @@ describe('groupErrorPatterns — IN_PROGRESS instances are not aggregated', () =
       } as K8sObject,
     ]
     const groups = groupErrorPatterns(instances)
-    expect(groups).toHaveLength(1)
-    expect(groups[0].instances[0].name).toBe('broken')
+    // Both instances have Ready=False — both appear in the Errors tab.
+    const allNames = groups.flatMap((g) => g.instances.map((i) => i.name))
+    expect(allNames).toContain('broken')
+    expect(allNames).toContain('reconciling-1')
   })
 
   it('skips GraphProgressing=True instances (kro v0.8.x compat)', () => {

--- a/web/src/components/ErrorsTab.tsx
+++ b/web/src/components/ErrorsTab.tsx
@@ -70,12 +70,11 @@ export function groupErrorPatterns(instances: K8sObject[]): ErrorGroup[] {
 
     const status = instance.status as Record<string, unknown> | undefined
 
-    // Skip instances that are actively reconciling (IN_PROGRESS kro state or
-    // Progressing=True condition). Their Ready=False is an expected transient
-    // state — not an actionable error pattern. Showing them in the Errors tab
-    // produces false positives (e.g. never-ready shows "2 error patterns"
-    // while the instance list correctly shows "Reconciling").
-    if (status?.state === 'IN_PROGRESS') continue
+    // Skip instances with an active Progressing condition — their Ready=False is
+    // a transient state during reconciliation, not an actionable error.
+    // Note: we intentionally do NOT skip all IN_PROGRESS instances because a
+    // stuck instance (e.g. never-ready, IN_PROGRESS for hours) with Ready=False
+    // conditions IS an actionable problem and should appear in the Errors tab.
     const rawConds = status?.conditions
     if (Array.isArray(rawConds)) {
       const isProgressing = (rawConds as Array<Record<string, unknown>>).some(

--- a/web/src/pages/InstanceDetail.tsx
+++ b/web/src/pages/InstanceDetail.tsx
@@ -135,6 +135,23 @@ function reconcilingSinceMinutes(instance: K8sObject | null): number | null {
 
 // ── Reconciling banner ─────────────────────────────────────────────────────
 
+/** Format a duration in minutes as a human-readable string.
+ * e.g. 3827m → "2d 15h", 90m → "1h 30m", 45m → "45m".
+ */
+function formatReconcileDuration(mins: number): string {
+  if (mins >= 24 * 60) {
+    const d = Math.floor(mins / (24 * 60))
+    const h = Math.floor((mins % (24 * 60)) / 60)
+    return h > 0 ? `${d}d ${h}h` : `${d}d`
+  }
+  if (mins >= 60) {
+    const h = Math.floor(mins / 60)
+    const m = mins % 60
+    return m > 0 ? `${h}h ${m}m` : `${h}h`
+  }
+  return `${mins}m`
+}
+
 function isReconciling(instance: K8sObject | null): boolean {
   if (!instance) return false
   const status = instance.status as Record<string, unknown> | undefined
@@ -446,7 +463,7 @@ export default function InstanceDetail() {
           >
             <span className="reconciling-banner-pulse" aria-hidden="true">●</span>
             {isStuck
-              ? <>kro has been reconciling this instance for {mins}m — check the Conditions panel and <code>kubectl describe</code> the child resources for errors.</>
+              ? <>kro has been reconciling this instance for {formatReconcileDuration(mins!)} — check the Conditions panel and <code>kubectl describe</code> the child resources for errors.</>
               : 'kro is reconciling this instance'
             }
           </div>


### PR DESCRIPTION
## Summary

Three production bugs found during comprehensive UI audit and fixed:

### BUG-6: Fleet shows "kro unknown" for kro version

- **Root cause**: PR #355 read `kro.run/kro-version` from RGD object annotations — but kro only stamps this label on **CR instances**, not on RGD objects themselves.
- **Fix**: Read the label from the first instance found during the existing per-RGD fan-out. Falls back to `DetectCapabilities` (Deployment probe) only when no instances exist.
- **Files**: `internal/api/handlers/fleet.go`, `fleet_test.go`

### BUG-19: Errors tab says "All instances are healthy" for stuck reconciling instances

- **Root cause**: PR #286 unconditionally skipped all `IN_PROGRESS` instances from error aggregation, preventing `never-ready` instances (IN_PROGRESS for 63+ hours with `Ready=False`) from surfacing.
- **Fix**: Only skip instances with an active `Progressing=True` or `GraphProgressing=True` condition (genuinely transitioning). Stuck IN_PROGRESS instances with `Ready=False` conditions are now shown.
- **Files**: `web/src/components/ErrorsTab.tsx`, `ErrorsTab.test.ts`

### BUG-20: Escalation banner shows raw "3827m" duration

- **Root cause**: `InstanceDetail.tsx` displayed raw `{mins}m` in the stuck reconciliation banner.
- **Fix**: Add `formatReconcileDuration(mins)` that converts minutes to human-readable form: `2d 15h`, `63h`, `45m`, etc.
- **Files**: `web/src/pages/InstanceDetail.tsx`

## Testing

- `go test -race ./...` — all pass
- `bun run vitest run` — 1202/1202 pass
- `bun run tsc --noEmit` — clean
- `go vet ./...` — clean