### PR TITLE
fix(css,docs): replace hardcoded #fff with var(--color-on-primary); correct stale timeout comments

### DIFF
--- a/internal/api/handlers/fleet.go
+++ b/internal/api/handlers/fleet.go
@@ -81,7 +81,7 @@ func (h *Handler) summariseContext(parent context.Context, ctx k8sclient.Context
 
 	// parent is already bounded by the route-level 30s timeout (server.go).
 	// No additional per-cluster deadline is added here — the per-RGD goroutines
-	// each apply their own 2s deadline via rctx (Constitution §XI).
+	// each apply their own 5s deadline via rctx (Constitution §XI; was 2s, increased in PR #354).
 
 	// Build ephemeral clients — does NOT affect the shared ClientFactory.
 	var kubeconfigPath string

--- a/internal/api/handlers/instances_all.go
+++ b/internal/api/handlers/instances_all.go
@@ -15,7 +15,7 @@
 package handlers
 
 // ListAllInstances returns a flat list of all live CR instances across all active RGDs.
-// Fan-out: one goroutine per RGD, each with a 2s deadline (constitution §XI).
+// Fan-out: one goroutine per RGD, each with a 5s deadline (constitution §XI; was 2s, increased in PR #352).
 // Response: {"items": [...InstanceSummary...], "total": N}
 //
 // Used by the global instance search page (/instances) in the frontend.

--- a/web/src/pages/Catalog.css
+++ b/web/src/pages/Catalog.css
@@ -265,5 +265,5 @@
 /* Errors active state — accent with error color */
 .catalog__status-btn--active[data-testid="catalog-status-errors"] {
   background: var(--color-error);
-  color: #fff;
+  color: var(--color-on-primary);
 }

--- a/web/src/pages/Home.css
+++ b/web/src/pages/Home.css
@@ -251,12 +251,12 @@
 
 .home__rgd-error-btn:hover {
   background: var(--color-error);
-  color: #fff;
+  color: var(--color-on-primary);
 }
 
 .home__rgd-error-btn--active {
   background: var(--color-error);
-  color: #fff;
+  color: var(--color-on-primary);
 }
 
 .home__rgd-error-count {


### PR DESCRIPTION
## Summary

Findings from codebase audit:

### CSS — closes #360 (Constitution §IX violation)
Three rules in specs 069/070 used the hardcoded hex literal `#fff` instead of the correct `var(--color-on-primary)` token:
- `web/src/pages/Home.css:252–259` — error button hover + active states
- `web/src/pages/Catalog.css:265–269` — catalog error-filter active state

**Fix**: replace `color: #fff` with `color: var(--color-on-primary)` (resolves to `#ffffff` in both themes via `tokens.css:22`).

### Stale comments
Two file-level comments still said "2s deadline" after the timeout was increased to 5s:
- `internal/api/handlers/fleet.go:84` — updated to "5s" with PR reference
- `internal/api/handlers/instances_all.go:18` — updated to "5s" with PR reference

## Related issues
- Closes #360
- Does not close #361 (unit tests) or #362 (E2E journeys) — those are tracked separately