### PR TITLE
fix(ux): health filter URL sync; reconciling StatusDot; blank ?tab= fallback

### DIFF
--- a/test/e2e/journeys/058-global-instance-search.spec.ts
+++ b/test/e2e/journeys/058-global-instance-search.spec.ts
@@ -200,16 +200,16 @@ test.describe('Journey 058: Global Instance Search', () => {
 
   // ── Health filter chips (spec 062) ────────────────────────────────────────────
 
-  test('Step 7: health filter chips present and interactive', async ({ page }) => {
-    await page.goto(`${BASE}/instances`)
-    await page.waitForFunction(
-      () => document.querySelector('[data-testid="instances-health-filter-all"]') !== null ||
-            document.querySelector('.panel-empty') !== null,
-      { timeout: 60000 }
-    )
-    const allChip = page.locator('[data-testid="instances-health-filter-all"]')
-    if (await allChip.count() > 0) {
-      // All chip should be active by default (aria-pressed=true)
+   test('Step 7: health filter chips present and interactive', async ({ page }) => {
+     await page.goto(`${BASE}/instances`)
+     await page.waitForFunction(
+       () => document.querySelector('[data-testid="instances-health-chip-all"]') !== null ||
+             document.querySelector('.panel-empty') !== null,
+       { timeout: 60000 }
+     )
+     const allChip = page.locator('[data-testid="instances-health-chip-all"]')
+     if (await allChip.count() > 0) {
+       // All chip should be active by default (aria-pressed=true)
       await expect(allChip).toHaveAttribute('aria-pressed', 'true')
       // All chip text should contain total count
       const text = await allChip.textContent()

--- a/web/src/components/StatusDot.css
+++ b/web/src/components/StatusDot.css
@@ -17,3 +17,9 @@
 .status-dot--unknown {
   background-color: var(--color-status-unknown);
 }
+
+/* Issue #366: reconciling state — amber dot using the existing reconciling token */
+.status-dot--reconciling {
+  background-color: var(--color-status-reconciling);
+  animation: reconciling-pulse 1.5s ease-in-out infinite;
+}

--- a/web/src/lib/format.test.ts
+++ b/web/src/lib/format.test.ts
@@ -218,6 +218,10 @@ describe('readyStateColor', () => {
   it('returns --color-status-unknown for unknown', () => {
     expect(readyStateColor('unknown')).toBe('--color-status-unknown')
   })
+
+  it('returns --color-status-reconciling for reconciling (issue #366)', () => {
+    expect(readyStateColor('reconciling')).toBe('--color-status-reconciling')
+  })
 })
 
 // ── readyStateLabel ──────────────────────────────────────────────────
@@ -233,6 +237,10 @@ describe('readyStateLabel', () => {
 
   it('returns Unknown for unknown', () => {
     expect(readyStateLabel('unknown')).toBe('Unknown')
+  })
+
+  it('returns Reconciling for reconciling (issue #366)', () => {
+    expect(readyStateLabel('reconciling')).toBe('Reconciling')
   })
 })
 

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -19,8 +19,8 @@ export interface K8sCondition {
   lastTransitionTime?: string
 }
 
-/** Tri-state status for UI rendering. */
-export type ReadyState = 'ready' | 'error' | 'unknown'
+/** Tri-state status for UI rendering — extended with reconciling (issue #366). */
+export type ReadyState = 'ready' | 'error' | 'unknown' | 'reconciling'
 
 /** Full extraction result — gives components everything they need. */
 export interface ReadyStatus {
@@ -288,6 +288,8 @@ export function readyStateColor(state: ReadyState): string {
       return '--color-status-ready'
     case 'error':
       return '--color-status-error'
+    case 'reconciling':
+      return '--color-status-reconciling'
     case 'unknown':
       return '--color-status-unknown'
   }
@@ -302,6 +304,8 @@ export function readyStateLabel(state: ReadyState): string {
       return 'Ready'
     case 'error':
       return 'Not Ready'
+    case 'reconciling':
+      return 'Reconciling'
     case 'unknown':
       return 'Unknown'
   }

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -3,9 +3,11 @@
 // Search input is debounced (300ms) to avoid per-keystroke filter churn.
 // FR-007 (spec 031-deletion-debugger): background fetch of per-RGD terminating counts.
 // spec 069: RGD error banner — shows compile-error count, toggles error-only filter.
+// Issue #368: health filter chip synced to/from ?health= URL param so filtered
+// views survive refresh and can be shared.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import type { K8sObject } from '@/lib/api'
 import { listRGDs, listInstances } from '@/lib/api'
 import { extractRGDName, extractReadyStatus } from '@/lib/format'
@@ -30,6 +32,10 @@ const RGD_CARD_HEIGHT = 130
 
 export default function Home() {
   usePageTitle('Overview')
+
+  // Issue #368: health filter synced to/from the ?health= URL param.
+  const [searchParams, setSearchParams] = useSearchParams()
+
   const [items, setItems] = useState<K8sObject[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -38,7 +44,12 @@ export default function Home() {
 
   // Health filter — set by clicking OverviewHealthBar chips (spec 060-health-filter).
   // When set, the card grid shows only RGDs with instances in that health state.
-  const [healthFilter, setHealthFilter] = useState<HealthFilterState | null>(null)
+  // Issue #368: read initial value from ?health= URL param on mount.
+  const rawHealthParam = searchParams.get('health') as HealthFilterState | null
+  const validHealthFilters: HealthFilterState[] = ['ready', 'degraded', 'reconciling', 'error', 'pending', 'noInstances']
+  const [healthFilter, setHealthFilter] = useState<HealthFilterState | null>(
+    rawHealthParam && validHealthFilters.includes(rawHealthParam) ? rawHealthParam : null
+  )
 
   // spec 069: RGD compile-error filter — toggled by clicking the error banner.
   // When true, only error-state RGDs (Ready=False) are shown in the card grid.
@@ -215,7 +226,12 @@ export default function Home() {
                   <button
                     type="button"
                     className="home__clear-filter"
-                    onClick={() => { setHealthFilter(null); setShowOnlyErrors(false); }}
+                    onClick={() => {
+                      setHealthFilter(null)
+                      setShowOnlyErrors(false)
+                      // Issue #368: clear URL param on filter clear
+                      setSearchParams((prev) => { prev.delete('health'); return prev }, { replace: true })
+                    }}
                     title="Clear all filters"
                     data-testid="clear-health-filter"
                   >
@@ -250,7 +266,15 @@ export default function Home() {
           summaries={healthSummaries}
           totalRGDs={items.length}
           activeFilter={healthFilter}
-          onFilter={(state) => { setHealthFilter(state); }}
+          onFilter={(state) => {
+              setHealthFilter(state)
+              // Issue #368: sync to URL param so filter can be shared/bookmarked.
+              if (state === null) {
+                setSearchParams((prev) => { prev.delete('health'); return prev }, { replace: true })
+              } else {
+                setSearchParams((prev) => { prev.set('health', state); return prev }, { replace: true })
+              }
+            }}
         />
       )}
 

--- a/web/src/pages/Instances.tsx
+++ b/web/src/pages/Instances.tsx
@@ -4,9 +4,11 @@
 // Also provides namespace dropdown filter and health state filter.
 // Spec: .specify/specs/058-global-instance-search/spec.md
 // Namespace filter: spec .specify/specs/062-instance-namespace-filter/spec.md
+// Issue #365/#368: health filter is synced to/from the ?health= URL param so
+// filtered views can be shared and survive page refresh.
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { listAllInstances } from '@/lib/api'
 import type { InstanceSummary } from '@/lib/api'
 import { formatAge } from '@/lib/format'
@@ -26,9 +28,9 @@ function toHealthState(instance: InstanceSummary): 'ready' | 'reconciling' | 'er
   return 'unknown'
 }
 
-// StatusDot only accepts 3 states; map 4-state → 3-state for the dot.
-function toDotState(health: 'ready' | 'reconciling' | 'error' | 'unknown'): 'ready' | 'error' | 'unknown' {
-  if (health === 'reconciling') return 'unknown' // amber-ish via unknown state
+// StatusDot now accepts 'reconciling' — map 4-state health to StatusDot state.
+// Issue #366: reconciling maps to 'reconciling' (amber pulsing dot), not 'unknown'.
+function toDotState(health: 'ready' | 'reconciling' | 'error' | 'unknown'): 'ready' | 'error' | 'unknown' | 'reconciling' {
   return health
 }
 
@@ -77,15 +79,31 @@ const PAGE_SIZE = 50
 export default function InstancesPage() {
   usePageTitle('Instances')
 
+  // Issue #365: health filter is synced to the ?health= URL param so that
+  // filtered views survive refresh and can be shared. Read the param on mount;
+  // write it back on every chip click via setSearchParams.
+  const [searchParams, setSearchParams] = useSearchParams()
+  const rawHealthParam = searchParams.get('health') as HealthFilter | null
+  const validHealthFilters: HealthFilter[] = ['all', 'ready', 'reconciling', 'error', 'unknown']
+  const healthFromUrl: HealthFilter =
+    rawHealthParam && validHealthFilters.includes(rawHealthParam) ? rawHealthParam : 'all'
+
   const [items, setItems] = useState<InstanceSummary[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [query, setQuery] = useState('')
   const [nsFilter, setNsFilter] = useState('') // namespace dropdown
-  const [healthFilter, setHealthFilter] = useState<HealthFilter>('all')
+  const [healthFilter, setHealthFilter] = useState<HealthFilter>(healthFromUrl)
   const [sortKey, setSortKey] = useState<SortKey>('health')
   const [sortDir, setSortDir] = useState<SortDir>('asc')
   const [page, setPage] = useState(0)
+
+  // Sync healthFilter from URL on mount (handles direct navigation with ?health=).
+  // Only runs once; subsequent changes are driven by chip clicks.
+  useEffect(() => {
+    setHealthFilter(healthFromUrl)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []) // intentionally empty — we only want to read the URL once at mount
 
   const fetchAll = useCallback(() => {
     setIsLoading(true)
@@ -229,9 +247,19 @@ export default function InstancesPage() {
                 key={state}
                 type="button"
                 className={`instances-page__health-chip instances-page__health-chip--${state}${healthFilter === state ? ' instances-page__health-chip--active' : ''}`}
-                onClick={() => { setHealthFilter(state); setPage(0) }}
+                onClick={() => {
+                  setHealthFilter(state)
+                  setPage(0)
+                  // Issue #365: sync to URL so the view can be shared/bookmarked.
+                  // Remove the param entirely for "all" (cleaner URL).
+                  if (state === 'all') {
+                    setSearchParams((prev) => { prev.delete('health'); return prev }, { replace: true })
+                  } else {
+                    setSearchParams((prev) => { prev.set('health', state); return prev }, { replace: true })
+                  }
+                }}
                 aria-pressed={healthFilter === state}
-                data-testid={`instances-health-filter-${state}`}
+                data-testid={`instances-health-chip-${state}`}
               >
                 {label} ({count})
               </button>

--- a/web/src/pages/RGDDetail.tsx
+++ b/web/src/pages/RGDDetail.tsx
@@ -62,7 +62,13 @@ export default function RGDDetail() {
   const fromRgd = (location.state as { from?: string } | null)?.from || null
 
   const rawTab = searchParams.get("tab")
-  const activeTab: TabId = isValidTab(rawTab) ? rawTab : "graph"
+  // Issue #367: if ?tab=revisions but the cluster doesn't support GraphRevisions
+  // (kro < v0.9.0), treat it as invalid so we fall back to the graph tab.
+  // Without this check, navigating to ?tab=revisions renders a blank content area
+  // because the Revisions tab content is gated on hasRevisions.
+  const activeTab: TabId = isValidTab(rawTab) && (rawTab !== "revisions" || hasRevisions)
+    ? rawTab
+    : "graph"
 
   // ── RGD data ──────────────────────────────────────────────────────────────
   const [rgd, setRgd] = useState<K8sObject | null>(null)


### PR DESCRIPTION
## Summary

Four UX bugs fixed: health filters are now URL-synced (shareable/bookmarkable), reconciling instances show an amber pulsing dot, and unknown `?tab=` values fall back to the Graph tab instead of rendering blank.

## Changes

### #365 — /instances health filter not synced to URL
- `Instances.tsx`: added `useSearchParams`; reads `?health=` on mount; writes `?health=` on chip click; deletes param for "all"
- Renamed `data-testid` from `instances-health-filter-*` → `instances-health-chip-*` (matches journey 062)
- Updated journey 058 Step 7 to use the new testid

### #368 — Overview health filter not synced to URL
- `Home.tsx`: same pattern — reads `?health=` on mount, writes on chip click, deletes on clear

### #366 — Reconciling instances show grey "Unknown" dot
- `format.ts`: `ReadyState` extended with `'reconciling'`; `readyStateColor()` and `readyStateLabel()` handle it using `--color-status-reconciling` token
- `StatusDot.css`: `status-dot--reconciling` — amber pulsing dot (`@keyframes reconciling-pulse`)
- `Instances.tsx`: `toDotState()` now returns `'reconciling'` directly — no more `unknown` fallback
- `format.test.ts`: 2 new tests

### #367 — Unknown `?tab=` renders blank content
- `RGDDetail.tsx`: treats `'revisions'` as invalid when `!hasRevisions` (kro < v0.9.0), falling back to `'graph'`

## Testing
- `bun run tsc --noEmit` — clean
- `bun run vitest run` — 1204/1204 passed
- `go vet ./...` — clean

Closes #365
Closes #366
Closes #367
Closes #368