### PR TITLE
chore(release): prepare v0.8.1

### DIFF
--- a/helm/kro-ui/Chart.yaml
+++ b/helm/kro-ui/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kro-ui
 description: Web dashboard for kro ResourceGraphDefinitions
 type: application
-version: 0.8.0
-appVersion: "0.8.0"
+version: 0.8.1
+appVersion: "0.8.1"
 keywords:
   - kro
   - kubernetes


### PR DESCRIPTION
## v0.8.1

Patch release containing 5 fixes since v0.8.0:

| PR | Fix |
|----|-----|
| #359 | Fleet kro version reads from instance labels (not RGD annotations); Errors tab shows stuck IN_PROGRESS instances; escalation banner shows human-readable duration (2d 16h) |
| #363 | `#fff` → `var(--color-on-primary)` in Home.css + Catalog.css; stale 2s→5s timeout comments fixed |
| #364 | E2E journey backfill for specs 062, 064, 065, 066, 069, 070 |
| #369 | Health filter chips synced to `?health=` URL param (shareable); reconciling instances show amber pulsing dot; `?tab=revisions` falls back to graph on kro < v0.9.0 |
| #370 | OverviewHealthBar "no instances" chip tooltip no longer reads "no instances instances" |

## Changes

- `helm/kro-ui/Chart.yaml`: 0.8.0 → 0.8.1