### PR TITLE
fix(dag): external ref nodes show alive (not reconciling) while CR is IN_PROGRESS

### DIFF
--- a/web/src/lib/instanceNodeState.test.ts
+++ b/web/src/lib/instanceNodeState.test.ts
@@ -428,8 +428,10 @@ describe('buildNodeStateMap', () => {
   // ── T020: External ref nodes use globalState, not 'not-found' ────────────
   // External refs are pre-existing resources that kro watches but does not
   // create. They never receive kro.run/node-id labels, so they will always be
-  // absent from the stateMap after step 2. Instead of showing 'not-found' (grey),
-  // external nodes should reflect the CR-level globalState.
+  // absent from the stateMap after step 2. Instead of showing 'not-found' (grey)
+  // or inheriting 'reconciling' (amber), external nodes show 'alive' (green)
+  // whenever the CR is not in error — the ref was already resolved by kro before
+  // reconciliation reached the downstream resource that is still provisioning.
 
   describe('T020 — external ref node state inferred from globalState', () => {
     const externalNode = makeNode('inputConfig', 'ConfigMap', 'external')
@@ -446,12 +448,26 @@ describe('buildNodeStateMap', () => {
       expect(map['appOutput']?.state).toBe('alive')
     })
 
-    it('T020-02: external node shows reconciling when globalState=reconciling', () => {
+    it('T020-02: external node shows alive (not reconciling) when globalState=reconciling', () => {
+      // The external ref was already read by kro before it moved on to the slow
+      // downstream resource. Show green, not amber — the ref itself is not the
+      // thing that is reconciling.
       const instance = makeInstance([{ type: 'Progressing', status: 'True' }])
 
       const map = buildNodeStateMap(instance, [], [externalNode])
 
-      expect(map['inputConfig']?.state).toBe('reconciling')
+      expect(map['inputConfig']?.state).toBe('alive')
+    })
+
+    it('T020-02b: external node shows alive when globalState=reconciling via IN_PROGRESS', () => {
+      const instance = makeInstanceWithKroState('IN_PROGRESS', [
+        { type: 'ResourcesReady', status: 'False' },
+        { type: 'Ready', status: 'False' },
+      ])
+
+      const map = buildNodeStateMap(instance, [], [externalNode])
+
+      expect(map['inputConfig']?.state).toBe('alive')
     })
 
     it('T020-03: external node shows not-found when globalState=error (CR failed)', () => {

--- a/web/src/lib/instanceNodeState.ts
+++ b/web/src/lib/instanceNodeState.ts
@@ -255,13 +255,18 @@ export function buildNodeStateMap(
   // External ref resources are pre-existing and never created (or labelled)
   // by kro. GetInstanceChildren only returns kro-labelled resources, so
   // external nodes will always be absent from the stateMap after step 2.
-  // Showing 'not-found' (grey) for them is misleading when the CR is
-  // Ready=True — if the instance is healthy, the external ref was successfully
-  // accessed. Map external nodes to globalState instead so they reflect the
-  // actual CR health:
-  //   globalState=alive       → 'alive'  (green  — ref was accessed, instance ready)
-  //   globalState=reconciling → 'reconciling'  (amber — kro is resolving the ref)
-  //   globalState=error       → 'not-found'    (grey  — unknown if ref is reachable)
+  // Their state must be inferred from the CR-level signal:
+  //
+  //   globalState=alive       → 'alive'     (green  — ref was accessed, instance ready)
+  //   globalState=reconciling → 'alive'     (green  — ref was READ before kro moved on;
+  //                                           it exists. Showing amber is misleading since
+  //                                           the ref itself is not what's reconciling.)
+  //   globalState=error       → 'not-found' (grey   — unknown if ref is reachable; show
+  //                                           grey not amber to avoid false alarm on the ref)
+  //
+  // This fixes the same class of bug as PR #379: external refs like `kroConfig`
+  // (a ConfigMap externalRef) were showing amber while an unrelated downstream
+  // resource (e.g. RDS DBInstance with readyWhen) was still provisioning.
   for (const node of rgdNodes) {
     if (node.nodeType === 'instance' || node.nodeType === 'state') continue
     const nodeId = node.id  // use the RGD resource id, matching kro.run/node-id
@@ -273,9 +278,11 @@ export function buildNodeStateMap(
 
     let nodeState: NodeLiveState
     if (isExternalNode) {
-      // External refs are watched, not created — their health is inferred from
-      // the CR-level state rather than from a kro.run/node-id label on the resource.
-      nodeState = globalState === 'error' ? 'not-found' : globalState
+      // External refs are watched, not created. If the CR failed (error), we
+      // don't know if the ref is still reachable → show 'not-found' (grey).
+      // For both 'alive' and 'reconciling', the ref was already resolved by kro
+      // at an earlier reconciliation wave → show 'alive' (green).
+      nodeState = globalState === 'error' ? 'not-found' : 'alive'
     } else {
       const hasIncludeWhen = node.includeWhen.some((e) => e.trim() !== '')
       nodeState = hasIncludeWhen ? 'pending' : 'not-found'


### PR DESCRIPTION
## Summary

Same class of bug as PR #379. External ref nodes (e.g. a pre-existing ConfigMap that kro reads via `externalRef`) were showing amber/reconciling while a downstream resource was still provisioning and keeping the CR in `IN_PROGRESS`.

In Carlos Santana's `aiagentsystem` RGD, `kroConfig` is an `externalRef` to a ConfigMap. It was successfully read at the start of reconciliation. But while the RDS `vectordb` (with `readyWhen: dbInstanceStatus == "available"`) was still provisioning, `kroConfig` showed amber — misleading operators into thinking the config itself had an issue.

## Root Cause

`instanceNodeState.ts:278` mapped external nodes directly to `globalState`:
```typescript
nodeState = globalState === 'error' ? 'not-found' : globalState
// When globalState='reconciling' → 'reconciling' (amber) ← wrong
```

External refs are resolved in an early reconciliation wave. By the time a downstream resource is still provisioning (keeping the CR in `IN_PROGRESS`), the external ref was already successfully read — it is not the thing reconciling.

## Fix

External refs show `'alive'` for both `'alive'` and `'reconciling'` globalState. Only `globalState=error` maps to `'not-found'` (CR failed → ref reachability unknown):

```typescript
nodeState = globalState === 'error' ? 'not-found' : 'alive'
```

## Tests

T020-02 updated; T020-02b added (covers the `IN_PROGRESS` path). 28 cases, all pass.
`bun run vitest run` — 1208/1208 passed.