### PR TITLE
fix(css): add overflow-x: hidden to all overflow-y: auto scroll containers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,6 +251,7 @@ These were discovered in production QA. Every one produced a GitHub issue.
 | Fleet `isInstanceDegraded()` only checking `Ready=False` without excluding IN_PROGRESS | #343 | Check `status.state === 'IN_PROGRESS'` before the Ready condition check; IN_PROGRESS instances are reconciling, not degraded |
 | `ListAllInstances` fan-out timeout 2s insufficient on throttled clusters | #352 | Use 5s per-goroutine timeout; goroutines run in parallel so total handler latency ≈ max(individual) not sum(individual). 2s was leaving no time after DiscoverPlural (~1-2s on throttled clusters). |
 | Live DAG inheriting CR reconciling state to all child nodes | #379 | When globalState=reconciling (CR in IN_PROGRESS), each child should be judged on its own conditions, not inherit amber. Only globalState=error propagates to children. A Namespace or ConfigMap created in wave 1 shows green while a downstream RDS instance is still provisioning. |
+| `overflow-y: auto` without `overflow-x: hidden` on scroll containers | CSS | Setting `overflow-y` to a non-`visible` value causes the browser to implicitly promote `overflow-x` from `visible` to `auto`, creating a spurious horizontal scrollbar from sub-pixel rounding or ResizeObserver timing. Always pair `overflow-y: auto/scroll` with `overflow-x: hidden` on containers that should never scroll horizontally. |
 
 ### Upstream kro node types (5 real types + 1 kro-ui extension)
 

--- a/web/src/components/ContextSwitcher.css
+++ b/web/src/components/ContextSwitcher.css
@@ -84,6 +84,7 @@
   max-width: 360px;
   max-height: 300px;
   overflow-y: auto;
+  overflow-x: hidden;
   background: var(--color-surface-2);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);

--- a/web/src/components/GenerateTab.css
+++ b/web/src/components/GenerateTab.css
@@ -68,6 +68,7 @@
 .generate-tab__input-pane {
   min-width: 0;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .generate-tab__preview-pane {

--- a/web/src/components/LabelFilter.css
+++ b/web/src/components/LabelFilter.css
@@ -58,6 +58,7 @@
   min-width: 200px;
   max-height: 280px;
   overflow-y: auto;
+  overflow-x: hidden;
   background: var(--color-surface-2);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);

--- a/web/src/components/Layout.css
+++ b/web/src/components/Layout.css
@@ -26,4 +26,7 @@
 .layout__content {
   flex: 1;
   padding: 24px 32px;
+  /* Prevent page-level horizontal scrollbar — same class of bug as VirtualGrid.
+   * Pages should never scroll horizontally; clamp at the layout level. */
+  overflow-x: hidden;
 }

--- a/web/src/components/VirtualGrid.css
+++ b/web/src/components/VirtualGrid.css
@@ -3,6 +3,12 @@
 /* Outer scroll container */
 .virtual-grid {
   overflow-y: auto;
+  /* Prevent horizontal scrollbar: setting overflow-y to non-visible causes the
+   * browser to implicitly promote overflow-x from 'visible' to 'auto', which
+   * triggers a spurious horizontal scrollbar when content is even 1px wider
+   * (sub-pixel rounding, scrollbar gutter width, ResizeObserver timing race).
+   * Cards use 1fr columns and are never intentionally wider than the container. */
+  overflow-x: hidden;
   position: relative;
   /* Height set by caller via className; e.g. .home__virtual-grid */
 }

--- a/web/src/pages/AuthorPage.css
+++ b/web/src/pages/AuthorPage.css
@@ -63,6 +63,7 @@
   flex: 1 1 380px;
   min-width: 0;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 /* ── Right pane — DAG preview + YAML preview stacked ─────────────────── */
@@ -105,4 +106,5 @@
   min-width: 0;
   min-height: 0;
   overflow-y: auto;
+  overflow-x: hidden;
 }


### PR DESCRIPTION
## Root cause

Setting `overflow-y` to a non-`visible` value (`auto`/`scroll`) causes the browser to implicitly promote `overflow-x` from `visible` to `auto` per the CSS overflow spec. This creates a spurious **horizontal scrollbar** whenever content is even 1 pixel wider than the container — triggered by:
- Sub-pixel rounding in `grid-template-columns: repeat(N, 1fr)`
- Scrollbar gutter width changing the available space
- `ResizeObserver` timing races on first render

The VirtualGrid on Overview and Catalog pages was the most visible instance (scrollbar visible at the bottom of the card grid, as reported in the issue). But the same class of bug existed in 5 other scroll containers.

## Fix

Added `overflow-x: hidden` to every `overflow-y: auto` container that should never scroll horizontally:

| File | Container |
|------|-----------|
| `VirtualGrid.css` | `.virtual-grid` — the card grid (primary fix) |
| `Layout.css` | `.layout__content` — page-level shell |
| `LabelFilter.css` | dropdown list |
| `GenerateTab.css` | `.generate-tab__input-pane` |
| `ContextSwitcher.css` | dropdown list |
| `AuthorPage.css` | `.author-page__form-pane` + `.author-page__preview-pane` |

`NodeDetailPanel.css` is intentionally excluded — the node detail body allows horizontal scroll for wide YAML/code content.

## AGENTS.md

Added anti-pattern entry: *"Always pair `overflow-y: auto/scroll` with `overflow-x: hidden` on containers that should never scroll horizontally."*

## Testing
- `bun run tsc --noEmit` — clean
- `bun run vitest run` — 1209/1209 passed