### PR TITLE
fix(css): VirtualGrid gap-aware columns, align-items:start, card height 178px

### DIFF
--- a/web/src/components/Layout.css
+++ b/web/src/components/Layout.css
@@ -26,7 +26,7 @@
 .layout__content {
   flex: 1;
   padding: 24px 32px;
-  /* Prevent page-level horizontal scrollbar — same class of bug as VirtualGrid.
-   * Pages should never scroll horizontally; clamp at the layout level. */
-  overflow-x: hidden;
+  /* Do NOT add overflow-x: hidden here — it clips the DAG SVG on RGD detail
+   * pages (the graph SVG renders wider than its container and gets cut off,
+   * shifting the topology to the right with a blank left area). */
 }

--- a/web/src/components/RGDCard.css
+++ b/web/src/components/RGDCard.css
@@ -6,13 +6,11 @@
   transition: border-color var(--transition);
   display: flex;
   flex-direction: column;
-  /* Fixed height to match RGD_CARD_HEIGHT=130 in Home.tsx / Catalog.tsx.
-   * VirtualGrid uses this constant for row-offset math — if any card grows
-   * taller (e.g. error-hint text wraps), subsequent rows are misaligned and
-   * the right column gets clipped. overflow:hidden clips any overflow instead
-   * of letting the card grow. Content is still readable via tooltips (title
-   * attrs on error-hint, kind badge, etc.). */
-  height: 130px;
+  /* Fixed height matching RGD_CARD_HEIGHT=178 in Home.tsx.
+   * Derived: 16+24+8+18+16+16+4+24+8+28+16 = 178px (worst case with error hint).
+   * MUST match the JS constant — VirtualGrid uses it for row-offset math.
+   * overflow:hidden clips content that would grow the card beyond 178px. */
+  height: 178px;
   overflow: hidden;
 }
 

--- a/web/src/components/VirtualGrid.css
+++ b/web/src/components/VirtualGrid.css
@@ -3,12 +3,13 @@
 /* Outer scroll container */
 .virtual-grid {
   overflow-y: auto;
-  /* Prevent horizontal scrollbar: setting overflow-y to non-visible causes the
-   * browser to implicitly promote overflow-x from 'visible' to 'auto', which
-   * triggers a spurious horizontal scrollbar when content is even 1px wider
-   * (sub-pixel rounding, scrollbar gutter width, ResizeObserver timing race).
-   * Cards use 1fr columns and are never intentionally wider than the container. */
-  overflow-x: hidden;
+  /* Do NOT add overflow-x: hidden here — it causes two problems:
+   * 1. ResizeObserver reads the narrowed clientWidth and calculates fewer
+   *    columns (2 instead of 3), producing an incorrect grid layout.
+   * 2. The DAG SVG on RGD detail pages renders wider than the container;
+   *    overflow-x:hidden clips it and shifts the graph to the right.
+   * The horizontal scrollbar is prevented by Math.floor() in VirtualGrid.tsx
+   * which ensures the computed grid width never exceeds the container. */
   position: relative;
   /* Height set by caller via className; e.g. .home__virtual-grid */
 }
@@ -23,6 +24,10 @@
   display: grid;
   grid-template-columns: repeat(var(--vg-cols, 3), 1fr);
   gap: 16px;
+  /* align-items:start prevents the grid from stretching children to the tallest
+   * card in each row. Cards have a fixed height (RGD_CARD_HEIGHT px) enforced
+   * by the card CSS; stretching would override that fixed height. */
+  align-items: start;
 }
 
 /* Default empty-state wrapper */

--- a/web/src/components/VirtualGrid.tsx
+++ b/web/src/components/VirtualGrid.tsx
@@ -48,16 +48,20 @@ export default function VirtualGrid<T>({
 
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
+        // Math.floor prevents sub-pixel rounding from producing a grid
+        // fractionally wider than the container, which would cause a spurious
+        // horizontal scrollbar. contentRect.width is a float (e.g. 1274.666);
+        // flooring it ensures col calculations always fit within the container.
         const { width, height } = entry.contentRect
-        setContainerWidth(width)
-        setContainerHeight(height)
+        setContainerWidth(Math.floor(width))
+        setContainerHeight(Math.floor(height))
       }
     })
 
     observer.observe(el)
-    // Set initial dimensions synchronously
-    setContainerWidth(el.clientWidth)
-    setContainerHeight(el.clientHeight)
+    // Set initial dimensions synchronously — floor to prevent sub-pixel scrollbar
+    setContainerWidth(Math.floor(el.clientWidth))
+    setContainerHeight(Math.floor(el.clientHeight))
 
     return () => {
       observer.disconnect()
@@ -79,7 +83,12 @@ export default function VirtualGrid<T>({
     }
   }, [])
 
-  const cols = Math.max(1, Math.floor(containerWidth / MIN_CARD_WIDTH))
+  // Column count: account for gaps so the grid never overflows the container.
+  // With N columns and (N-1) gaps of GRID_GAP px:
+  //   N * MIN_CARD_WIDTH + (N-1) * GRID_GAP <= containerWidth
+  //   N <= (containerWidth + GRID_GAP) / (MIN_CARD_WIDTH + GRID_GAP)
+  const GRID_GAP = 16
+  const cols = Math.max(1, Math.floor((containerWidth + GRID_GAP) / (MIN_CARD_WIDTH + GRID_GAP)))
 
   // When containerHeight is 0 (not yet measured — JSDOM, SSR, or first paint),
   // render all items so the page is not blank and tests work without mocking

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -27,8 +27,10 @@ import OverviewHealthBar from '@/components/OverviewHealthBar'
 import type { HealthFilterState } from '@/components/OverviewHealthBar'
 import './Home.css'
 
-// RGDCard renders at a fixed ~130px height (header + meta + actions, no-wrap text).
-const RGD_CARD_HEIGHT = 130
+// RGDCard height: 16px pad + 24px header + 8px gap + 18px meta + 16px meta-margin
+//   + 16px error-hint + 4px hint-margin + 24px chip-row + 8px chip-margin
+//   + 28px actions + 16px pad = 178px. MUST match height:178px in RGDCard.css.
+const RGD_CARD_HEIGHT = 178
 
 export default function Home() {
   usePageTitle('Overview')


### PR DESCRIPTION
## Root causes fixed

Multiple interacting bugs caused the 3rd column clipping and variable card heights. They were only discoverable by live browser testing with pixel measurement.

### 1. `overflow-x: hidden` on `.virtual-grid` — REMOVED

This was added in PR #382 to prevent a horizontal scrollbar. It caused two severe side effects:
- `ResizeObserver` measured a narrowed `clientWidth` → column count dropped from 3→2
- Clipped the DAG SVG on RGD detail pages (graph shifted right with blank left area)

### 2. Gap-aware column formula — FIXED

The column calculation ignored the 16px CSS gaps between columns:
```
// OLD: at 1280px container, floor(1280/320) = 4 columns
//      4×320 + 3×16 = 1328px > 1280px → OVERFLOW
const cols = Math.floor(containerWidth / MIN_CARD_WIDTH)

// NEW: accounts for gaps in both numerator and denominator
//      at 1280px: floor((1280+16)/(320+16)) = floor(3.857) = 3 columns
//      3×320 + 2×16 = 992px → each 1fr = (1280-32)/3 = 416px ✓
const GRID_GAP = 16
const cols = Math.floor((containerWidth + GRID_GAP) / (MIN_CARD_WIDTH + GRID_GAP))
```

### 3. `ResizeObserver` float width — Math.floor applied

`contentRect.width` is a float (e.g. `1274.666`). `Math.floor()` ensures the column count never overestimates and the grid stays within bounds.

### 4. `align-items: start` on `.virtual-grid__items`

CSS Grid default is `stretch`. Without `align-items: start`, each row stretches its grid cells to the tallest card in that row — overriding the fixed `height: 178px` on `.rgd-card`. Adding `align-items: start` makes each card render at exactly its declared height.

### 5. `.rgd-card` height: 130px → 178px

`130px` was set before the Instances button was added. The full card layout needs 178px (measured: 16+24+8+18+16+16+4+24+8+28+16).

### `overflow-x: hidden` on `.layout__content` — REMOVED  

Also clipped the DAG SVG. The VirtualGrid's `overflow-y: auto` implicitly makes `overflow-x: auto`, but with the gap-aware column fix the grid no longer overflows its container — so no scrollbar appears.