### PR TITLE
fix(css): body overflow-x:hidden — prevents page-level horizontal scrollbar

### DIFF
--- a/web/src/tokens.css
+++ b/web/src/tokens.css
@@ -274,6 +274,10 @@ body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  /* Prevent page-level horizontal scroll. The app is a SPA — no page should
+   * ever scroll horizontally. Individual panels (e.g. YAML viewers) use their
+   * own overflow-x:auto when horizontal scroll is intentional. */
+  overflow-x: hidden;
 }
 
 code, pre, .mono { font-family: var(--font-mono); }


### PR DESCRIPTION
## What was wrong

On narrower viewports the entire page scrolled horizontally, pushing the left column off-screen (visible as clipped card names like "map-pair", "tesian-foreach" in the screenshot).

This was a **page-level** horizontal scrollbar on `<body>`, not the VirtualGrid's own scrollbar. The gap-aware column formula in PR #385 ensures the VirtualGrid never overflows by more than a sub-pixel. But floating-point 1fr column layout can still produce a total width 1-2px wider than the viewport — enough for the browser to add a page-level scrollbar.

## Fix

`body { overflow-x: hidden }` in `tokens.css`. A SPA never needs to scroll horizontally at the page level. Individual panels that intentionally need horizontal scroll (YAML viewers, wide tables) already have their own `overflow-x: auto` on their specific containers.

## Screenshot

Before: left column clipped, page scrolled right, horizontal scrollbar at bottom.  
After: 3 equal columns, all fully visible, no horizontal scrollbar, no clipping.