### PR TITLE
fix(secret-yaml): mask Secret data on initial load — GH #402 regression

### DIFF
--- a/web/src/components/LiveNodeDetailPanel.tsx
+++ b/web/src/components/LiveNodeDetailPanel.tsx
@@ -119,9 +119,15 @@ function YamlSection({ nodeId, resourceInfo, onRawObj }: YamlSectionProps) {
 
   const isSecret = rawObj != null && typeof rawObj.kind === 'string' && rawObj.kind === 'Secret'
 
-  /** Build the YAML string, masking Secret data fields unless revealed. */
+  /** Build the YAML string, masking Secret data fields unless revealed.
+   * GH #402 fix: derive isSecret from the obj parameter directly, not from
+   * the rawObj state variable — setRawObj is async so rawObj is still null
+   * when buildYaml is first called on initial load, causing the mask to be
+   * skipped and the raw base64 value to be rendered on the first render.
+   */
   function buildYaml(obj: K8sObject, revealed: boolean): string {
-    if (!isSecret || revealed) {
+    const objIsSecret = typeof obj.kind === 'string' && obj.kind === 'Secret'
+    if (!objIsSecret || revealed) {
       return toYaml(cleanK8sObject(obj))
     }
     // Mask: replace every base64 value in data/stringData with '••••••••'


### PR DESCRIPTION
## Summary

- Fixes a regression introduced in #404: Secret `data` values were shown as raw base64 on the first render of the YAML panel, before the user clicked the Reveal toggle.

## Root cause

`buildYaml` checked `isSecret` — a derived value from the `rawObj` React state variable. `rawObj` is `null` at the time `buildYaml` is first called inside the `.then()` callback (React `setState` is async). So `isSecret` was `false` on initial load, the masking branch was skipped, and the unmasked YAML was stored in `yamlState.yaml`.

The `🔒` banner rendered correctly on the next cycle (after `rawObj` settled), but by then `yamlState.yaml` already held the unmasked text.

## Fix

Read `obj.kind === 'Secret'` directly from the function parameter inside `buildYaml` instead of the stale `rawObj` state. The `isSecret` state variable is kept for the banner/toggle conditional rendering (which runs after `rawObj` has settled).

## Verification

Clicked the `secret` (Secret) node on `scp-alpha` (secret-configmap-pair instance):
- Before fix: `token: c3RhdGljLXRva2VuLWZvci1kZW1v` on first load
- After fix: `token: ••••••••` on first load; Reveal shows base64; Hide restores mask