### PR TITLE
fix(rgd-detail): prevent resource complexity hint from pushing layout right

### DIFF
--- a/web/src/pages/RGDDetail.css
+++ b/web/src/pages/RGDDetail.css
@@ -136,16 +136,23 @@
 
 /* ── Graph tab ────────────────────────────────────────────────────────────── */
 
+/* Column wrapper: stacks the refresh hint above the graph area. */
+.rgd-graph-column {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
 /* Issue #129: "refreshed X ago" indicator (constitution §XIII). */
 .rgd-graph-refresh-hint {
   padding: 4px 32px;
   font-size: 11px;
   color: var(--color-text-faint);
-  text-align: left;
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 0;
+  flex-shrink: 0;
   min-width: 0;
   overflow: hidden;
 }

--- a/web/src/pages/RGDDetail.tsx
+++ b/web/src/pages/RGDDetail.tsx
@@ -515,7 +515,7 @@ export default function RGDDetail() {
       {/* Tab content */}
       <div className="rgd-tab-content">
         {activeTab === "graph" && (
-          <>
+          <div className="rgd-graph-column">
             {/* Issue #129: "refreshed X ago" indicator (constitution §XIII) */}
             {rgdLastFetched && (
               <div className="rgd-graph-refresh-hint" aria-live="polite">
@@ -593,7 +593,7 @@ export default function RGDDetail() {
                 onClose={() => setSelectedNodeId(null)}
               />
             )}
-          </>
+          </div>
         )}
 
         {activeTab === "instances" && (


### PR DESCRIPTION
The 'refreshed X ago · N resources (ConfigMap, ServiceAccount, ...)' row in the DAG graph tab used `text-align: right` with no overflow constraint. Long resource lists expanded the row past the viewport width, pushing the DAG and all page content to the right.

**Fix:** remove `text-align: right`, use flex layout, add `overflow: hidden` on the row and `text-overflow: ellipsis` on the complexity span. Full list still accessible via `title` tooltip.