### PR TITLE
feat(kro): upgrade to kro v0.9.1

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -98,7 +98,7 @@ jobs:
           KRO_UI_BINARY: ${{ github.workspace }}/bin/kro-ui
           # Pin kro chart version to avoid a GitHub API call per run.
           # Bump this when upgrading kro in CI.
-          KRO_CHART_VERSION: "0.9.0"
+          KRO_CHART_VERSION: "0.9.1"
           CI: "true"
 
       # ── Artifacts ─────────────────────────────────────────────────────────

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ All changes go through PRs. Direct push to `main` is blocked.
 | `060-health-filter` | — | Clickable OverviewHealthBar chips — filter Overview by health state | Merged (PR #329) |
 | `061-helm-security` | — | Helm chart security hardening — runAsNonRoot, readOnlyRootFilesystem, drop ALL | Merged (PR #330) |
 | `062-instance-namespace-filter` | — | /instances namespace dropdown + health state filter chips | Merged (PR #345) |
+| `063-kro-v091-upgrade` | — | kro v0.9.1 upgrade — GraphRevision hash column, CEL hash help, reconcile suspended, version pins | In Progress |
 | `064-fleet-reconciling-count` | — | Fleet cluster card shows reconciling instance count separately from degraded | Merged (PR #347) |
 | `fix/fleet-kro-version` | — | Fleet kro version from RGD annotation — avoids DetectCapabilities delay | Merged (PR #355) |
 | `069-overview-rgd-error-banner` | — | Overview RGD compile-error banner — count + error-only filter toggle | Merged (PR #356) |
@@ -452,12 +453,13 @@ Always read the spec before writing code. Always run `go vet ./...` and
 - Go 1.25 backend + TypeScript 5.x + React 19 + React Router v7 + Vite — no new npm or Go dependencies introduced since v0.2.1
 - All state is local React `useState`; no persistence layer; no state management libraries
 - 6-state `InstanceHealthState` (ready/degraded/reconciling/error/pending/unknown); state map keyed by `kro.run/node-id` label (not by kind)
-- kro v0.9.0 API: GraphRevision CRD, scope badge, capabilities baseline (`hasGraphRevisions`, `hasExternalRefSelector`, `hasCELOmitFunction`)
+- kro v0.9.1 API: GraphRevision CRD + `kro.run/graph-revision-hash` label, scope badge, capabilities baseline (`hasGraphRevisions`, `hasExternalRefSelector`, `hasCELOmitFunction`); CEL hash functions `hash.fnv64a/sha256/md5`; `kro.run/reconcile=suspended` canonical annotation (also accepts legacy `disabled`)
 - Stress-test fixture RGDs on kind cluster: `never-ready`, `invalid-cel-rgd`, `typed-schema`, `optimization-candidate`, `triple-config`, `crashloop-app`, `multi-ns-app`, `multi-conditional`, `deep-dependency-chain`, `large-schema`, `multi-hpa-app`, `webapp-with-pdb`, `secret-configmap-pair`, `cross-namespace-config`
 - TypeScript 5.x / React 19 / Vite + React Router v7 (navigation), existing `@/lib/api` and `@/lib/format` (no new deps) (062-overview-sre-dashboard)
 - `localStorage` (layout mode key `"overview-layout"`, chart mode key `"overview-health-chart"`) (062-overview-sre-dashboard)
 
  ## Recent Changes
+ - v0.9.3 (063-kro-v091-upgrade): kro v0.9.1 upgrade — version pins bumped (scripts/demo.sh, global-setup.ts, e2e.yml); RevisionsTab hash column from `kro.run/graph-revision-hash` label (8-char truncation, graceful "—" on v0.9.0); CEL hash help in Designer (hash.fnv64a/sha256/md5); reconcile-paused banner uses canonical `suspended` annotation (accepts legacy `disabled`)
  - v0.9.2: fix(deep-dag) root CR expand toggle removed; DAG expanded panel SVG paint order fix; ValidationTab kro v0.9.0 condition names (GraphAccepted/GraphRevisionsResolved); RevisionsTab GraphVerified condition; double-v version display; listEvents AbortSignal; events.go 5s timeout; extractLastRevision() to @/lib/format; Helm chart CRDs vendor; RGDStatStrip + RGDDetail.logic tests; AGENTS.md docs fixes
  - v0.9.1: RGD detail stat strip (Age/Resources/Instances/Latest revision); RGD Graph tab DAG card panel matching instance detail layout; kro demo cluster upgraded to v0.9.0; GraphRevision CRD applied in demo + CI setup
  - v0.9.0: initial v0.9.0 release — fix(rgd-revision) read revision from GraphRevisionsResolved condition; fix(kro-version) demo/E2E setup apply GraphRevision CRD; kro v0.9.0 Helm install on kind demo cluster
@@ -492,6 +494,4 @@ Always read the spec before writing code. Always run `go vet ./...` and
 - v0.3.3: cluster-wide child resource search; parallel events fan-out; DAG width fitted; null items guard
 - v0.3.2: Docker image includes aws CLI v2 for EKS exec credential plugin
 - v0.3.1: DAG legend; required-field a11y; overlay crash fix; expand accordion fix; demo hardening
-- v0.3.0: instance telemetry panel; cross-instance error aggregation (Errors tab); instance health roll-up; DAG instance overlay; global footer; first-time onboarding; deletion debugger; RBAC SA auto-detection; RGD detail header enrichment
-
-- 062-overview-sre-dashboard: Added TypeScript 5.x / React 19 / Vite + React Router v7 (navigation), existing `@/lib/api` and `@/lib/format` (no new deps)
+ - v0.3.0: instance telemetry panel; cross-instance error aggregation (Errors tab); instance health roll-up; DAG instance overlay; global footer; first-time onboarding; deletion debugger; RBAC SA auto-detection; RGD detail header enrichment

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -42,7 +42,7 @@ ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 FIXTURES_DIR="${ROOT_DIR}/test/e2e/fixtures"
 BINARY="${ROOT_DIR}/bin/kro-ui"
 KUBECONFIG_PATH="${ROOT_DIR}/.demo-kubeconfig.yaml"
-FALLBACK_KRO_VERSION="0.9.0"
+FALLBACK_KRO_VERSION="0.9.1"
 
 # ── Colour helpers ────────────────────────────────────────────────────────────
 GREEN='\033[0;32m'

--- a/test/e2e/setup/global-setup.ts
+++ b/test/e2e/setup/global-setup.ts
@@ -513,7 +513,7 @@ function registerAltContext(kubeconfigPath: string, sourceContext: string, newCo
  * Falls back to a known-good version if the API call fails.
  */
 function detectLatestKroVersion(): string {
-  const FALLBACK_VERSION = '0.9.0'
+  const FALLBACK_VERSION = '0.9.1'
   try {
     const output = execFileSync(
       'curl',

--- a/web/src/components/RGDAuthoringForm.tsx
+++ b/web/src/components/RGDAuthoringForm.tsx
@@ -654,7 +654,7 @@ export default function RGDAuthoringForm({ state, onChange, staticIssues }: RGDA
                 />
                 <span
                   className="rgd-authoring-form__cel-badge"
-                  title="CEL — Common Expression Language. References schema fields with ${schema.spec.fieldName}. Example: ${schema.spec.replicas}"
+                  title="CEL — Common Expression Language. References schema fields with ${schema.spec.fieldName}. Example: ${schema.spec.replicas} | hash functions (kro ≥0.9.1): hash.fnv64a(str)→bytes (recommended), hash.sha256(str)→bytes, hash.md5(str)→bytes"
                 >CEL</span>
               </div>
               <button
@@ -1095,7 +1095,7 @@ export default function RGDAuthoringForm({ state, onChange, staticIssues }: RGDA
                             />
                             <span
                               className="rgd-authoring-form__cel-badge"
-                              title="CEL — Common Expression Language. This expression must evaluate to true for the resource to be considered Ready. Example: ${web.status.availableReplicas} >= 1"
+                              title="CEL — Common Expression Language. This expression must evaluate to true for the resource to be considered Ready. Example: ${web.status.availableReplicas} >= 1 | hash functions (kro ≥0.9.1): hash.fnv64a(str)→bytes (recommended), hash.sha256(str)→bytes, hash.md5(str)→bytes"
                             >CEL</span>
                           </div>
                           <button

--- a/web/src/components/RevisionsTab.css
+++ b/web/src/components/RevisionsTab.css
@@ -70,6 +70,28 @@
   width: 40%;
 }
 
+/* ── Hash column (kro v0.9.1+ — kro.run/graph-revision-hash label) ────────── */
+
+.revisions-table__th--hash {
+  min-width: 90px;
+}
+
+.revisions-table__td--hash {
+  white-space: nowrap;
+}
+
+.revisions-table__hash {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-muted);
+  cursor: default;
+}
+
+.revisions-table__hash--absent {
+  color: var(--color-text-disabled, var(--color-text-muted));
+  opacity: 0.5;
+}
+
 .revisions-table__td {
   padding: 8px 12px;
   border-bottom: 1px solid var(--color-border-subtle);

--- a/web/src/components/RevisionsTab.tsx
+++ b/web/src/components/RevisionsTab.tsx
@@ -43,6 +43,22 @@ function revisionNumber(rev: K8sObject): number {
   return typeof spec?.revision === 'number' ? spec.revision : 0
 }
 
+/** Read the compiled graph hash from the GraphRevision label (kro v0.9.1+).
+ *
+ * Returns the first 8 chars of `kro.run/graph-revision-hash` for display,
+ * and the full value for the title tooltip. Returns "—" when absent
+ * (kro v0.9.0 objects and any revision created before the label existed).
+ */
+function hashFromRevision(rev: K8sObject): { display: string; full: string | undefined } {
+  const labels = (rev.metadata as Record<string, unknown> | undefined)?.labels
+  const full =
+    typeof labels === 'object' && labels !== null
+      ? ((labels as Record<string, unknown>)['kro.run/graph-revision-hash'] as string | undefined)
+      : undefined
+  if (!full) return { display: '—', full: undefined }
+  return { display: full.length > 8 ? full.slice(0, 8) : full, full }
+}
+
 /** Extract the compiled state from a GraphRevision status.
  *
  * Condition type mapping by kro version:
@@ -265,6 +281,7 @@ export default function RevisionsTab({ rgdName }: RevisionsTabProps) {
           <tr>
             {revisions.length > 1 && <th className="revisions-table__th revisions-table__th--check" />}
             <th className="revisions-table__th">Revision</th>
+            <th className="revisions-table__th revisions-table__th--hash">Hash</th>
             <th className="revisions-table__th">Status</th>
             <th className="revisions-table__th">Age</th>
             <th className="revisions-table__th revisions-table__th--msg">Message</th>
@@ -279,6 +296,7 @@ export default function RevisionsTab({ rgdName }: RevisionsTabProps) {
             const createdAt = extractCreationTimestamp(rev)
             const age = createdAt ? formatAge(createdAt) : '—'
             const revNum = revisionNumber(rev)
+            const { display: hashDisplay, full: hashFull } = hashFromRevision(rev)
             const isExpanded = expanded === name
 
             return (
@@ -308,6 +326,13 @@ export default function RevisionsTab({ rgdName }: RevisionsTabProps) {
                     <span className="revisions-table__rev-num">#{revNum}</span>
                     <span className="revisions-table__rev-name" title={name}>{name}</span>
                   </td>
+                  <td className="revisions-table__td revisions-table__td--hash">
+                    {hashFull ? (
+                      <span className="revisions-table__hash" title={hashFull}>{hashDisplay}</span>
+                    ) : (
+                      <span className="revisions-table__hash revisions-table__hash--absent">—</span>
+                    )}
+                  </td>
                   <td className="revisions-table__td">
                     <span className={`revisions-table__badge revisions-table__badge--${state}`}>
                       {state === 'compiled' ? 'Compiled' : state === 'failed' ? 'Failed' : 'Unknown'}
@@ -324,7 +349,7 @@ export default function RevisionsTab({ rgdName }: RevisionsTabProps) {
                 </tr>
                 {isExpanded && (
                   <tr key={`${name}-detail`} className="revisions-table__detail-row">
-                    <td colSpan={4} className="revisions-table__detail-cell">
+                    <td colSpan={5} className="revisions-table__detail-cell">
                       <KroCodeBlock
                         code={toYaml(cleanK8sObject(rev))}
                         title={`Revision ${name}`}

--- a/web/src/pages/InstanceDetail.tsx
+++ b/web/src/pages/InstanceDetail.tsx
@@ -97,8 +97,10 @@ function RefreshIndicator({
 }
 
 // ── Reconcile-paused detection ────────────────────────────────────────────
-// kro v0.9.0 changed from a label to an annotation:
-//   Annotation: metadata.annotations["kro.run/reconcile"] === "disabled"
+// kro v0.9.1 made `suspended` the canonical annotation value (PR #1221).
+// kro v0.9.0 used `disabled`. Both are still accepted by kro ≥v0.9.1.
+// kro-ui detects either value so the banner shows on both old and new clusters.
+//   Annotation: metadata.annotations["kro.run/reconcile"] === "suspended" | "disabled"
 // When present, kro stops reconciling the instance until the annotation is removed.
 
 function isReconcilePaused(instance: K8sObject | null): boolean {
@@ -107,7 +109,8 @@ function isReconcilePaused(instance: K8sObject | null): boolean {
   if (!meta) return false
   const annotations = meta.annotations
   if (typeof annotations !== 'object' || annotations === null) return false
-  return (annotations as Record<string, unknown>)['kro.run/reconcile'] === 'disabled'
+  const val = (annotations as Record<string, unknown>)['kro.run/reconcile']
+  return val === 'suspended' || val === 'disabled'
 }
 
 // ── Reconciling duration ──────────────────────────────────────────────────
@@ -460,17 +463,17 @@ export default function InstanceDetail() {
         />
       )}
 
-      {/* Reconciliation paused banner (kro v0.9.0 — annotation kro.run/reconcile=disabled) */}
+      {/* Reconciliation paused banner (kro v0.9.1 — annotation kro.run/reconcile=suspended (also accepts legacy 'disabled')) */}
       {fastData && isReconcilePaused(fastData.instance) && (
         <div
           className="reconcile-paused-banner"
           role="status"
           aria-live="polite"
-          title="kro.run/reconcile: disabled annotation is present. Remove the annotation to resume reconciliation: kubectl annotate <kind> <name> kro.run/reconcile-"
+          title="kro.run/reconcile: suspended annotation is present. Remove the annotation to resume reconciliation: kubectl annotate <kind> <name> kro.run/reconcile-"
         >
           <span className="reconcile-paused-banner__icon" aria-hidden="true">⏸</span>
           Reconciliation paused — kro will not apply changes until the{' '}
-          <code className="reconcile-paused-banner__code">kro.run/reconcile: disabled</code>
+          <code className="reconcile-paused-banner__code">kro.run/reconcile: suspended</code>
           {' '}annotation is removed.
         </div>
       )}


### PR DESCRIPTION
## Summary

- **Version pins**: bump `scripts/demo.sh`, `test/e2e/setup/global-setup.ts`, `.github/workflows/e2e.yml` from `0.9.0` → `0.9.1`; live demo cluster upgraded via `helm upgrade`
- **RevisionsTab**: add `Hash` column reading `kro.run/graph-revision-hash` label — 8-char display, full value in `title` tooltip, graceful `"—"` on pre-v0.9.1 objects
- **CEL hash help**: `RGDAuthoringForm` status-field and readyWhen CEL badges now surface `hash.fnv64a/sha256/md5` in their `title` tooltips
- **Reconcile-paused banner**: `isReconcilePaused()` accepts both `suspended` (canonical v0.9.1) and `disabled` (legacy); all user-visible copy updated to `suspended`

## Testing

Verified live on `kind-kro-ui-demo` cluster (kro v0.9.1):
- `kubectl get graphrevisions -A` shows `HASH` column populated on all revisions
- Revisions tab shows `53b82793` (8-char) with full hash `53b827937ebe4551` in tooltip
- CEL badge tooltip includes `hash.fnv64a(str)→bytes (recommended), hash.sha256(str)→bytes, hash.md5(str)→bytes`
- Banner shows with `kro.run/reconcile: suspended` copy for both `suspended` and `disabled` annotation values

## Spec

`.specify/specs/063-kro-v091-upgrade/spec.md`

Closes #63