### PR TITLE
fix: in-cluster fallback

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -66,7 +66,7 @@ var versionCmd = &cobra.Command{
 
 func init() {
 	serveCmd.Flags().IntVarP(&port, "port", "p", 40107, "Port to listen on (40107 = D,A,G)")
-	serveCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig (defaults to $KUBECONFIG or ~/.kube/config)")
+	serveCmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig (defaults to $KUBECONFIG; if unset, attempts in-cluster config)")
 	serveCmd.Flags().StringVar(&context, "context", "", "Kubernetes context to use (defaults to current context)")
 
 	rootCmd.AddCommand(serveCmd)

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -81,21 +80,25 @@ type ClientFactory struct {
 }
 
 // NewClientFactory creates a ClientFactory from the given kubeconfig path and context.
-// If kubeconfigPath is empty it falls back to $KUBECONFIG then ~/.kube/config.
+// If kubeconfigPath is empty it falls back to $KUBECONFIG.
+// If neither is set, it attempts in-cluster config (for running inside a Kubernetes cluster).
 // If context is empty it uses the current context in the kubeconfig.
 func NewClientFactory(kubeconfigPath, context string) (*ClientFactory, error) {
-	if kubeconfigPath == "" {
-		if env := os.Getenv("KUBECONFIG"); env != "" {
-			kubeconfigPath = env
-		} else {
-			home, _ := os.UserHomeDir()
-			kubeconfigPath = filepath.Join(home, ".kube", "config")
+	path := kubeconfigPath
+	if path == "" {
+		path = os.Getenv("KUBECONFIG")
+	}
+	if path != "" {
+		f := &ClientFactory{kubeconfigPath: path}
+		if err := f.load(context); err != nil {
+			return nil, err
 		}
+		return f, nil
 	}
 
-	f := &ClientFactory{kubeconfigPath: kubeconfigPath}
-	if err := f.load(context); err != nil {
-		return nil, err
+	f := &ClientFactory{kubeconfigPath: ""}
+	if err := f.loadInCluster(); err != nil {
+		return nil, fmt.Errorf("no kubeconfig and in-cluster unavailable: %w", err)
 	}
 	return f, nil
 }
@@ -146,6 +149,34 @@ func (f *ClientFactory) load(context string) error {
 	f.discovery = disc
 	f.activeContext = active
 	// Invalidate discovery cache on context switch so the new cluster is discovered fresh.
+	f.discCache.invalidate()
+	return nil
+}
+
+// loadInCluster builds clients using in-cluster config (ServiceAccount token).
+// This is used when running inside a Kubernetes cluster without a kubeconfig file.
+func (f *ClientFactory) loadInCluster() error {
+	restCfg, err := rest.InClusterConfig()
+	if err != nil {
+		return fmt.Errorf("in-cluster config: %w", err)
+	}
+
+	dyn, err := dynamic.NewForConfig(restCfg)
+	if err != nil {
+		return fmt.Errorf("build dynamic client: %w", err)
+	}
+
+	disc, err := discovery.NewDiscoveryClientForConfig(restCfg)
+	if err != nil {
+		return fmt.Errorf("build discovery client: %w", err)
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.restConfig = restCfg
+	f.dynamic = dyn
+	f.discovery = disc
+	f.activeContext = "in-cluster"
 	f.discCache.invalidate()
 	return nil
 }

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -80,13 +80,18 @@ type ClientFactory struct {
 }
 
 // NewClientFactory creates a ClientFactory from the given kubeconfig path and context.
-// If kubeconfigPath is empty it falls back to $KUBECONFIG.
-// If neither is set, it attempts in-cluster config (for running inside a Kubernetes cluster).
+// Fallback chain: explicit path → $KUBECONFIG → ~/.kube/config → in-cluster.
 // If context is empty it uses the current context in the kubeconfig.
 func NewClientFactory(kubeconfigPath, context string) (*ClientFactory, error) {
 	path := kubeconfigPath
 	if path == "" {
 		path = os.Getenv("KUBECONFIG")
+	}
+	if path == "" {
+		defaultPath := os.ExpandEnv("$HOME/.kube/config")
+		if _, err := os.Stat(defaultPath); err == nil {
+			path = defaultPath
+		}
 	}
 	if path != "" {
 		f := &ClientFactory{kubeconfigPath: path}
@@ -182,11 +187,15 @@ func (f *ClientFactory) loadInCluster() error {
 }
 
 // SwitchContext reloads all clients for the given context.
-// Returns an error if the context name is empty or not found in the kubeconfig.
+// Returns an error if the factory was created with in-cluster mode
+// (context switching is not supported when running inside a pod).
 // After a successful switch, all registered context-switch hooks are called.
 func (f *ClientFactory) SwitchContext(ctx string) error {
 	if ctx == "" {
 		return errors.New("context name must not be empty")
+	}
+	if f.kubeconfigPath == "" {
+		return errors.New("context switching not supported in in-cluster mode")
 	}
 	if err := f.load(ctx); err != nil {
 		return err
@@ -267,7 +276,13 @@ func (f *ClientFactory) ActiveContext() string {
 }
 
 // ListContexts returns all available contexts from the kubeconfig and the active context.
+// When running in-cluster (no kubeconfig file), returns a synthetic single-context list
+// containing only the in-cluster context.
 func (f *ClientFactory) ListContexts() ([]Context, string, error) {
+	if f.kubeconfigPath == "" {
+		return []Context{{Name: "in-cluster", Cluster: "", User: ""}}, "in-cluster", nil
+	}
+
 	loadingRules := &clientcmd.ClientConfigLoadingRules{ExplicitPath: f.kubeconfigPath}
 	rawCfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		loadingRules, &clientcmd.ConfigOverrides{},

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -263,3 +263,45 @@ func TestConcurrentAccess(t *testing.T) {
 	active := f.ActiveContext()
 	assert.Contains(t, []string{"dev", "prod"}, active)
 }
+
+func TestInClusterFallback(t *testing.T) {
+	t.Run("returns clear error when not running in a pod", func(t *testing.T) {
+		// Point HOME to a temp dir so ~/.kube/config doesn't exist,
+		// forcing the code past the kubeconfig fallback into the in-cluster path.
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv("KUBECONFIG", "")
+		t.Setenv("KUBERNETES_SERVICE_HOST", "")
+		t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+		_, err := NewClientFactory("", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "in-cluster unavailable")
+	})
+}
+
+func TestInClusterModeListContexts(t *testing.T) {
+	// Simulate in-cluster mode by constructing a factory with no kubeconfig path.
+	f := &ClientFactory{
+		kubeconfigPath: "",
+		activeContext:  "in-cluster",
+	}
+
+	contexts, active, err := f.ListContexts()
+	require.NoError(t, err)
+	assert.Equal(t, "in-cluster", active)
+	require.Len(t, contexts, 1)
+	assert.Equal(t, "in-cluster", contexts[0].Name)
+}
+
+func TestInClusterModeSwitchContext(t *testing.T) {
+	f := &ClientFactory{
+		kubeconfigPath: "",
+		activeContext:  "in-cluster",
+	}
+
+	err := f.SwitchContext("some-context")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "in-cluster mode")
+	// Active context unchanged.
+	assert.Equal(t, "in-cluster", f.ActiveContext())
+}


### PR DESCRIPTION
Add in-cluster config fallback for NewClientFactory

- Removed unused path/filepath import
- NewClientFactory now falls back to KUBECONFIG env, then in-cluster config
- Added loadInCluster() method using ServiceAccount token for running inside a pod