### PR TITLE
test(validate): real type-checking + comprehensive coverage for CEL version isolation

### DIFF
--- a/internal/api/handlers/validate_test.go
+++ b/internal/api/handlers/validate_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	apitypes "github.com/pnz1990/kro-ui/internal/api/types"
+	k8sclient "github.com/pnz1990/kro-ui/internal/k8s"
 )
 
 // ── helpers ────────────────────────────────────────────────────────────────
@@ -329,3 +330,109 @@ spec:
 
 // Ensure the rgdGVR variable from rgds.go is accessible in this file.
 var _ = schema.GroupVersionResource{}
+
+// ── TestKroVersionForRequest ───────────────────────────────────────────────
+
+// TestKroVersionForRequest verifies that kroVersionForRequest returns the
+// version from the capabilities cache when warm, and "" when cold.
+// It also verifies that a warm cache with an older kro version causes
+// ValidateRGDStatic to reject expressions using newer kro functions.
+func TestKroVersionForRequest(t *testing.T) {
+	t.Cleanup(func() { capCache.invalidate() })
+
+	t.Run("cold cache returns empty string", func(t *testing.T) {
+		capCache.invalidate()
+		v := kroVersionForRequest()
+		if v != "" {
+			t.Errorf("cold cache: expected \"\", got %q", v)
+		}
+	})
+
+	t.Run("warm cache returns stored version", func(t *testing.T) {
+		capCache.invalidate()
+		capCache.set(&k8sclient.KroCapabilities{Version: "v0.9.1"})
+		v := kroVersionForRequest()
+		if v != "v0.9.1" {
+			t.Errorf("warm cache: expected \"v0.9.1\", got %q", v)
+		}
+	})
+
+	// End-to-end: when capCache is warm with v0.8.5, ValidateRGDStatic must
+	// reject hash.fnv64a (a v0.9.1-only function).
+	t.Run("ValidateRGDStatic rejects v0.9.1 function on v0.8.5 cluster", func(t *testing.T) {
+		capCache.invalidate()
+		capCache.set(&k8sclient.KroCapabilities{Version: "v0.8.5"})
+
+		h := newStaticHandler()
+		yaml := `apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: my-app
+spec:
+  schema:
+    kind: MyApp
+    apiVersion: v1alpha1
+  resources:
+    - id: web
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${hash.fnv64a("hello")}
+`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/rgds/validate/static", strings.NewReader(yaml))
+		w := httptest.NewRecorder()
+
+		h.ValidateRGDStatic(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var res apitypes.StaticValidationResult
+		if err := json.NewDecoder(w.Body).Decode(&res); err != nil {
+			t.Fatalf("decode error: %v", err)
+		}
+		if len(res.Issues) == 0 {
+			t.Error("expected at least 1 issue: hash.fnv64a should be rejected on v0.8.5 cluster")
+		}
+	})
+
+	// End-to-end: same expression must be accepted on a v0.9.1 cluster.
+	t.Run("ValidateRGDStatic accepts v0.9.1 function on v0.9.1 cluster", func(t *testing.T) {
+		capCache.invalidate()
+		capCache.set(&k8sclient.KroCapabilities{Version: "v0.9.1"})
+
+		h := newStaticHandler()
+		yaml := `apiVersion: kro.run/v1alpha1
+kind: ResourceGraphDefinition
+metadata:
+  name: my-app
+spec:
+  schema:
+    kind: MyApp
+    apiVersion: v1alpha1
+  resources:
+    - id: web
+      template:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: ${hash.fnv64a("hello")}
+`
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/rgds/validate/static", strings.NewReader(yaml))
+		w := httptest.NewRecorder()
+
+		h.ValidateRGDStatic(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var res apitypes.StaticValidationResult
+		if err := json.NewDecoder(w.Body).Decode(&res); err != nil {
+			t.Fatalf("decode error: %v", err)
+		}
+		if len(res.Issues) != 0 {
+			t.Errorf("expected 0 issues for hash.fnv64a on v0.9.1 cluster, got: %v", res.Issues)
+		}
+	})
+}

--- a/internal/validate/cel_versions.go
+++ b/internal/validate/cel_versions.go
@@ -32,12 +32,15 @@ package validate
 //
 //	{
 //	    minVersion: "X.Y.Z",
-//	    build: func() (func(string) error, error) {
-//	        env, err := cel.NewEnv(
-//	            krocel.BaseDeclarations()...,
-//	            // ── add ONLY the libraries introduced in vX.Y.Z here ──
+//	    build: func() (func(string, []string) error, error) {
+//	        env, err := cel.NewEnv(append(
+//	            baseCELOptions(),
+//	            // ── include ALL libraries from all prior versions ──
+//	            library.Omit(),   // v0.9.0
+//	            library.Hash(),   // v0.9.1
+//	            // ── add ONLY the new libraries introduced in vX.Y.Z ──
 //	            cel.Lib(library.NewThing()),
-//	        )
+//	        )...)
 //	        if err != nil { return nil, err }
 //	        return checkFunc(env), nil
 //	    },
@@ -142,6 +145,14 @@ var celVersionRegistry = []*celVersionEntry{
 		build: func() (func(expr string, varNames []string) error, error) {
 			env, err := cel.NewEnv(append(
 				baseCELOptions(),
+				// v0.9.0 additions
+				library.Omit(),
+				library.Maps(),
+				library.JSON(),
+				library.Lists(),
+				ext.Bindings(),
+				ext.TwoVarComprehensions(),
+				// v0.9.1 additions
 				library.Hash(),
 			)...)
 			if err != nil {
@@ -160,6 +171,7 @@ var celVersionRegistry = []*celVersionEntry{
 		build: func() (func(expr string, varNames []string) error, error) {
 			env, err := cel.NewEnv(append(
 				baseCELOptions(),
+				// v0.9.0 additions
 				library.Omit(),
 				library.Maps(),
 				library.JSON(),

--- a/internal/validate/cel_versions.go
+++ b/internal/validate/cel_versions.go
@@ -39,7 +39,7 @@ package validate
 //	            cel.Lib(library.NewThing()),
 //	        )
 //	        if err != nil { return nil, err }
-//	        return parseFunc(env), nil
+//	        return checkFunc(env), nil
 //	    },
 //	},
 //
@@ -67,21 +67,55 @@ type celVersionEntry struct {
 	minVersion string
 
 	once    sync.Once
-	fn      func(string) error // set by build on first use
+	fn      func(expr string, varNames []string) error // set by build on first use
 	initErr error
 
 	// build constructs the CEL environment for this bucket.
 	// It is only invoked once; the result is cached in fn.
-	build func() (func(string) error, error)
+	build func() (func(expr string, varNames []string) error, error)
 }
 
-// parseFunc wraps a *cel.Env into the string-in/error-out closure used by
-// ValidateCELExpressions. The *cel.Env type from github.com/google/cel-go is
-// captured inside the closure so callers never need to import cel-go directly.
-func parseFunc(env *cel.Env) func(string) error {
-	return func(expr string) error {
-		_, iss := env.Parse(expr)
-		if iss != nil {
+// checkFunc wraps a *cel.Env into the (expr, varNames) → error closure used by
+// ValidateCELExpressions. It performs both syntax (Parse) and semantic
+// (Check) validation so that calls to unknown functions — e.g. hash.fnv64a()
+// on a v0.8.x cluster — are correctly rejected.
+//
+// varNames are the resource IDs visible in the current expression context
+// (e.g. "schema", "vpc", "subnet"). Each is declared as cel.DynType so that
+// field-access chains like schema.spec.replicas type-check without requiring
+// the full OpenAPI schema.
+//
+// The *cel.Env type from github.com/google/cel-go is captured inside the
+// closure so callers never need to import cel-go directly.
+func checkFunc(env *cel.Env) func(expr string, varNames []string) error {
+	return func(expr string, varNames []string) error {
+		// Build a per-check extension of the base env that declares the
+		// resource variables as dynamic-typed. env.Extend() is cheap —
+		// it inherits all library registrations from the parent.
+		vars := make([]cel.EnvOption, 0, len(varNames)+1)
+		// "schema" is always in scope in kro CEL expressions.
+		vars = append(vars, cel.Variable("schema", cel.DynType))
+		for _, name := range varNames {
+			if name != "" && name != "schema" {
+				vars = append(vars, cel.Variable(name, cel.DynType))
+			}
+		}
+		checkEnv, err := env.Extend(vars...)
+		if err != nil {
+			// Fallback: parse-only if the extension fails (should never happen).
+			_, iss := env.Parse(expr)
+			if iss != nil {
+				return iss.Err()
+			}
+			return nil
+		}
+
+		ast, iss := checkEnv.Parse(expr)
+		if iss != nil && iss.Err() != nil {
+			return iss.Err()
+		}
+		_, iss = checkEnv.Check(ast)
+		if iss != nil && iss.Err() != nil {
 			return iss.Err()
 		}
 		return nil
@@ -105,7 +139,7 @@ var celVersionRegistry = []*celVersionEntry{
 	// Ref:   https://github.com/kubernetes-sigs/kro/releases/tag/v0.9.1
 	{
 		minVersion: "0.9.1",
-		build: func() (func(string) error, error) {
+		build: func() (func(expr string, varNames []string) error, error) {
 			env, err := cel.NewEnv(append(
 				baseCELOptions(),
 				library.Hash(),
@@ -113,7 +147,7 @@ var celVersionRegistry = []*celVersionEntry{
 			if err != nil {
 				return nil, fmt.Errorf("build v0.9.1 CEL env: %w", err)
 			}
-			return parseFunc(env), nil
+			return checkFunc(env), nil
 		},
 	},
 
@@ -123,7 +157,7 @@ var celVersionRegistry = []*celVersionEntry{
 	// Ref:   https://github.com/kubernetes-sigs/kro/releases/tag/v0.9.0
 	{
 		minVersion: "0.9.0",
-		build: func() (func(string) error, error) {
+		build: func() (func(expr string, varNames []string) error, error) {
 			env, err := cel.NewEnv(append(
 				baseCELOptions(),
 				library.Omit(),
@@ -136,7 +170,7 @@ var celVersionRegistry = []*celVersionEntry{
 			if err != nil {
 				return nil, fmt.Errorf("build v0.9.0 CEL env: %w", err)
 			}
-			return parseFunc(env), nil
+			return checkFunc(env), nil
 		},
 	},
 
@@ -146,12 +180,12 @@ var celVersionRegistry = []*celVersionEntry{
 	// and so does "unknown" after envForVersion's fallback logic.
 	{
 		minVersion: "0.8.0",
-		build: func() (func(string) error, error) {
+		build: func() (func(expr string, varNames []string) error, error) {
 			env, err := cel.NewEnv(baseCELOptions()...)
 			if err != nil {
 				return nil, fmt.Errorf("build v0.8.x CEL env: %w", err)
 			}
-			return parseFunc(env), nil
+			return checkFunc(env), nil
 		},
 	},
 }
@@ -179,13 +213,13 @@ func baseCELOptions() []cel.EnvOption {
 	}
 }
 
-// envForVersion returns the parse function for the given kro version string.
+// envForVersion returns the check function for the given kro version string.
 // It selects the newest registry entry whose minVersion is ≤ kroVersion.
 // When kroVersion is empty or "unknown", the oldest (most conservative) entry
 // is returned so validation never produces false positives.
 //
 // The selected entry's build func is called at most once (sync.Once).
-func envForVersion(kroVersion string) (func(string) error, error) {
+func envForVersion(kroVersion string) (func(expr string, varNames []string) error, error) {
 	// Determine which entry to use.
 	selected := celVersionRegistry[len(celVersionRegistry)-1] // oldest = safest default
 

--- a/internal/validate/cel_versions_internal_test.go
+++ b/internal/validate/cel_versions_internal_test.go
@@ -1,0 +1,260 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package validate — internal (white-box) tests for package-private helpers.
+// Uses `package validate` (not `package validate_test`) to access unexported
+// functions: compareVersionStrings, parseVersionTriple, envForVersion,
+// celVersionRegistry.
+package validate
+
+import (
+	"errors"
+	"sync"
+	"testing"
+)
+
+// ── compareVersionStrings ─────────────────────────────────────────────────
+
+func TestCompareVersionStrings(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		// Major comparison
+		{"1.0.0", "0.9.1", 1},
+		{"0.9.1", "1.0.0", -1},
+		// Minor comparison (same major)
+		{"0.9.0", "0.8.5", 1},
+		{"0.8.5", "0.9.0", -1},
+		// Patch comparison (same major.minor)
+		{"0.9.2", "0.9.1", 1},
+		{"0.9.1", "0.9.2", -1},
+		// Equal
+		{"0.9.1", "0.9.1", 0},
+		{"0.8.0", "0.8.0", 0},
+		// Leading "v" stripped
+		{"v0.9.1", "0.9.1", 0},
+		{"v0.9.1", "v0.9.0", 1},
+		// Pre-release stripped
+		{"0.9.1-alpha.1", "0.9.1", 0},
+		{"v0.9.1-rc.2", "0.9.0", 1},
+		// Unparseable treated as 0.0.0
+		{"", "0.0.0", 0},
+		{"unknown", "0.0.0", 0},
+		{"bad", "0.0.0", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a+"_vs_"+tt.b, func(t *testing.T) {
+			got := compareVersionStrings(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("compareVersionStrings(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+// ── parseVersionTriple ────────────────────────────────────────────────────
+
+func TestParseVersionTriple(t *testing.T) {
+	tests := []struct {
+		input                       string
+		wantMaj, wantMin, wantPatch int
+	}{
+		// Normal
+		{"0.9.1", 0, 9, 1},
+		{"1.2.3", 1, 2, 3},
+		// Leading lowercase v
+		{"v0.9.1", 0, 9, 1},
+		// Leading uppercase V
+		{"V0.9.1", 0, 9, 1},
+		// Pre-release suffix stripped
+		{"0.9.1-alpha.1", 0, 9, 1},
+		{"v0.9.1-rc.2", 0, 9, 1},
+		// Fewer than 3 parts → (0,0,0)
+		{"0.9", 0, 0, 0},
+		{"1", 0, 0, 0},
+		// Empty → (0,0,0)
+		{"", 0, 0, 0},
+		// Unparseable → (0,0,0)
+		{"not.a.version", 0, 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			maj, min, patch := parseVersionTriple(tt.input)
+			if maj != tt.wantMaj || min != tt.wantMin || patch != tt.wantPatch {
+				t.Errorf("parseVersionTriple(%q) = (%d,%d,%d), want (%d,%d,%d)",
+					tt.input, maj, min, patch, tt.wantMaj, tt.wantMin, tt.wantPatch)
+			}
+		})
+	}
+}
+
+// ── envForVersion: initErr path ───────────────────────────────────────────
+
+// TestEnvForVersionInitError injects a poisoned registry entry and verifies
+// that envForVersion propagates the build error correctly. The sticky
+// sync.Once behaviour is also verified: a second call returns the same error
+// without calling build again.
+func TestEnvForVersionInitError(t *testing.T) {
+	buildCalls := 0
+	poisoned := &celVersionEntry{
+		minVersion: "99.0.0", // newest-first; will always be selected for "99.0.0"
+		build: func() (func(string, []string) error, error) {
+			buildCalls++
+			return nil, errors.New("injected build failure")
+		},
+	}
+
+	// Prepend to the registry for this test; restore afterwards.
+	orig := celVersionRegistry
+	celVersionRegistry = append([]*celVersionEntry{poisoned}, celVersionRegistry...)
+	defer func() { celVersionRegistry = orig }()
+
+	fn, err := envForVersion("99.0.0")
+	if err == nil {
+		t.Fatal("expected error from poisoned entry, got nil")
+	}
+	if fn != nil {
+		t.Error("expected nil fn on error, got non-nil")
+	}
+	if buildCalls != 1 {
+		t.Errorf("build called %d times, want 1", buildCalls)
+	}
+
+	// Second call: sync.Once must not re-invoke build.
+	fn2, err2 := envForVersion("99.0.0")
+	if err2 == nil {
+		t.Fatal("expected same error on second call, got nil")
+	}
+	if fn2 != nil {
+		t.Error("expected nil fn on second call")
+	}
+	if buildCalls != 1 {
+		t.Errorf("build called %d times after second call, want still 1", buildCalls)
+	}
+}
+
+// TestEnvForVersionBelowMinimum verifies that a version below all registry
+// entries (e.g. "0.7.0") falls through to the oldest (last) entry.
+func TestEnvForVersionBelowMinimum(t *testing.T) {
+	// "0.7.0" is below the oldest minVersion "0.8.0"; should still return a
+	// valid fn (the v0.8.x fallback), not an error.
+	fn, err := envForVersion("0.7.0")
+	if err != nil {
+		t.Fatalf("unexpected error for version below minimum: %v", err)
+	}
+	if fn == nil {
+		t.Fatal("expected non-nil fn for version below minimum")
+	}
+
+	// The returned fn should accept a valid base expression.
+	if err := fn("schema.spec.replicas + 1", []string{}); err != nil {
+		t.Errorf("base expression unexpectedly rejected: %v", err)
+	}
+}
+
+// ── envForVersion: version isolation (real function-availability check) ───
+
+// TestEnvForVersionFunctionIsolation verifies that the v0.8.x environment
+// REJECTS functions introduced in later versions via type-checking (not just
+// parse-phase). This is the core correctness guarantee of the whole system.
+func TestEnvForVersionFunctionIsolation(t *testing.T) {
+	// hash.fnv64a is registered only in v0.9.1+.
+	hashExpr := `hash.fnv64a("hello")`
+
+	// omit() is registered only in v0.9.0+.
+	omitExpr := `schema.spec.val != "" ? schema.spec.val : omit()`
+
+	tests := []struct {
+		name       string
+		kroVersion string
+		expr       string
+		wantErr    bool
+	}{
+		// v0.8.x must REJECT hash.fnv64a (type-check: undeclared function)
+		{"hash rejected on v0.8.5", "0.8.5", hashExpr, true},
+		{"hash rejected on v0.8.0", "0.8.0", hashExpr, true},
+		// v0.9.1 must ACCEPT hash.fnv64a
+		{"hash accepted on v0.9.1", "v0.9.1", hashExpr, false},
+		// future version also accepts hash
+		{"hash accepted on v1.0.0", "v1.0.0", hashExpr, false},
+
+		// v0.8.x must REJECT omit()
+		{"omit rejected on v0.8.5", "0.8.5", omitExpr, true},
+		// v0.9.0 must ACCEPT omit()
+		{"omit accepted on v0.9.0", "0.9.0", omitExpr, false},
+		{"omit accepted on v0.9.1", "0.9.1", omitExpr, false},
+
+		// hash must also be REJECTED on v0.9.0 (only in v0.9.1+)
+		{"hash rejected on v0.9.0", "0.9.0", hashExpr, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn, err := envForVersion(tt.kroVersion)
+			if err != nil {
+				t.Fatalf("envForVersion(%q): unexpected error: %v", tt.kroVersion, err)
+			}
+			checkErr := fn(tt.expr, []string{})
+			if tt.wantErr && checkErr == nil {
+				t.Errorf("expected type-check error for %q on kro %s, but expression was accepted",
+					tt.expr, tt.kroVersion)
+			}
+			if !tt.wantErr && checkErr != nil {
+				t.Errorf("expected expression %q to be accepted on kro %s, but got: %v",
+					tt.expr, tt.kroVersion, checkErr)
+			}
+		})
+	}
+}
+
+// ── sync.Once isolation between entries ──────────────────────────────────
+
+// TestCelVersionEntryIndependence verifies each registry entry has its own
+// sync.Once — a build failure in one entry does not poison another.
+func TestCelVersionEntryIndependence(t *testing.T) {
+	poisoned := &celVersionEntry{
+		minVersion: "98.0.0",
+		build: func() (func(string, []string) error, error) {
+			return nil, errors.New("entry A fails")
+		},
+	}
+	good := &celVersionEntry{
+		minVersion: "97.0.0",
+		once:       sync.Once{},
+		build: func() (func(string, []string) error, error) {
+			return func(expr string, vars []string) error { return nil }, nil
+		},
+	}
+
+	orig := celVersionRegistry
+	celVersionRegistry = append([]*celVersionEntry{poisoned, good}, celVersionRegistry...)
+	defer func() { celVersionRegistry = orig }()
+
+	// Poison entry A
+	if _, err := envForVersion("98.0.0"); err == nil {
+		t.Fatal("expected error from poisoned entry A")
+	}
+
+	// Good entry B must still work
+	fn, err := envForVersion("97.0.0")
+	if err != nil {
+		t.Fatalf("good entry B failed unexpectedly: %v", err)
+	}
+	if fn == nil {
+		t.Fatal("good entry B returned nil fn")
+	}
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -116,8 +116,9 @@ func ValidateSpecFields(fieldMap map[string]string) (issues []apitypes.StaticIss
 
 // ── ValidateCELExpressions ────────────────────────────────────────────────
 
-// ValidateCELExpressions validates CEL syntax in resource template expressions
-// using the CEL environment that matches the connected cluster's kro version.
+// ValidateCELExpressions validates CEL syntax and function availability in
+// resource template expressions using the CEL environment that matches the
+// connected cluster's kro version.
 //
 // kroVersion is the version string reported by the cluster (e.g. "v0.9.1",
 // "0.8.5"). Pass "" or "unknown" to use the most conservative (oldest)
@@ -126,8 +127,13 @@ func ValidateSpecFields(fieldMap map[string]string) (issues []apitypes.StaticIss
 // Each entry in resources carries a resource ID and a list of raw "${...}"
 // strings extracted from the template body. Non-"${...}" strings are skipped.
 //
-// Returns one StaticIssue per expression that fails CEL parsing, referencing
-// the resource ID.
+// Validation performs both syntax (Parse) and semantic (Check) analysis.
+// The resource ID and "schema" are declared as dynamic-typed variables so
+// field-access chains (e.g. schema.spec.replicas) pass type-checking without
+// requiring the full OpenAPI schema. Unknown functions from newer kro versions
+// (e.g. hash.fnv64a on a v0.8.x cluster) are correctly rejected.
+//
+// Returns one StaticIssue per expression that fails, referencing the resource ID.
 // Panic-safe: any panic from kro library code is recovered and returned as an issue.
 func ValidateCELExpressions(kroVersion string, resources []ResourceExpressions) (issues []apitypes.StaticIssue) {
 	defer func() {
@@ -139,7 +145,7 @@ func ValidateCELExpressions(kroVersion string, resources []ResourceExpressions) 
 		}
 	}()
 
-	parse, err := envForVersion(kroVersion)
+	check, err := envForVersion(kroVersion)
 	if err != nil {
 		return []apitypes.StaticIssue{{
 			Field:   "internal",
@@ -148,6 +154,10 @@ func ValidateCELExpressions(kroVersion string, resources []ResourceExpressions) 
 	}
 
 	for _, res := range resources {
+		// varNames declares the variables in scope for this resource's expressions:
+		// "schema" is always present; the resource's own ID is also in scope so
+		// expressions can reference sibling resources.
+		varNames := []string{res.ID}
 		for _, raw := range res.Expressions {
 			// Only process "${...}" expressions
 			if !strings.HasPrefix(raw, "${") || !strings.HasSuffix(raw, "}") {
@@ -155,7 +165,7 @@ func ValidateCELExpressions(kroVersion string, resources []ResourceExpressions) 
 			}
 			// Strip the ${ } wrappers to get raw CEL text
 			celText := raw[2 : len(raw)-1]
-			if err := parse(celText); err != nil {
+			if err := check(celText, varNames); err != nil {
 				issues = append(issues, apitypes.StaticIssue{
 					Field:   fmt.Sprintf("spec.resources[%s].template", res.ID),
 					Message: err.Error(),

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -187,39 +187,50 @@ func TestValidateCELExpressionsVersionRouting(t *testing.T) {
 		name       string
 		kroVersion string
 		resources  []validate.ResourceExpressions
-		// wantIssues: true means we expect at least one issue (false positive guard).
+		// wantIssues: true means we expect at least one issue.
 		// false means we expect no issues (valid for that version).
 		wantIssues bool
 	}{
-		// ── hash.fnv64a ───────────────────────────────────────────────────
-		// Parse phase: function calls are syntax, so hash.fnv64a() parses on
-		// all versions. The version gate matters for type-checking (future).
-		// Current behaviour: parse always succeeds for well-formed call syntax.
+		// ── hash.fnv64a: type-check enforces version boundary ─────────────
+		// hash.fnv64a is registered only in v0.9.1+; type-checking rejects
+		// it on v0.8.x and v0.9.0 with "undeclared reference to 'hash.fnv64a'"
 		{
-			name:       "hash.fnv64a valid syntax on v0.9.1",
+			name:       "hash.fnv64a accepted on v0.9.1",
 			kroVersion: "v0.9.1",
 			resources:  hashExpr,
 			wantIssues: false,
 		},
 		{
-			name:       "hash.fnv64a valid syntax on v0.8.5 (parse-only check)",
+			name:       "hash.fnv64a rejected on v0.8.5 (type-check)",
 			kroVersion: "v0.8.5",
 			resources:  hashExpr,
-			wantIssues: false,
+			wantIssues: true, // type-check: hash.fnv64a not registered in v0.8.x env
+		},
+		{
+			name:       "hash.fnv64a rejected on v0.9.0 (type-check)",
+			kroVersion: "0.9.0",
+			resources:  hashExpr,
+			wantIssues: true, // hash is only in v0.9.1+
 		},
 
-		// ── omit() ────────────────────────────────────────────────────────
+		// ── omit(): type-check enforces version boundary ──────────────────
 		{
-			name:       "omit() valid syntax on v0.9.0",
+			name:       "omit() accepted on v0.9.0",
 			kroVersion: "v0.9.0",
 			resources:  omitExpr,
 			wantIssues: false,
 		},
 		{
-			name:       "omit() valid syntax on v0.9.1",
+			name:       "omit() accepted on v0.9.1",
 			kroVersion: "v0.9.1",
 			resources:  omitExpr,
 			wantIssues: false,
+		},
+		{
+			name:       "omit() rejected on v0.8.5 (type-check)",
+			kroVersion: "0.8.5",
+			resources:  omitExpr,
+			wantIssues: true, // omit() not registered in v0.8.x env
 		},
 
 		// ── base expressions work on every version ────────────────────────
@@ -242,41 +253,53 @@ func TestValidateCELExpressionsVersionRouting(t *testing.T) {
 			wantIssues: false,
 		},
 
-		// ── unknown / empty version uses conservative env ─────────────────
+		// ── unknown / empty / below-minimum version ───────────────────────
 		{
-			name:       "unknown version uses conservative env",
+			name:       "unknown version uses conservative env (base expr ok)",
 			kroVersion: "unknown",
 			resources:  baseExpr,
 			wantIssues: false,
 		},
 		{
-			name:       "empty version uses conservative env",
+			name:       "empty version uses conservative env (base expr ok)",
 			kroVersion: "",
 			resources:  baseExpr,
 			wantIssues: false,
 		},
+		{
+			name:       "below-minimum version (0.7.0) uses oldest bucket",
+			kroVersion: "0.7.0",
+			resources:  baseExpr,
+			wantIssues: false,
+		},
+		{
+			name:       "below-minimum version rejects v0.9.1 functions",
+			kroVersion: "0.7.0",
+			resources:  hashExpr,
+			wantIssues: true,
+		},
 
 		// ── version bucketing boundaries ──────────────────────────────────
 		{
-			name:       "v0.9.1 bucket selected for v0.9.1",
+			name:       "v0.9.1 bucket: hash accepted",
 			kroVersion: "v0.9.1",
 			resources:  hashExpr,
 			wantIssues: false,
 		},
 		{
-			name:       "v0.9.0 bucket selected for v0.9.0",
+			name:       "v0.9.0 bucket: omit accepted",
 			kroVersion: "0.9.0",
 			resources:  omitExpr,
 			wantIssues: false,
 		},
 		{
-			name:       "v0.8.x bucket selected for v0.8.5",
+			name:       "v0.8.x bucket: base accepted",
 			kroVersion: "0.8.5",
 			resources:  baseExpr,
 			wantIssues: false,
 		},
 		{
-			name:       "future version falls into newest bucket",
+			name:       "future version falls into newest bucket (hash accepted)",
 			kroVersion: "v1.0.0",
 			resources:  hashExpr,
 			wantIssues: false,
@@ -295,32 +318,49 @@ func TestValidateCELExpressionsVersionRouting(t *testing.T) {
 	}
 }
 
-// TestCELVersionEnvIsolation verifies that each version bucket is built
-// independently and can be used concurrently without data races.
+// TestCELVersionEnvIsolation verifies that version buckets are independent and
+// safe for concurrent use. It runs multiple goroutines simultaneously with
+// different versions, checking both pass and fail outcomes to ensure each
+// goroutine uses its own environment without cross-contamination.
 func TestCELVersionEnvIsolation(t *testing.T) {
-	versions := []string{"v0.8.5", "v0.9.0", "v0.9.1", "unknown", ""}
-	expr := []validate.ResourceExpressions{
-		{ID: "r", Expressions: []string{"${schema.spec.name}"}},
+	type workItem struct {
+		version    string
+		resources  []validate.ResourceExpressions
+		wantIssues bool
+	}
+	items := []workItem{
+		// Base expression: valid on all versions
+		{"v0.8.5", []validate.ResourceExpressions{{ID: "r", Expressions: []string{"${schema.spec.name}"}}}, false},
+		{"v0.9.0", []validate.ResourceExpressions{{ID: "r", Expressions: []string{"${schema.spec.name}"}}}, false},
+		{"v0.9.1", []validate.ResourceExpressions{{ID: "r", Expressions: []string{"${schema.spec.name}"}}}, false},
+		// hash.fnv64a: rejected on v0.8.5, accepted on v0.9.1
+		{"v0.8.5", []validate.ResourceExpressions{{ID: "r", Expressions: []string{`${hash.fnv64a("x")}`}}}, true},
+		{"v0.9.1", []validate.ResourceExpressions{{ID: "r", Expressions: []string{`${hash.fnv64a("x")}`}}}, false},
+		// omit(): rejected on v0.8.5, accepted on v0.9.0
+		{"v0.8.5", []validate.ResourceExpressions{{ID: "r", Expressions: []string{`${schema.spec.x != "" ? schema.spec.x : omit()}`}}}, true},
+		{"v0.9.0", []validate.ResourceExpressions{{ID: "r", Expressions: []string{`${schema.spec.x != "" ? schema.spec.x : omit()}`}}}, false},
 	}
 
-	// Run concurrently to surface any sync.Once or closure sharing bugs.
-	done := make(chan struct{}, len(versions)*3)
-	for i := 0; i < 3; i++ {
-		for _, v := range versions {
-			v := v
+	const goroutinesPerItem = 4
+	total := len(items) * goroutinesPerItem
+	done := make(chan struct{}, total)
+
+	for _, item := range items {
+		for i := 0; i < goroutinesPerItem; i++ {
+			item := item
 			go func() {
 				defer func() { done <- struct{}{} }()
-				issues := validate.ValidateCELExpressions(v, expr)
-				if len(issues) != 0 {
-					t.Errorf("unexpected issues for version %q: %v", v, issues)
+				issues := validate.ValidateCELExpressions(item.version, item.resources)
+				hasIssues := len(issues) > 0
+				if hasIssues != item.wantIssues {
+					t.Errorf("concurrent: version=%q wantIssues=%v got issues=%v (%v)",
+						item.version, item.wantIssues, hasIssues, issues)
 				}
 			}()
 		}
 	}
-	for range versions {
-		for i := 0; i < 3; i++ {
-			<-done
-		}
+	for i := 0; i < total; i++ {
+		<-done
 	}
 }
 


### PR DESCRIPTION
## Summary

Post-merge coverage audit of PR #435 found 6 gaps. This PR fixes all of them.

### Critical fix (Gap 3)
`parseFunc` → `checkFunc`: validation now runs `env.Parse()` + `env.Check()` with resource variables declared as `DynType`. Previously `hash.fnv64a("x")` was syntactically valid CEL and passed on **all** version environments — the version isolation was vacuous. Now it is correctly rejected by the v0.8.x and v0.9.0 environments via type-checking.

### New tests
- `TestEnvForVersionInitError` — `sync.Once` stickiness and error propagation from poisoned build functions
- `TestCelVersionEntryIndependence` — a failing entry doesn't poison sibling entries
- `TestEnvForVersionFunctionIsolation` — 8 cases asserting each function is rejected/accepted on the correct version boundary (real type-check, not parse-only)
- `TestCompareVersionStrings` — 14 direct cases: major/minor/patch branches, `v` prefix, pre-release suffix, unparseable
- `TestParseVersionTriple` — 9 direct cases: capital-V, pre-release, too-few-parts, empty, unparseable  
- `TestEnvForVersionBelowMinimum` — `0.7.0` correctly falls to oldest bucket
- `TestKroVersionForRequest` — cold/warm cache in handler; end-to-end: v0.8.5 warm cache rejects `hash.fnv64a`, v0.9.1 warm cache accepts it
- `TestCELVersionEnvIsolation` rewritten — 7 work items × 4 goroutines; checks both pass **and** fail outcomes concurrently

### Updated test
`TestValidateCELExpressionsVersionRouting`: `hash.fnv64a valid syntax on v0.8.5` now correctly expects `wantIssues: true` (was `false` — the prior test was passing vacuously).