### PR TITLE
feat(web): RGD graph revision diff — merged DAG with diff overlays (spec 009, GH #13)

### DIFF
--- a/test/e2e/journeys/009-rgd-graph-diff.spec.ts
+++ b/test/e2e/journeys/009-rgd-graph-diff.spec.ts
@@ -1,0 +1,225 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Journey 009: RGD Graph Diff View (spec 009-rgd-graph-diff)
+ *
+ * Validates the merged-DAG diff view in the Revisions tab.
+ *
+ * All steps are capability-gated: the entire journey skips gracefully on
+ * clusters where hasGraphRevisions=false (pre-kro-v0.9.0).
+ *
+ * The hermetic E2E cluster runs kro v0.9.1 with the test-app RGD applied.
+ * test-app normally only has 1 revision (created on first Apply). Steps that
+ * require 2+ revisions must apply a spec change to generate a second revision,
+ * and skip when the second revision is not yet available.
+ *
+ * Cluster pre-conditions:
+ *   - kind cluster running with kro v0.9.0+ installed
+ *   - test-app RGD applied and Ready
+ *
+ * Spec ref: .specify/specs/009-rgd-graph-diff/spec.md
+ *
+ * E2E anti-patterns avoided:
+ *   - HTTP status to detect nonexistent SPA routes (§XIV — use API check)
+ *   - waitForTimeout for data-load (§XIV — use waitForFunction)
+ *   - locator.or().toBeVisible() when both may be visible
+ */
+
+import { test, expect } from '@playwright/test'
+import { fixtureState } from '../fixture-state'
+
+const PORT = parseInt(process.env.KRO_UI_PORT ?? '40107', 10)
+const BASE = `http://localhost:${PORT}`
+
+// ── Step 1: capability guard ──────────────────────────────────────────────────
+
+test.describe('Journey 009 — Graph Diff (spec 009)', () => {
+
+  test('Step 1: capabilities API reports hasGraphRevisions (kro v0.9.0+ required)', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/v1/kro/capabilities`)
+    expect(res.ok(), `capabilities endpoint returned ${res.status()}`).toBe(true)
+    const body = await res.json()
+    // Log for CI visibility regardless of whether we skip
+    const has = body?.schema?.hasGraphRevisions === true
+    if (!has) {
+      test.skip(true, 'hasGraphRevisions=false — cluster does not support GraphRevisions; skipping spec-009 journey')
+      return
+    }
+    expect(body?.schema?.hasGraphRevisions).toBe(true)
+  })
+
+  // ── Step 2: Revisions tab visible on test-app RGD ─────────────────────────
+
+  test('Step 2: Revisions tab is visible on test-app RGD detail page', async ({ page, request }) => {
+    // Capability guard
+    const capsRes = await request.get(`${BASE}/api/v1/kro/capabilities`)
+    if (!capsRes.ok() || !(await capsRes.json())?.schema?.hasGraphRevisions) {
+      test.skip(true, 'hasGraphRevisions=false; skipping')
+      return
+    }
+
+    // Verify test-app RGD exists
+    const rgdRes = await request.get(`${BASE}/api/v1/rgds/test-app`)
+    if (!rgdRes.ok()) {
+      test.skip(true, 'test-app RGD not present on this cluster')
+      return
+    }
+
+    await page.goto(`${BASE}/rgds/test-app`)
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="rgd-detail"]') !== null ||
+            document.querySelector('[role="main"]') !== null,
+      { timeout: 15_000 }
+    )
+
+    // Click the Revisions tab
+    await page.getByRole('tab', { name: /revisions/i }).click()
+
+    // Wait for the revisions tab to render (loading state resolves)
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="revisions-tab"]') !== null,
+      { timeout: 15_000 }
+    )
+
+    const tab = page.locator('[data-testid="revisions-tab"]')
+    await expect(tab).toBeVisible()
+  })
+
+  // ── Step 3: RevisionSelector and DAG diff render with ≥2 revisions ───────
+
+  test('Step 3: RevisionSelector and RGDDiffView render when 2+ revisions exist', async ({ page, request }) => {
+    // Capability guard
+    const capsRes = await request.get(`${BASE}/api/v1/kro/capabilities`)
+    if (!capsRes.ok() || !(await capsRes.json())?.schema?.hasGraphRevisions) {
+      test.skip(true, 'hasGraphRevisions=false; skipping')
+      return
+    }
+
+    // Check how many revisions test-app has
+    const revRes = await request.get(`${BASE}/api/v1/kro/graph-revisions?rgd=test-app`)
+    if (!revRes.ok()) {
+      test.skip(true, 'Could not fetch revisions')
+      return
+    }
+    const revBody = await revRes.json()
+    const items = Array.isArray(revBody?.items) ? revBody.items : []
+    if (items.length < 2) {
+      test.skip(true, `test-app only has ${items.length} revision(s) — need 2+ for diff; skipping`)
+      return
+    }
+
+    await page.goto(`${BASE}/rgds/test-app?tab=revisions`)
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="revisions-tab"]') !== null,
+      { timeout: 15_000 }
+    )
+
+    // RevisionSelector should be visible (shown when ≥2 revisions)
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="revision-selector"]') !== null,
+      { timeout: 15_000 }
+    )
+    const selector = page.locator('[data-testid="revision-selector"]')
+    await expect(selector).toBeVisible()
+
+    // The dag-diff-svg should appear (default pair auto-selected)
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="dag-diff-svg"]') !== null ||
+            document.querySelector('[data-testid="rgd-diff-view"]') !== null,
+      { timeout: 15_000 }
+    )
+    const dagDiff = page.locator('[data-testid="dag-diff-svg"]')
+    await expect(dagDiff).toBeVisible()
+
+    // Legend should be present
+    const legend = page.locator('[data-testid="dag-diff-legend"]')
+    await expect(legend).toBeVisible()
+  })
+
+  // ── Step 4: single-revision RGD shows "Only one revision exists" message ──
+
+  test('Step 4: single-revision RGD shows "Only one revision exists" message', async ({ page, request }) => {
+    // Capability guard
+    const capsRes = await request.get(`${BASE}/api/v1/kro/capabilities`)
+    if (!capsRes.ok() || !(await capsRes.json())?.schema?.hasGraphRevisions) {
+      test.skip(true, 'hasGraphRevisions=false; skipping')
+      return
+    }
+
+    // Find an RGD with exactly 1 revision (test-app typically has 1 on first apply)
+    const rgdRes = await request.get(`${BASE}/api/v1/rgds/test-app`)
+    if (!rgdRes.ok()) {
+      test.skip(true, 'test-app not available')
+      return
+    }
+
+    const revRes = await request.get(`${BASE}/api/v1/kro/graph-revisions?rgd=test-app`)
+    if (!revRes.ok()) {
+      test.skip(true, 'Could not fetch revisions')
+      return
+    }
+    const items = (await revRes.json())?.items ?? []
+    if (items.length !== 1) {
+      test.skip(true, `test-app has ${items.length} revision(s) — need exactly 1 for this step`)
+      return
+    }
+
+    await page.goto(`${BASE}/rgds/test-app?tab=revisions`)
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="revisions-tab"]') !== null,
+      { timeout: 15_000 }
+    )
+
+    // The dag-diff section should NOT show RevisionSelector
+    // Instead it shows the "Only one revision exists" message
+    await page.waitForFunction(
+      () => {
+        const msg = document.querySelector('[data-testid="revision-selector-single-msg"]')
+        const selector = document.querySelector('[data-testid="revision-selector"]')
+        return msg !== null || selector === null
+      },
+      { timeout: 15_000 }
+    )
+
+    // Revisions table should still show the single revision
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="revisions-table"]') !== null,
+      { timeout: 10_000 }
+    )
+    const table = page.locator('[data-testid="revisions-table"]')
+    await expect(table).toBeVisible()
+  })
+
+  // ── Step 5: diff section absent when revisions not available ─────────────
+
+  test('Step 5: graph-diff section only renders when hasGraphRevisions=true', async ({ request }) => {
+    const res = await request.get(`${BASE}/api/v1/kro/capabilities`)
+    expect(res.ok()).toBe(true)
+    const body = await res.json()
+
+    if (body?.schema?.hasGraphRevisions === false) {
+      // Verify the revisions API returns an empty list (not an error)
+      const revRes = await request.get(`${BASE}/api/v1/kro/graph-revisions?rgd=test-app`)
+      expect(revRes.ok()).toBe(true)
+      const revBody = await revRes.json()
+      expect(Array.isArray(revBody.items)).toBe(true)
+    } else {
+      // hasGraphRevisions=true: just verify the API works
+      const revRes = await request.get(`${BASE}/api/v1/kro/graph-revisions?rgd=test-app`)
+      expect(revRes.ok()).toBe(true)
+    }
+  })
+
+}) // end test.describe

--- a/test/e2e/journeys/009-rgd-graph-diff.spec.ts
+++ b/test/e2e/journeys/009-rgd-graph-diff.spec.ts
@@ -78,14 +78,12 @@ test.describe('Journey 009 — Graph Diff (spec 009)', () => {
     }
 
     await page.goto(`${BASE}/rgds/test-app`)
-    await page.waitForFunction(
-      () => document.querySelector('[data-testid="rgd-detail"]') !== null ||
-            document.querySelector('[role="main"]') !== null,
-      { timeout: 15_000 }
-    )
+
+    // Wait for the RGD detail page to load (dag-svg is a reliable indicator)
+    await expect(page.getByTestId('dag-svg')).toBeVisible({ timeout: 20_000 })
 
     // Click the Revisions tab
-    await page.getByRole('tab', { name: /revisions/i }).click()
+    await page.getByTestId('tab-revisions').click()
 
     // Wait for the revisions tab to render (loading state resolves)
     await page.waitForFunction(
@@ -121,6 +119,18 @@ test.describe('Journey 009 — Graph Diff (spec 009)', () => {
     }
 
     await page.goto(`${BASE}/rgds/test-app?tab=revisions`)
+
+    // Wait for page to load, then navigate to revisions tab if needed
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="dag-svg"]') !== null ||
+            document.querySelector('[data-testid="revisions-tab"]') !== null,
+      { timeout: 20_000 }
+    )
+    // If the graph tab loaded by default, click Revisions
+    const isDagVisible = await page.locator('[data-testid="dag-svg"]').isVisible({ timeout: 500 }).catch(() => false)
+    if (isDagVisible) {
+      await page.getByTestId('tab-revisions').click()
+    }
     await page.waitForFunction(
       () => document.querySelector('[data-testid="revisions-tab"]') !== null,
       { timeout: 15_000 }
@@ -177,6 +187,17 @@ test.describe('Journey 009 — Graph Diff (spec 009)', () => {
     }
 
     await page.goto(`${BASE}/rgds/test-app?tab=revisions`)
+
+    // Wait for page to load, then navigate to revisions tab if needed
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="dag-svg"]') !== null ||
+            document.querySelector('[data-testid="revisions-tab"]') !== null,
+      { timeout: 20_000 }
+    )
+    const isDagVisibleStep4 = await page.locator('[data-testid="dag-svg"]').isVisible({ timeout: 500 }).catch(() => false)
+    if (isDagVisibleStep4) {
+      await page.getByTestId('tab-revisions').click()
+    }
     await page.waitForFunction(
       () => document.querySelector('[data-testid="revisions-tab"]') !== null,
       { timeout: 15_000 }

--- a/web/src/components/RGDDiffView.css
+++ b/web/src/components/RGDDiffView.css
@@ -1,0 +1,222 @@
+/* RGDDiffView — merged DAG renderer with diff status overlays.
+ * All colors via var(--token-name) — no hardcoded hex or rgba values.
+ * Spec: 009-rgd-graph-diff Phase 2 (T012).
+ */
+
+/* ── Outer container ─────────────────────────────────────────────────────── */
+
+.rgd-diff-view {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.rgd-diff-view__error-msg {
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+  padding: 12px 0;
+  margin: 0;
+}
+
+/* ── Canvas / SVG wrapper ─────────────────────────────────────────────────── */
+
+.rgd-diff-view__canvas {
+  overflow-x: auto;
+  overflow-y: hidden; /* pair with overflow-x to prevent spurious scrollbar */
+}
+
+/* ── Node diff overlays ───────────────────────────────────────────────────── */
+
+/* Background and border per diff status — uses tokens defined in tokens.css FR-007 */
+.dag-node-rect--diff-added {
+  fill: var(--color-diff-added-bg);
+  stroke: var(--color-diff-added-border);
+  stroke-width: 1.5;
+}
+
+.dag-node-rect--diff-removed {
+  fill: var(--color-diff-removed-bg);
+  stroke: var(--color-diff-removed-border);
+  stroke-width: 1.5;
+}
+
+.dag-node-rect--diff-modified {
+  fill: var(--color-diff-modified-bg);
+  stroke: var(--color-diff-modified-border);
+  stroke-width: 1.5;
+}
+
+.dag-node-rect--diff-unchanged {
+  fill: var(--color-diff-unchanged-bg);
+  stroke: var(--color-diff-unchanged-border);
+  stroke-width: 1;
+}
+
+/* Removed nodes have reduced opacity to de-emphasise them */
+.dag-node--removed {
+  opacity: 0.65;
+}
+
+/* Modified nodes show a pointer cursor to hint at clickability */
+.dag-node--diff-modified {
+  cursor: pointer;
+}
+
+/* ── Diff status badges (+, −, ~) ─────────────────────────────────────────── */
+
+.dag-diff-badge {
+  font-size: 10px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  dominant-baseline: middle;
+  text-anchor: middle;
+}
+
+.dag-diff-badge--diff-added    { fill: var(--color-diff-added);    }
+.dag-diff-badge--diff-removed  { fill: var(--color-diff-removed);  }
+.dag-diff-badge--diff-modified { fill: var(--color-diff-modified); }
+
+/* ── Edge diff overlays ───────────────────────────────────────────────────── */
+
+.dag-diff-edge--added {
+  stroke: var(--color-diff-added);
+  stroke-width: 1.5;
+  fill: none;
+}
+
+.dag-diff-edge--removed {
+  stroke: var(--color-diff-removed);
+  stroke-width: 1.5;
+  fill: none;
+  opacity: 0.65;
+}
+
+/* ── Legend ───────────────────────────────────────────────────────────────── */
+
+.dag-diff-legend {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  padding: 4px 0 8px;
+}
+
+.dag-diff-legend__item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.dag-diff-legend__badge {
+  font-family: var(--font-mono);
+  font-weight: 700;
+  font-size: 0.875rem;
+}
+
+.dag-diff-legend__item--added    .dag-diff-legend__badge { color: var(--color-diff-added);    }
+.dag-diff-legend__item--removed  .dag-diff-legend__badge { color: var(--color-diff-removed);  }
+.dag-diff-legend__item--modified .dag-diff-legend__badge { color: var(--color-diff-modified); }
+
+/* ── CEL Diff Panel ───────────────────────────────────────────────────────── */
+
+.dag-diff-cel-panel {
+  background: var(--color-surface);
+  border: 1px solid var(--color-diff-modified-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.dag-diff-cel-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px;
+  background: var(--color-diff-modified-bg);
+  border-bottom: 1px solid var(--color-diff-modified-border);
+}
+
+.dag-diff-cel-panel__title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.dag-diff-cel-panel__title code {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  color: var(--color-diff-modified);
+}
+
+.dag-diff-cel-panel__close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+  padding: 2px 6px;
+  border-radius: 4px;
+  transition: color 0.15s ease;
+}
+
+.dag-diff-cel-panel__close:hover {
+  color: var(--color-text);
+}
+
+.dag-diff-cel-panel__body {
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dag-diff-cel-panel__no-cel {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+/* ── CEL sections (before / after columns) ──────────────────────────────── */
+
+.dag-diff-cel-section__label {
+  font-family: var(--font-mono);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.dag-diff-cel-section__cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+@media (max-width: 680px) {
+  .dag-diff-cel-section__cols {
+    grid-template-columns: 1fr;
+  }
+}
+
+.dag-diff-cel-section__col-header {
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-bottom: 4px;
+  padding: 3px 0;
+}
+
+.dag-diff-cel-section__col--before .dag-diff-cel-section__col-header {
+  color: var(--color-diff-removed);
+}
+
+.dag-diff-cel-section__col--after .dag-diff-cel-section__col-header {
+  color: var(--color-diff-added);
+}
+
+.dag-diff-cel-section__empty {
+  font-size: 0.875rem;
+  color: var(--color-text-faint);
+}

--- a/web/src/components/RGDDiffView.tsx
+++ b/web/src/components/RGDDiffView.tsx
@@ -1,0 +1,473 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RGDDiffView — merged DAG renderer with diff status overlays.
+//
+// Spec: .specify/specs/009-rgd-graph-diff/ Phase 2 (T009–T012).
+// Takes two GraphRevision objects, builds their DAGs, diffs them, and renders
+// a single merged SVG where each node/edge is color-coded by DiffStatus.
+//
+// Node diff badges: + (added), - (removed), ~ (modified).
+// Removed nodes render with a dashed border.
+// Clicking a modified node shows a before/after CEL panel (FR-006).
+//
+// Layout: removed nodes use their graphA coordinates; all others use graphB.
+// The SVG viewBox is fitted to the union of all node bounding boxes.
+
+import { useState, useRef } from 'react'
+import type { K8sObject } from '@/lib/api'
+import { buildDAGGraph, nodeBadge, forEachLabel } from '@/lib/dag'
+import type { DAGNode } from '@/lib/dag'
+import { diffDAGGraphs } from '@/lib/dag-diff'
+import type { DiffNode, DiffEdge, DiffGraph } from '@/lib/dag-diff'
+import KroCodeBlock from './KroCodeBlock'
+import DAGTooltip from './DAGTooltip'
+import type { DAGTooltipTarget } from './DAGTooltip'
+import './RGDDiffView.css'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Extract spec.snapshot from a GraphRevision K8sObject. */
+function extractSnapshot(rev: K8sObject): Record<string, unknown> | null {
+  const spec = rev.spec
+  if (typeof spec !== 'object' || spec === null) return null
+  const snapshot = (spec as Record<string, unknown>).snapshot
+  if (typeof snapshot !== 'object' || snapshot === null) return null
+  return snapshot as Record<string, unknown>
+}
+
+/** CSS class suffix for a diff status. */
+function diffClass(status: DiffNode['diffStatus']): string {
+  switch (status) {
+    case 'added':     return 'diff-added'
+    case 'removed':   return 'diff-removed'
+    case 'modified':  return 'diff-modified'
+    case 'unchanged': return 'diff-unchanged'
+  }
+}
+
+/** Badge character for a diff node. */
+function diffBadgeChar(status: DiffNode['diffStatus']): string | null {
+  switch (status) {
+    case 'added':    return '+'
+    case 'removed':  return '−'
+    case 'modified': return '~'
+    default:         return null
+  }
+}
+
+/** Cubic bezier path from parent bottom-center to child top-center. */
+function edgePath(
+  from: DAGNode,
+  to: DAGNode,
+): string {
+  const x1 = from.x + from.width / 2
+  const y1 = from.y + from.height
+  const x2 = to.x + to.width / 2
+  const y2 = to.y
+  const dy = Math.max((y2 - y1) * 0.4, 20)
+  return `M ${x1} ${y1} C ${x1} ${y1 + dy}, ${x2} ${y2 - dy}, ${x2} ${y2}`
+}
+
+/** Compute fitted SVG dimensions from all node bounding boxes. */
+function fittedDimensions(nodes: DiffNode[]) {
+  if (nodes.length === 0) return { width: 400, height: 200 }
+  const maxRight = Math.max(...nodes.map((n) => n.x + n.width)) + 32
+  const maxBottom = Math.max(...nodes.map((n) => n.y + n.height)) + 32
+  return { width: maxRight, height: maxBottom }
+}
+
+// ── CEL Diff Panel ────────────────────────────────────────────────────────────
+
+interface CELDiffPanelProps {
+  node: DiffNode
+  onClose: () => void
+}
+
+function CELDiffPanel({ node, onClose }: CELDiffPanelProps) {
+  const { prevCEL, nextCEL } = node
+  if (!prevCEL || !nextCEL) return null
+
+  const sections: Array<{ label: string; before: string[]; after: string[] }> = []
+
+  if (prevCEL.includeWhen.length > 0 || nextCEL.includeWhen.length > 0) {
+    sections.push({
+      label: 'includeWhen',
+      before: prevCEL.includeWhen,
+      after: nextCEL.includeWhen,
+    })
+  }
+  if (prevCEL.readyWhen.length > 0 || nextCEL.readyWhen.length > 0) {
+    sections.push({
+      label: 'readyWhen',
+      before: prevCEL.readyWhen,
+      after: nextCEL.readyWhen,
+    })
+  }
+  if (prevCEL.forEach !== nextCEL.forEach) {
+    sections.push({
+      label: 'forEach',
+      before: prevCEL.forEach ? [prevCEL.forEach] : [],
+      after:  nextCEL.forEach ? [nextCEL.forEach] : [],
+    })
+  }
+
+  return (
+    <div className="dag-diff-cel-panel" data-testid="dag-diff-cel-panel">
+      <div className="dag-diff-cel-panel__header">
+        <span className="dag-diff-cel-panel__title">
+          CEL changes — <code>{node.id}</code>
+        </span>
+        <button
+          type="button"
+          className="dag-diff-cel-panel__close"
+          onClick={onClose}
+          aria-label="Close CEL diff panel"
+        >
+          ✕
+        </button>
+      </div>
+      <div className="dag-diff-cel-panel__body">
+        {sections.map((s) => (
+          <div key={s.label} className="dag-diff-cel-section">
+            <div className="dag-diff-cel-section__label">{s.label}</div>
+            <div className="dag-diff-cel-section__cols">
+              <div className="dag-diff-cel-section__col dag-diff-cel-section__col--before">
+                <div className="dag-diff-cel-section__col-header">Before</div>
+                {s.before.length > 0 ? (
+                  s.before.map((expr, i) => (
+                    <KroCodeBlock key={i} code={expr} title={`${s.label} (before)`} />
+                  ))
+                ) : (
+                  <span className="dag-diff-cel-section__empty">—</span>
+                )}
+              </div>
+              <div className="dag-diff-cel-section__col dag-diff-cel-section__col--after">
+                <div className="dag-diff-cel-section__col-header">After</div>
+                {s.after.length > 0 ? (
+                  s.after.map((expr, i) => (
+                    <KroCodeBlock key={i} code={expr} title={`${s.label} (after)`} />
+                  ))
+                ) : (
+                  <span className="dag-diff-cel-section__empty">—</span>
+                )}
+              </div>
+            </div>
+          </div>
+        ))}
+        {sections.length === 0 && (
+          <p className="dag-diff-cel-panel__no-cel">
+            No CEL expression changes detected. Other structural differences may exist.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Diff Node SVG Group ───────────────────────────────────────────────────────
+
+interface DiffNodeGroupProps {
+  node: DiffNode
+  isSelected: boolean
+  onClick: (node: DiffNode) => void
+  onHover: (target: DAGTooltipTarget | null) => void
+  svgRef: React.RefObject<SVGSVGElement | null>
+}
+
+function DiffNodeGroup({ node, isSelected, onClick, onHover, svgRef }: DiffNodeGroupProps) {
+  const status = node.diffStatus
+  const diffBadge = diffBadgeChar(status)
+  const nodeBadgeChar = nodeBadge(node)   // existing type badge (∀, ⬡, etc.)
+  const cx = node.x + node.width / 2
+  const labelY = node.y + 17
+  const kindY = node.y + 32
+  const forEachY = node.y + 45
+  const badgeX = node.x + node.width - 10
+  const badgeY = node.y + 10
+  const diffBadgeX = node.x + 12
+  const diffBadgeY = node.y + 10
+
+  const className = [
+    'dag-node',
+    `dag-node--${node.nodeType}`,
+    `dag-node--${diffClass(status)}`,
+    node.isConditional ? 'node-conditional' : '',
+    isSelected ? 'dag-node--selected' : '',
+    status === 'removed' ? 'dag-node--removed' : '',
+  ].filter(Boolean).join(' ')
+
+  function handleMouseEnter() {
+    const svgRect = svgRef.current?.getBoundingClientRect()
+    if (!svgRect) return
+    onHover({
+      node,
+      anchorX: svgRect.left + node.x,
+      anchorY: svgRect.top + node.y,
+      nodeWidth: node.width,
+      nodeHeight: node.height,
+    })
+  }
+
+  return (
+    <g
+      data-testid={`dag-diff-node-${node.id}`}
+      data-diff-status={status}
+      className={className}
+      tabIndex={0}
+      role="button"
+      aria-label={`${node.label} (${node.nodeType}, ${status})`}
+      aria-pressed={isSelected}
+      onClick={() => onClick(node)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={() => onHover(null)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onClick(node)
+        }
+      }}
+    >
+      <rect
+        className={`dag-node-rect dag-node-rect--${diffClass(status)}`}
+        x={node.x}
+        y={node.y}
+        width={node.width}
+        height={node.height}
+        rx={8}
+        strokeDasharray={status === 'removed' ? '4 3' : undefined}
+      />
+      <text className="dag-node-label" x={cx} y={labelY}>
+        {node.label}
+      </text>
+      {node.kind && node.kind !== node.id && (
+        <text className="dag-node-kind" x={cx} y={kindY}>
+          {node.kind}
+        </text>
+      )}
+      {forEachLabel(node.forEach) && (
+        <text
+          className="dag-node-foreach"
+          x={cx}
+          y={forEachY}
+          aria-label={`forEach: ${node.forEach}`}
+        >
+          <title>{node.forEach}</title>
+          {forEachLabel(node.forEach)}
+        </text>
+      )}
+      {/* Diff status badge: +, −, ~ — top-left corner */}
+      {diffBadge && (
+        <text
+          className={`dag-diff-badge dag-diff-badge--${diffClass(status)}`}
+          x={diffBadgeX}
+          y={diffBadgeY}
+          aria-label={status}
+        >
+          {diffBadge}
+        </text>
+      )}
+      {/* Node-type badge (∀, ⬡, ?) — top-right corner (same as DAGGraph) */}
+      {nodeBadgeChar && (
+        <text
+          className={`dag-node-badge dag-node-badge--${
+            node.isConditional ? 'conditional'
+            : node.nodeType === 'collection' ? 'collection'
+            : 'external'
+          }`}
+          x={badgeX}
+          y={badgeY}
+        >
+          {nodeBadgeChar}
+        </text>
+      )}
+    </g>
+  )
+}
+
+// ── Legend ────────────────────────────────────────────────────────────────────
+
+function DiffLegend() {
+  return (
+    <div className="dag-diff-legend" aria-label="Diff legend" data-testid="dag-diff-legend">
+      <span className="dag-diff-legend__item dag-diff-legend__item--added">
+        <span className="dag-diff-legend__badge">+</span> Added
+      </span>
+      <span className="dag-diff-legend__item dag-diff-legend__item--removed">
+        <span className="dag-diff-legend__badge">−</span> Removed
+      </span>
+      <span className="dag-diff-legend__item dag-diff-legend__item--modified">
+        <span className="dag-diff-legend__badge">~</span> Modified
+      </span>
+      <span className="dag-diff-legend__item dag-diff-legend__item--unchanged">
+        Unchanged
+      </span>
+    </div>
+  )
+}
+
+// ── Main component ─────────────────────────────────────────────────────────────
+
+interface RGDDiffViewProps {
+  /** The "before" GraphRevision (Rev A). */
+  revA: K8sObject
+  /** The "after" GraphRevision (Rev B). */
+  revB: K8sObject
+}
+
+/**
+ * RGDDiffView — merged DAG showing the diff between two GraphRevisions.
+ *
+ * Spec: .specify/specs/009-rgd-graph-diff/ FR-002 through FR-007.
+ *
+ * - Builds graphA and graphB from spec.snapshot.
+ * - Calls diffDAGGraphs to get the merged diff.
+ * - Renders a single SVG with color-coded overlays per DiffStatus.
+ * - Clicking a modified node shows before/after CEL in a detail panel.
+ */
+export default function RGDDiffView({ revA, revB }: RGDDiffViewProps) {
+  const [selectedNode, setSelectedNode] = useState<DiffNode | null>(null)
+  const [hoveredTooltip, setHoveredTooltip] = useState<DAGTooltipTarget | null>(null)
+  const svgRef = useRef<SVGSVGElement>(null)
+
+  const snapA = extractSnapshot(revA)
+  const snapB = extractSnapshot(revB)
+
+  if (!snapA || !snapB) {
+    return (
+      <div className="rgd-diff-view rgd-diff-view--error" data-testid="rgd-diff-view-error">
+        <p className="rgd-diff-view__error-msg">
+          Could not read revision snapshot. The GraphRevision object may be malformed.
+        </p>
+      </div>
+    )
+  }
+
+  const graphA = buildDAGGraph(snapA)
+  const graphB = buildDAGGraph(snapB)
+  const diff: DiffGraph = diffDAGGraphs(graphA, graphB)
+
+  const nodeMap = new Map<string, DiffNode>(diff.nodes.map((n) => [n.id, n]))
+  const { width: svgWidth, height: svgHeight } = fittedDimensions(diff.nodes)
+
+  function handleNodeClick(node: DiffNode) {
+    if (node.diffStatus === 'modified') {
+      setSelectedNode((prev) => (prev?.id === node.id ? null : node))
+    } else {
+      setSelectedNode(null)
+    }
+  }
+
+  // Edge color class: added = diff-added, removed = diff-removed, unchanged = neutral
+  function edgeClass(edge: DiffEdge): string {
+    switch (edge.diffStatus) {
+      case 'added':     return 'dag-diff-edge--added'
+      case 'removed':   return 'dag-diff-edge--removed'
+      default:          return 'dag-edge'
+    }
+  }
+
+  // Arrow marker IDs per diff status
+  function arrowMarkerId(edge: DiffEdge): string {
+    switch (edge.diffStatus) {
+      case 'added':   return 'dag-arrowhead-added'
+      case 'removed': return 'dag-arrowhead-removed'
+      default:        return 'dag-arrowhead'
+    }
+  }
+
+  return (
+    <div className="rgd-diff-view" data-testid="rgd-diff-view">
+      <DiffLegend />
+
+      <div className="rgd-diff-view__canvas">
+        <svg
+          ref={svgRef}
+          data-testid="dag-diff-svg"
+          width={svgWidth}
+          height={svgHeight}
+          viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+          xmlns="http://www.w3.org/2000/svg"
+          aria-label="Resource graph revision diff"
+          role="img"
+          style={{ display: 'block' }}
+        >
+          <defs>
+            {/* Arrow markers per diff status for color-coded edges */}
+            <marker id="dag-arrowhead" viewBox="0 0 10 10" refX="9" refY="5"
+              markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+              <path d="M 0 1 L 9 5 L 0 9 z" style={{ fill: 'var(--color-border)' }} />
+            </marker>
+            <marker id="dag-arrowhead-added" viewBox="0 0 10 10" refX="9" refY="5"
+              markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+              <path d="M 0 1 L 9 5 L 0 9 z" style={{ fill: 'var(--color-diff-added)' }} />
+            </marker>
+            <marker id="dag-arrowhead-removed" viewBox="0 0 10 10" refX="9" refY="5"
+              markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+              <path d="M 0 1 L 9 5 L 0 9 z" style={{ fill: 'var(--color-diff-removed)' }} />
+            </marker>
+          </defs>
+
+          {/* Edges — behind nodes */}
+          <g aria-hidden="true">
+            {diff.edges.map((edge) => {
+              const fromNode = nodeMap.get(edge.from)
+              const toNode = nodeMap.get(edge.to)
+              if (!fromNode || !toNode) return null
+              return (
+                <path
+                  key={`${edge.from}→${edge.to}`}
+                  className={`dag-edge ${edgeClass(edge)}`}
+                  d={edgePath(fromNode, toNode)}
+                  markerEnd={`url(#${arrowMarkerId(edge)})`}
+                  strokeDasharray={edge.diffStatus === 'removed' ? '5 4' : undefined}
+                />
+              )
+            })}
+          </g>
+
+          {/* Nodes */}
+          <g>
+            {diff.nodes.map((node) => (
+              <DiffNodeGroup
+                key={node.id}
+                node={node}
+                isSelected={selectedNode?.id === node.id}
+                onClick={handleNodeClick}
+                onHover={setHoveredTooltip}
+                svgRef={svgRef}
+              />
+            ))}
+          </g>
+        </svg>
+      </div>
+
+      {/* CEL diff detail panel — shown when a modified node is clicked */}
+      {selectedNode && selectedNode.diffStatus === 'modified' && (
+        <CELDiffPanel
+          node={selectedNode}
+          onClose={() => setSelectedNode(null)}
+        />
+      )}
+
+      <DAGTooltip
+        node={hoveredTooltip?.node ?? null}
+        anchorX={hoveredTooltip?.anchorX ?? 0}
+        anchorY={hoveredTooltip?.anchorY ?? 0}
+        nodeWidth={hoveredTooltip?.nodeWidth ?? 0}
+        nodeHeight={hoveredTooltip?.nodeHeight ?? 0}
+      />
+    </div>
+  )
+}

--- a/web/src/components/RevisionSelector.css
+++ b/web/src/components/RevisionSelector.css
@@ -1,0 +1,63 @@
+/* RevisionSelector — two-select diff pair picker.
+ * All colors via var(--token-name) — no hardcoded hex or rgba values.
+ * Spec: 009-rgd-graph-diff Phase 1 (T008).
+ */
+
+.revision-selector {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  padding: 12px 0 16px;
+  flex-wrap: wrap;
+}
+
+.revision-selector__group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.revision-selector__label {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.revision-selector__select {
+  background: var(--color-surface-2);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 0.875rem;
+  font-family: var(--font-mono);
+  cursor: pointer;
+  min-width: 220px;
+  transition: border-color 0.15s ease;
+}
+
+.revision-selector__select:hover {
+  border-color: var(--color-primary);
+}
+
+.revision-selector__select:focus {
+  outline: none;
+  border-color: var(--color-border-focus);
+  box-shadow: 0 0 0 2px var(--color-primary-muted);
+}
+
+.revision-selector__arrow {
+  font-size: 1.125rem;
+  color: var(--color-text-muted);
+  padding-bottom: 8px; /* align vertically with the select boxes */
+  user-select: none;
+}
+
+.revision-selector__single-msg {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  padding: 12px 0;
+  margin: 0;
+}

--- a/web/src/components/RevisionSelector.tsx
+++ b/web/src/components/RevisionSelector.tsx
@@ -1,0 +1,162 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RevisionSelector — two-dropdown UI for picking a revision pair to diff.
+//
+// Spec: .specify/specs/009-rgd-graph-diff/ Phase 1 (T007).
+// Emits onChange({ revA, revB }) when both selects have distinct selections.
+// Shows an informational message when < 2 revisions exist.
+
+import type { K8sObject } from '@/lib/api'
+import './RevisionSelector.css'
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function revisionNumber(rev: K8sObject): number {
+  const spec = rev.spec as Record<string, unknown> | undefined
+  return typeof spec?.revision === 'number' ? spec.revision : 0
+}
+
+function revisionName(rev: K8sObject): string {
+  const meta = rev.metadata as Record<string, unknown> | undefined
+  return typeof meta?.name === 'string' ? meta.name : '?'
+}
+
+function revisionLabel(rev: K8sObject): string {
+  return `#${revisionNumber(rev)} — ${revisionName(rev)}`
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface RevisionPair {
+  revA: K8sObject
+  revB: K8sObject
+}
+
+interface RevisionSelectorProps {
+  /**
+   * All available revisions, sorted descending by revision number (latest first).
+   * Passed directly from RevisionsTab.
+   */
+  revisions: K8sObject[]
+  /**
+   * Called when the user has selected a valid pair (both distinct, both present).
+   * Called with null when the selection is cleared or incomplete.
+   */
+  onChange: (pair: RevisionPair | null) => void
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+/**
+ * RevisionSelector — two <select> dropdowns for choosing a diff pair.
+ *
+ * When only 1 revision exists, shows "Only one revision exists — nothing to compare."
+ * When 0 revisions exist, shows nothing (the parent tab handles the empty state).
+ *
+ * Spec: T007 (Phase 1).
+ */
+export default function RevisionSelector({ revisions, onChange }: RevisionSelectorProps) {
+  if (revisions.length < 2) {
+    if (revisions.length === 1) {
+      return (
+        <p
+          className="revision-selector__single-msg"
+          data-testid="revision-selector-single-msg"
+        >
+          Only one revision exists — nothing to compare.
+        </p>
+      )
+    }
+    return null
+  }
+
+  function handleChange(
+    e: React.ChangeEvent<HTMLSelectElement>,
+    role: 'a' | 'b',
+    currentOther: string,
+  ) {
+    const selected = e.target.value
+    const nameA = role === 'a' ? selected : currentOther
+    const nameB = role === 'b' ? selected : currentOther
+    if (!nameA || !nameB || nameA === nameB) {
+      onChange(null)
+      return
+    }
+    const revA = revisions.find((r) => revisionName(r) === nameA)
+    const revB = revisions.find((r) => revisionName(r) === nameB)
+    if (revA && revB) onChange({ revA, revB })
+    else onChange(null)
+  }
+
+  // Default: Rev A = latest, Rev B = second-latest
+  const defaultA = revisionName(revisions[0])
+  const defaultB = revisionName(revisions[1])
+
+  return (
+    <div className="revision-selector" data-testid="revision-selector">
+      <div className="revision-selector__group">
+        <label className="revision-selector__label" htmlFor="rev-select-a">
+          Rev A (before)
+        </label>
+        <select
+          id="rev-select-a"
+          className="revision-selector__select"
+          aria-label="Select revision A (before)"
+          defaultValue={defaultA}
+          onChange={(e) => {
+            const bSelect = document.getElementById('rev-select-b') as HTMLSelectElement | null
+            handleChange(e, 'a', bSelect?.value ?? defaultB)
+          }}
+        >
+          {revisions.map((rev) => {
+            const name = revisionName(rev)
+            return (
+              <option key={name} value={name}>
+                {revisionLabel(rev)}
+              </option>
+            )
+          })}
+        </select>
+      </div>
+
+      <div className="revision-selector__arrow" aria-hidden="true">→</div>
+
+      <div className="revision-selector__group">
+        <label className="revision-selector__label" htmlFor="rev-select-b">
+          Rev B (after)
+        </label>
+        <select
+          id="rev-select-b"
+          className="revision-selector__select"
+          aria-label="Select revision B (after)"
+          defaultValue={defaultB}
+          onChange={(e) => {
+            const aSelect = document.getElementById('rev-select-a') as HTMLSelectElement | null
+            handleChange(e, 'b', aSelect?.value ?? defaultA)
+          }}
+        >
+          {revisions.map((rev) => {
+            const name = revisionName(rev)
+            return (
+              <option key={name} value={name}>
+                {revisionLabel(rev)}
+              </option>
+            )
+          })}
+        </select>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/RevisionSelector.tsx
+++ b/web/src/components/RevisionSelector.tsx
@@ -18,6 +18,7 @@
 // Emits onChange({ revA, revB }) when both selects have distinct selections.
 // Shows an informational message when < 2 revisions exist.
 
+import { useState, useEffect } from 'react'
 import type { K8sObject } from '@/lib/api'
 import './RevisionSelector.css'
 
@@ -68,6 +69,19 @@ interface RevisionSelectorProps {
  * Spec: T007 (Phase 1).
  */
 export default function RevisionSelector({ revisions, onChange }: RevisionSelectorProps) {
+  // Default: Rev A = latest, Rev B = second-latest
+  const [nameA, setNameA] = useState(() => revisions.length >= 1 ? revisionName(revisions[0]) : '')
+  const [nameB, setNameB] = useState(() => revisions.length >= 2 ? revisionName(revisions[1]) : '')
+
+  // Emit the initial default pair on first render (auto-seeds the diff view)
+  useEffect(() => {
+    if (revisions.length < 2) return
+    const revA = revisions[0]
+    const revB = revisions[1]
+    onChange({ revA, revB })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []) // intentionally empty — only on mount
+
   if (revisions.length < 2) {
     if (revisions.length === 1) {
       return (
@@ -82,27 +96,25 @@ export default function RevisionSelector({ revisions, onChange }: RevisionSelect
     return null
   }
 
-  function handleChange(
-    e: React.ChangeEvent<HTMLSelectElement>,
-    role: 'a' | 'b',
-    currentOther: string,
-  ) {
-    const selected = e.target.value
-    const nameA = role === 'a' ? selected : currentOther
-    const nameB = role === 'b' ? selected : currentOther
-    if (!nameA || !nameB || nameA === nameB) {
-      onChange(null)
-      return
-    }
-    const revA = revisions.find((r) => revisionName(r) === nameA)
+  function handleChangeA(e: React.ChangeEvent<HTMLSelectElement>) {
+    const next = e.target.value
+    setNameA(next)
+    if (!next || !nameB || next === nameB) { onChange(null); return }
+    const revA = revisions.find((r) => revisionName(r) === next)
     const revB = revisions.find((r) => revisionName(r) === nameB)
     if (revA && revB) onChange({ revA, revB })
     else onChange(null)
   }
 
-  // Default: Rev A = latest, Rev B = second-latest
-  const defaultA = revisionName(revisions[0])
-  const defaultB = revisionName(revisions[1])
+  function handleChangeB(e: React.ChangeEvent<HTMLSelectElement>) {
+    const next = e.target.value
+    setNameB(next)
+    if (!nameA || !next || nameA === next) { onChange(null); return }
+    const revA = revisions.find((r) => revisionName(r) === nameA)
+    const revB = revisions.find((r) => revisionName(r) === next)
+    if (revA && revB) onChange({ revA, revB })
+    else onChange(null)
+  }
 
   return (
     <div className="revision-selector" data-testid="revision-selector">
@@ -114,11 +126,8 @@ export default function RevisionSelector({ revisions, onChange }: RevisionSelect
           id="rev-select-a"
           className="revision-selector__select"
           aria-label="Select revision A (before)"
-          defaultValue={defaultA}
-          onChange={(e) => {
-            const bSelect = document.getElementById('rev-select-b') as HTMLSelectElement | null
-            handleChange(e, 'a', bSelect?.value ?? defaultB)
-          }}
+          value={nameA}
+          onChange={handleChangeA}
         >
           {revisions.map((rev) => {
             const name = revisionName(rev)
@@ -141,11 +150,8 @@ export default function RevisionSelector({ revisions, onChange }: RevisionSelect
           id="rev-select-b"
           className="revision-selector__select"
           aria-label="Select revision B (after)"
-          defaultValue={defaultB}
-          onChange={(e) => {
-            const aSelect = document.getElementById('rev-select-a') as HTMLSelectElement | null
-            handleChange(e, 'b', aSelect?.value ?? defaultA)
-          }}
+          value={nameB}
+          onChange={handleChangeB}
         >
           {revisions.map((rev) => {
             const name = revisionName(rev)

--- a/web/src/components/RevisionsTab.css
+++ b/web/src/components/RevisionsTab.css
@@ -1,6 +1,7 @@
 /* RevisionsTab.css — GraphRevision history tab styles.
  * All colors from tokens.css — no hardcoded hex.
  * GH #274 Phase 4.
+ * Spec 009: DAG Diff view section added below.
  */
 
 .revisions-tab {
@@ -279,4 +280,29 @@
   background: var(--color-surface-2);
   border-bottom: 1px solid var(--color-border);
   font-family: var(--font-mono);
+}
+
+/* ── Spec 009: DAG Diff view section ────────────────────────────────────── */
+
+.revisions-tab__dag-diff-section {
+  padding: 16px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.revisions-tab__dag-diff-header {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 0;
+}
+
+.revisions-tab__dag-diff-title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.revisions-tab__dag-diff-subtitle {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
 }

--- a/web/src/components/RevisionsTab.tsx
+++ b/web/src/components/RevisionsTab.tsx
@@ -18,8 +18,12 @@
 // creates a new revision. This tab shows the revision history with status,
 // age, and compilation result.
 //
-// GH #13 (spec 009): Select 2 revisions to show a side-by-side YAML diff
-// (side-by-side YAML diff is the remaining deliverable for spec 009).
+// Spec 009 (GH #13): Two views are provided:
+//   1. DAG Diff view — a single merged DAG with color-coded overlays for
+//      added/removed/modified/unchanged nodes and edges (FR-005, this PR).
+//      Implemented via RevisionSelector + RGDDiffView.
+//   2. YAML diff — the existing side-by-side raw YAML view (PR #318 foundation).
+//      Remains below the DAG diff as a complementary raw-data fallback.
 //
 // Spec ref: .specify/specs/046-kro-v090-upgrade/ (Phase 4 — Graph Revisions tab)
 // GH #274: kro v0.9.0 upgrade — Graph Revisions tab
@@ -30,6 +34,9 @@ import type { K8sObject } from '@/lib/api'
 import { formatAge, extractCreationTimestamp } from '@/lib/format'
 import { toYaml, cleanK8sObject } from '@/lib/yaml'
 import KroCodeBlock from './KroCodeBlock'
+import RevisionSelector from './RevisionSelector'
+import type { RevisionPair } from './RevisionSelector'
+import RGDDiffView from './RGDDiffView'
 import './RevisionsTab.css'
 
 interface RevisionsTabProps {
@@ -129,9 +136,12 @@ export default function RevisionsTab({ rgdName }: RevisionsTabProps) {
   const [error, setError] = useState<string | null>(null)
   const [expanded, setExpanded] = useState<string | null>(null)
 
-  // GH #13 (spec 009): Select 2 revisions to show side-by-side YAML diff
+  // Spec 009: diff pair selected via RevisionSelector
+  const [diffPair, setDiffPair] = useState<RevisionPair | null>(null)
+
+  // Legacy checkbox-based YAML diff (PR #318 foundation) — kept as raw-data fallback
   const [selectedRevs, setSelectedRevs] = useState<Set<string>>(new Set())
-  const [diffPair, setDiffPair] = useState<[K8sObject, K8sObject] | null>(null)
+  const [yamlDiffPair, setYamlDiffPair] = useState<[K8sObject, K8sObject] | null>(null)
 
   function toggleSelect(name: string, e: React.MouseEvent | React.ChangeEvent) {
     e.stopPropagation()
@@ -152,7 +162,7 @@ export default function RevisionsTab({ rgdName }: RevisionsTabProps) {
     const b = revisions.find((r) => {
       const m = r.metadata as Record<string, unknown>; return m?.name === keys[1]
     })
-    if (a && b) setDiffPair([a, b])
+    if (a && b) setYamlDiffPair([a, b])
   }
 
   const fetchRevisions = useCallback(() => {
@@ -211,7 +221,29 @@ export default function RevisionsTab({ rgdName }: RevisionsTabProps) {
 
   return (
     <div className="revisions-tab" data-testid="revisions-tab">
-      {/* GH #13 (spec 009): compare action bar */}
+
+      {/* ── Spec 009: DAG diff view ─────────────────────────────────────── */}
+      {/* RevisionSelector auto-defaults to latest → second-latest pair     */}
+      {revisions.length >= 2 && (
+        <div className="revisions-tab__dag-diff-section" data-testid="revisions-dag-diff-section">
+          <div className="revisions-tab__dag-diff-header">
+            <span className="revisions-tab__dag-diff-title">Graph Diff</span>
+            <span className="revisions-tab__dag-diff-subtitle">
+              Select two revisions to visualise node and edge changes
+            </span>
+          </div>
+          <RevisionSelector
+            revisions={revisions}
+            onChange={(pair) => setDiffPair(pair)}
+          />
+          {diffPair && (
+            <RGDDiffView revA={diffPair.revA} revB={diffPair.revB} />
+          )}
+        </div>
+      )}
+
+      {/* ── Legacy YAML diff action bar (PR #318 foundation) ─────────────── */}
+      {/* Kept as a complementary raw-data view (spec 009 §Foundation note)  */}
       {revisions.length > 1 && (
         <div className="revisions-tab__compare-bar">
           {selectedRevs.size === 2 ? (
@@ -222,33 +254,33 @@ export default function RevisionsTab({ rgdName }: RevisionsTabProps) {
                 onClick={handleCompare}
                 data-testid="revisions-compare-btn"
               >
-                Compare revisions
+                Compare YAML
               </button>
               <button
                 type="button"
                 className="revisions-tab__compare-clear"
-                onClick={() => { setSelectedRevs(new Set()); setDiffPair(null) }}
+                onClick={() => { setSelectedRevs(new Set()); setYamlDiffPair(null) }}
               >
                 Clear
               </button>
             </>
           ) : selectedRevs.size === 1 ? (
-            <span className="revisions-tab__compare-hint">Select 1 more to compare</span>
+            <span className="revisions-tab__compare-hint">Select 1 more to compare YAML</span>
           ) : (
-            <span className="revisions-tab__compare-hint">Select 2 revisions to compare</span>
+            <span className="revisions-tab__compare-hint">Or select 2 revisions to compare raw YAML</span>
           )}
         </div>
       )}
 
-      {/* GH #13 diff panel */}
-      {diffPair && (
+      {/* ── YAML diff panel (PR #318 foundation, retained as raw-data fallback) ── */}
+      {yamlDiffPair && (
         <div className="revisions-tab__diff-panel" data-testid="revisions-diff-panel">
           <div className="revisions-tab__diff-header">
-            <span className="revisions-tab__diff-title">Revision diff</span>
+            <span className="revisions-tab__diff-title">Raw YAML diff</span>
             <button
               type="button"
               className="revisions-tab__diff-close"
-              onClick={() => { setDiffPair(null); setSelectedRevs(new Set()) }}
+              onClick={() => { setYamlDiffPair(null); setSelectedRevs(new Set()) }}
             >
               Close diff
             </button>
@@ -257,20 +289,20 @@ export default function RevisionsTab({ rgdName }: RevisionsTabProps) {
             <div className="revisions-tab__diff-col">
               <div className="revisions-tab__diff-col-header">
                 {(() => {
-                  const m = diffPair[0].metadata as Record<string, unknown>
-                  return `Rev #${revisionNumber(diffPair[0])} — ${m?.name}`
+                  const m = yamlDiffPair[0].metadata as Record<string, unknown>
+                  return `Rev #${revisionNumber(yamlDiffPair[0])} — ${m?.name}`
                 })()}
               </div>
-              <KroCodeBlock code={toYaml(cleanK8sObject(diffPair[0]))} title="Rev A" />
+              <KroCodeBlock code={toYaml(cleanK8sObject(yamlDiffPair[0]))} title="Rev A" />
             </div>
             <div className="revisions-tab__diff-col">
               <div className="revisions-tab__diff-col-header">
                 {(() => {
-                  const m = diffPair[1].metadata as Record<string, unknown>
-                  return `Rev #${revisionNumber(diffPair[1])} — ${m?.name}`
+                  const m = yamlDiffPair[1].metadata as Record<string, unknown>
+                  return `Rev #${revisionNumber(yamlDiffPair[1])} — ${m?.name}`
                 })()}
               </div>
-              <KroCodeBlock code={toYaml(cleanK8sObject(diffPair[1]))} title="Rev B" />
+              <KroCodeBlock code={toYaml(cleanK8sObject(yamlDiffPair[1]))} title="Rev B" />
             </div>
           </div>
         </div>

--- a/web/src/lib/dag-diff.test.ts
+++ b/web/src/lib/dag-diff.test.ts
@@ -1,0 +1,290 @@
+// dag-diff.test.ts — Unit tests for diffDAGGraphs() (spec 009-rgd-graph-diff).
+//
+// Tests cover all 6 required cases from spec.md Testing Requirements, plus
+// edge cases and NFR-001 (performance).
+
+import { describe, it, expect } from 'vitest'
+import { buildDAGGraph } from './dag'
+import type { DAGGraph } from './dag'
+import { diffDAGGraphs } from './dag-diff'
+import type { DiffGraph } from './dag-diff'
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+/** Minimal RGD spec with a given set of resources. */
+function spec(resources: unknown[]) {
+  return {
+    schema: { kind: 'TestKind', apiVersion: 'v1alpha1' },
+    resources,
+  }
+}
+
+function resourceNode(id: string, kind = 'ConfigMap', extra?: Record<string, unknown>) {
+  return {
+    id,
+    template: { apiVersion: 'v1', kind, metadata: { name: `${id}-name` } },
+    ...extra,
+  }
+}
+
+function conditionalNode(id: string, includeWhen: string[]) {
+  return {
+    id,
+    template: { apiVersion: 'v1', kind: 'ConfigMap', metadata: { name: id } },
+    includeWhen,
+  }
+}
+
+function readyWhenNode(id: string, readyWhen: string[]) {
+  return {
+    id,
+    template: { apiVersion: 'v1', kind: 'ConfigMap', metadata: { name: id } },
+    readyWhen,
+  }
+}
+
+function collectionNode(id: string, forEach: string) {
+  return {
+    id,
+    forEach,
+    template: { apiVersion: 'v1', kind: 'ConfigMap', metadata: { name: id } },
+  }
+}
+
+/** Build a graph from a resource list. */
+function g(resources: unknown[]): DAGGraph {
+  return buildDAGGraph(spec(resources))
+}
+
+/** Find a node by id in a DiffGraph (throws if absent). */
+function findNode(dg: DiffGraph, id: string) {
+  const n = dg.nodes.find((n) => n.id === id)
+  if (!n) throw new Error(`Node ${id} not found in DiffGraph`)
+  return n
+}
+
+/** Find an edge by from+to in a DiffGraph. */
+function findEdge(dg: DiffGraph, from: string, to: string) {
+  return dg.edges.find((e) => e.from === from && e.to === to)
+}
+
+// ── Required test cases (spec.md Testing Requirements) ───────────────────
+
+describe('diffDAGGraphs', () => {
+  // ── Case 1: node present in B but not A → added ───────────────────────
+
+  it('classifies node present in B but not A as added', () => {
+    const gA = g([resourceNode('ns')])
+    const gB = g([resourceNode('ns'), resourceNode('deploy', 'Deployment')])
+
+    const diff = diffDAGGraphs(gA, gB)
+    const added = findNode(diff, 'deploy')
+    expect(added.diffStatus).toBe('added')
+    expect(added.prevCEL).toBeUndefined()
+    expect(added.nextCEL).toBeUndefined()
+  })
+
+  // ── Case 2: node present in A but not B → removed ─────────────────────
+
+  it('classifies node present in A but not B as removed', () => {
+    const gA = g([resourceNode('ns'), resourceNode('deploy', 'Deployment')])
+    const gB = g([resourceNode('ns')])
+
+    const diff = diffDAGGraphs(gA, gB)
+    const removed = findNode(diff, 'deploy')
+    expect(removed.diffStatus).toBe('removed')
+    expect(removed.prevCEL).toBeUndefined()
+    expect(removed.nextCEL).toBeUndefined()
+  })
+
+  // ── Case 3: node with different CEL → modified ────────────────────────
+
+  it('classifies node with different CEL as modified', () => {
+    const gA = g([conditionalNode('ns', ['${schema.spec.enabled}'])])
+    const gB = g([conditionalNode('ns', ['${schema.spec.enabled && schema.spec.ready}'])])
+
+    const diff = diffDAGGraphs(gA, gB)
+    const modified = findNode(diff, 'ns')
+    expect(modified.diffStatus).toBe('modified')
+    expect(modified.prevCEL).toBeDefined()
+    expect(modified.nextCEL).toBeDefined()
+    expect(modified.prevCEL!.includeWhen).toEqual(['${schema.spec.enabled}'])
+    expect(modified.nextCEL!.includeWhen).toEqual(['${schema.spec.enabled && schema.spec.ready}'])
+  })
+
+  // ── Case 4: identical nodes → unchanged ──────────────────────────────
+
+  it('classifies identical nodes as unchanged', () => {
+    const resource = resourceNode('ns')
+    const gA = g([resource])
+    const gB = g([resource])
+
+    const diff = diffDAGGraphs(gA, gB)
+    const unchanged = findNode(diff, 'ns')
+    expect(unchanged.diffStatus).toBe('unchanged')
+    expect(unchanged.prevCEL).toBeUndefined()
+    expect(unchanged.nextCEL).toBeUndefined()
+  })
+
+  // ── Case 5: new edge → added ──────────────────────────────────────────
+
+  it('classifies new edge as added', () => {
+    // In graphB, 'deploy' references 'ns' via CEL — creates an edge ns→deploy
+    const gA = g([resourceNode('ns'), resourceNode('deploy', 'Deployment')])
+    const gB = g([
+      resourceNode('ns'),
+      {
+        id: 'deploy',
+        template: {
+          apiVersion: 'apps/v1',
+          kind: 'Deployment',
+          metadata: { name: '${ns.metadata.name}-deploy' }, // reference to ns
+        },
+      },
+    ])
+
+    const diff = diffDAGGraphs(gA, gB)
+    const newEdge = findEdge(diff, 'ns', 'deploy')
+    expect(newEdge).toBeDefined()
+    expect(newEdge!.diffStatus).toBe('added')
+  })
+
+  // ── Case 6: removed edge → removed ───────────────────────────────────
+
+  it('classifies removed edge as removed', () => {
+    // graphA has ns→deploy edge; graphB removes the reference
+    const gA = g([
+      resourceNode('ns'),
+      {
+        id: 'deploy',
+        template: {
+          apiVersion: 'apps/v1',
+          kind: 'Deployment',
+          metadata: { name: '${ns.metadata.name}-deploy' }, // reference to ns
+        },
+      },
+    ])
+    const gB = g([resourceNode('ns'), resourceNode('deploy', 'Deployment')])
+
+    const diff = diffDAGGraphs(gA, gB)
+    const removedEdge = findEdge(diff, 'ns', 'deploy')
+    expect(removedEdge).toBeDefined()
+    expect(removedEdge!.diffStatus).toBe('removed')
+  })
+
+  // ── Edge case: node renamed between revisions = remove + add ─────────
+
+  it('node renamed between revisions is treated as remove + add, not modified', () => {
+    // Same kind, different id
+    const gA = g([resourceNode('nsOld', 'Namespace')])
+    const gB = g([resourceNode('nsNew', 'Namespace')])
+
+    const diff = diffDAGGraphs(gA, gB)
+    const removed = findNode(diff, 'nsOld')
+    const added = findNode(diff, 'nsNew')
+    expect(removed.diffStatus).toBe('removed')
+    expect(added.diffStatus).toBe('added')
+  })
+
+  // ── Edge case: prevCEL/nextCEL correct for readyWhen ─────────────────
+
+  it('returns correct prevCEL/nextCEL for modified node (readyWhen change)', () => {
+    const gA = g([readyWhenNode('svc', ['${schema.spec.ready}'])])
+    const gB = g([readyWhenNode('svc', ['${schema.spec.ready}', '${schema.spec.healthy}'])])
+
+    const diff = diffDAGGraphs(gA, gB)
+    const node = findNode(diff, 'svc')
+    expect(node.diffStatus).toBe('modified')
+    expect(node.prevCEL!.readyWhen).toEqual(['${schema.spec.ready}'])
+    expect(node.nextCEL!.readyWhen).toEqual(['${schema.spec.ready}', '${schema.spec.healthy}'])
+  })
+
+  // ── Edge case: prevCEL/nextCEL correct for forEach change ────────────
+
+  it('returns correct prevCEL/nextCEL for modified node (forEach change)', () => {
+    const gA = g([collectionNode('items', '${schema.spec.regions}')])
+    const gB = g([collectionNode('items', '${schema.spec.azs}')])
+
+    const diff = diffDAGGraphs(gA, gB)
+    const node = findNode(diff, 'items')
+    expect(node.diffStatus).toBe('modified')
+    expect(node.prevCEL!.forEach).toBe('${schema.spec.regions}')
+    expect(node.nextCEL!.forEach).toBe('${schema.spec.azs}')
+  })
+
+  // ── NFR-001: performance — completes in <100ms for 20-node graphs ─────
+
+  it('NFR-001: diffDAGGraphs completes in <100ms for 20-node graphs', () => {
+    // Build 20 independent resource nodes in each graph
+    const make20Resources = (suffix: string) =>
+      Array.from({ length: 20 }, (_, i) => resourceNode(`res${i}${suffix}`, 'ConfigMap'))
+
+    const gA = g(make20Resources('A'))
+    const gB = g(make20Resources('B'))
+
+    const start = performance.now()
+    diffDAGGraphs(gA, gB)
+    const elapsed = performance.now() - start
+
+    expect(elapsed).toBeLessThan(100)
+  })
+
+  // ── Root node always present in both (schema node) ────────────────────
+
+  it('root "schema" node is always classified as unchanged when kind is same', () => {
+    const gA = g([resourceNode('ns')])
+    const gB = g([resourceNode('ns'), resourceNode('deploy', 'Deployment')])
+
+    const diff = diffDAGGraphs(gA, gB)
+    const root = findNode(diff, 'schema')
+    expect(root.diffStatus).toBe('unchanged')
+  })
+
+  // ── Empty graphs produce an empty diff ──────────────────────────────
+
+  it('diffing empty graphs produces empty diff (just the schema root)', () => {
+    const gA = g([])
+    const gB = g([])
+
+    const diff = diffDAGGraphs(gA, gB)
+    // Only the schema root should exist
+    expect(diff.nodes).toHaveLength(1)
+    expect(diff.nodes[0].id).toBe('schema')
+    expect(diff.nodes[0].diffStatus).toBe('unchanged')
+    expect(diff.edges).toHaveLength(0)
+  })
+
+  // ── All edges unchanged when graphs are identical ─────────────────────
+
+  it('all edges are unchanged when graphs are identical', () => {
+    const resources = [
+      resourceNode('ns'),
+      {
+        id: 'deploy',
+        template: {
+          apiVersion: 'apps/v1',
+          kind: 'Deployment',
+          metadata: { name: '${ns.metadata.name}-d' },
+        },
+      },
+    ]
+    const gA = g(resources)
+    const gB = g(resources)
+
+    const diff = diffDAGGraphs(gA, gB)
+    for (const edge of diff.edges) {
+      expect(edge.diffStatus).toBe('unchanged')
+    }
+  })
+
+  // ── width/height come from graphB ─────────────────────────────────────
+
+  it('DiffGraph width/height come from graphB', () => {
+    const gA = g([resourceNode('ns')])
+    const gB = g([resourceNode('ns'), resourceNode('deploy', 'Deployment'), resourceNode('svc', 'Service')])
+
+    const diff = diffDAGGraphs(gA, gB)
+    expect(diff.width).toBe(gB.width)
+    expect(diff.height).toBe(gB.height)
+  })
+})

--- a/web/src/lib/dag-diff.ts
+++ b/web/src/lib/dag-diff.ts
@@ -1,0 +1,208 @@
+// dag-diff.ts — Pure diff function for two DAGGraph objects.
+//
+// Implements spec 009-rgd-graph-diff FR-001 through FR-005.
+// Takes two DAGGraph values (built by buildDAGGraph) and returns a
+// DiffGraph: a merged graph where every node and edge carries a
+// DiffStatus classifying its fate between revision A and revision B.
+//
+// Key design decisions:
+//   - Node identity is the node.id string (never fuzzy-matched).
+//     A renamed node (same kind, different id) is treated as remove + add.
+//   - Edge identity is the from+to id pair.
+//   - Modified nodes expose prevCEL / nextCEL arrays capturing the
+//     before/after values of includeWhen, readyWhen, forEach.
+//   - The merged graph's layout is NOT recomputed here; callers are
+//     expected to pass DiffGraph.nodes to layoutDAG themselves (or use
+//     the pre-laid-out positions from graphB for the "base" positions and
+//     add removed nodes from graphA at their original positions).
+//
+// Constitution §V: pure functions, no external deps.
+// Constitution §IX: no CSS, no DOM — pure data transformation.
+
+import type { DAGNode, DAGEdge, DAGGraph } from '@/lib/dag'
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+/**
+ * DiffStatus classifies whether a graph element was added, removed,
+ * modified (structurally present in both but with different CEL), or
+ * unchanged (identical in both revisions).
+ */
+export type DiffStatus = 'added' | 'removed' | 'modified' | 'unchanged'
+
+/**
+ * A node in the merged diff graph.
+ * Extends DAGNode with diff classification and before/after CEL snapshots.
+ */
+export interface DiffNode extends DAGNode {
+  diffStatus: DiffStatus
+  /**
+   * CEL expression arrays from the revision-A node.
+   * Only populated when diffStatus === 'modified'.
+   * Covers: includeWhen, readyWhen, forEach.
+   */
+  prevCEL: {
+    includeWhen: string[]
+    readyWhen: string[]
+    forEach: string | undefined
+  } | undefined
+  /**
+   * CEL expression arrays from the revision-B node.
+   * Only populated when diffStatus === 'modified'.
+   */
+  nextCEL: {
+    includeWhen: string[]
+    readyWhen: string[]
+    forEach: string | undefined
+  } | undefined
+}
+
+/**
+ * A directed edge in the merged diff graph.
+ */
+export interface DiffEdge extends DAGEdge {
+  diffStatus: Exclude<DiffStatus, 'modified'>  // edges have no "modified" state
+}
+
+/**
+ * The merged diff graph.
+ * Contains all nodes and edges from both revisions, each tagged with its status.
+ * Layout coordinates come from graphB for surviving/added nodes, and graphA for
+ * removed nodes.
+ */
+export interface DiffGraph {
+  nodes: DiffNode[]
+  edges: DiffEdge[]
+  /** Width from graphB (the "new" revision defines the layout baseline). */
+  width: number
+  /** Height from graphB. */
+  height: number
+}
+
+// ── CEL snapshot helpers ───────────────────────────────────────────────────
+
+interface CELSnapshot {
+  includeWhen: string[]
+  readyWhen: string[]
+  forEach: string | undefined
+}
+
+function celSnapshot(node: DAGNode): CELSnapshot {
+  return {
+    includeWhen: [...node.includeWhen],
+    readyWhen: [...node.readyWhen],
+    forEach: node.forEach,
+  }
+}
+
+/**
+ * Returns true when two CEL snapshots are identical.
+ * Array comparison is order-sensitive (same order = same CEL).
+ */
+function celEqual(a: CELSnapshot, b: CELSnapshot): boolean {
+  if (a.forEach !== b.forEach) return false
+  if (a.includeWhen.length !== b.includeWhen.length) return false
+  if (a.readyWhen.length !== b.readyWhen.length) return false
+  for (let i = 0; i < a.includeWhen.length; i++) {
+    if (a.includeWhen[i] !== b.includeWhen[i]) return false
+  }
+  for (let i = 0; i < a.readyWhen.length; i++) {
+    if (a.readyWhen[i] !== b.readyWhen[i]) return false
+  }
+  return true
+}
+
+// ── Main export ────────────────────────────────────────────────────────────
+
+/**
+ * diffDAGGraphs — compute the diff between two DAGGraph revisions.
+ *
+ * @param graphA - The "before" revision (selected as Rev A in the UI).
+ * @param graphB - The "after" revision (selected as Rev B in the UI).
+ * @returns DiffGraph with all nodes and edges tagged by their DiffStatus.
+ *
+ * Node classification (spec FR-003):
+ *   - present in B but not A → added
+ *   - present in A but not B → removed
+ *   - present in both, different CEL → modified (prevCEL + nextCEL populated)
+ *   - present in both, identical CEL → unchanged
+ *
+ * Edge classification (spec FR-004):
+ *   - present in B but not A → added
+ *   - present in A but not B → removed
+ *   - present in both → unchanged
+ *
+ * Layout coordinates:
+ *   - added / modified / unchanged nodes: coordinates from graphB
+ *   - removed nodes: coordinates from graphA (preserves approximate position)
+ *
+ * Performance: O(|nodes| + |edges|) for graph sizes up to 1 000 nodes.
+ * NFR-001: must complete in <100ms for 20-node graphs (verified in dag-diff.test.ts).
+ */
+export function diffDAGGraphs(graphA: DAGGraph, graphB: DAGGraph): DiffGraph {
+  // Build lookup maps
+  const nodesA = new Map<string, DAGNode>(graphA.nodes.map((n) => [n.id, n]))
+  const nodesB = new Map<string, DAGNode>(graphB.nodes.map((n) => [n.id, n]))
+
+  const edgesA = new Set<string>(graphA.edges.map((e) => `${e.from}→${e.to}`))
+  const edgesB = new Set<string>(graphB.edges.map((e) => `${e.from}→${e.to}`))
+
+  const diffNodes: DiffNode[] = []
+  const diffEdges: DiffEdge[] = []
+
+  // ── Node diff ─────────────────────────────────────────────────────────
+
+  // Pass 1: iterate B nodes — added, modified, unchanged
+  for (const [id, nodeB] of nodesB) {
+    const nodeA = nodesA.get(id)
+    if (!nodeA) {
+      // Present in B but not A → added
+      diffNodes.push({ ...nodeB, diffStatus: 'added', prevCEL: undefined, nextCEL: undefined })
+    } else {
+      // Present in both — compare CEL
+      const snapA = celSnapshot(nodeA)
+      const snapB = celSnapshot(nodeB)
+      if (celEqual(snapA, snapB)) {
+        diffNodes.push({ ...nodeB, diffStatus: 'unchanged', prevCEL: undefined, nextCEL: undefined })
+      } else {
+        diffNodes.push({
+          ...nodeB,
+          diffStatus: 'modified',
+          prevCEL: snapA,
+          nextCEL: snapB,
+        })
+      }
+    }
+  }
+
+  // Pass 2: iterate A nodes not in B → removed (keep A's layout coordinates)
+  for (const [id, nodeA] of nodesA) {
+    if (!nodesB.has(id)) {
+      diffNodes.push({ ...nodeA, diffStatus: 'removed', prevCEL: undefined, nextCEL: undefined })
+    }
+  }
+
+  // ── Edge diff ─────────────────────────────────────────────────────────
+
+  // Pass 1: B edges — added or unchanged
+  for (const edgeB of graphB.edges) {
+    const key = `${edgeB.from}→${edgeB.to}`
+    const status: DiffEdge['diffStatus'] = edgesA.has(key) ? 'unchanged' : 'added'
+    diffEdges.push({ ...edgeB, diffStatus: status })
+  }
+
+  // Pass 2: A edges not in B → removed
+  for (const edgeA of graphA.edges) {
+    const key = `${edgeA.from}→${edgeA.to}`
+    if (!edgesB.has(key)) {
+      diffEdges.push({ ...edgeA, diffStatus: 'removed' })
+    }
+  }
+
+  return {
+    nodes: diffNodes,
+    edges: diffEdges,
+    width: graphB.width,
+    height: graphB.height,
+  }
+}

--- a/web/src/tokens.css
+++ b/web/src/tokens.css
@@ -44,6 +44,22 @@
   --color-error:           #f43f5e;   /* Ready=False — rose */
   --color-not-found:       #6b7280;   /* absent / unknown — gray */
 
+  /* Semantic: graph diff (spec 009-rgd-graph-diff — FR-007)
+   * Same hues as existing state tokens; distinct names for diff-specific semantics.
+   * Background variants use low-opacity fills for node rect backgrounds.         */
+  --color-diff-added:          #10b981;   /* emerald — same hue as --color-alive   */
+  --color-diff-removed:        #f43f5e;   /* rose    — same hue as --color-error   */
+  --color-diff-modified:       #f59e0b;   /* amber   — same hue as --color-reconciling */
+  --color-diff-unchanged:      var(--color-text-muted);   /* gray muted text for unchanged */
+  --color-diff-added-bg:       rgba(16, 185, 129, 0.14);
+  --color-diff-removed-bg:     rgba(244, 63, 94, 0.14);
+  --color-diff-modified-bg:    rgba(245, 158, 11, 0.14);
+  --color-diff-unchanged-bg:   transparent;
+  --color-diff-added-border:   #10b981;
+  --color-diff-removed-border: #f43f5e;
+  --color-diff-modified-border: #f59e0b;
+  --color-diff-unchanged-border: var(--color-border);
+
   /* Semantic: UI status badges (same hue, separate tokens for semantics) */
   --color-status-ready:          #10b981;
   --color-status-degraded:       #f97316;   /* Degraded: CR ready but child has errors — orange */
@@ -177,6 +193,17 @@
   --color-pending:         #7c3aed;   /* darker violet */
   --color-error:           #e11d48;   /* darker rose */
   --color-not-found:       #6b7280;
+
+  /* Semantic: graph diff — light mode (darker variants for contrast on light bg) */
+  --color-diff-added:          #059669;   /* darker emerald */
+  --color-diff-removed:        #e11d48;   /* darker rose */
+  --color-diff-modified:       #d97706;   /* darker amber */
+  --color-diff-added-bg:       rgba(5, 150, 105, 0.10);
+  --color-diff-removed-bg:     rgba(225, 29, 72, 0.10);
+  --color-diff-modified-bg:    rgba(217, 119, 6, 0.10);
+  --color-diff-added-border:   #059669;
+  --color-diff-removed-border: #e11d48;
+  --color-diff-modified-border: #d97706;
 
   /* Semantic: UI status */
   --color-status-ready:          #059669;


### PR DESCRIPTION
## Summary

Implements **spec 009-rgd-graph-diff** in full — the merged DAG diff view for GraphRevision history in the Revisions tab.

**What ships**:
- `diffDAGGraphs()` pure function in `web/src/lib/dag-diff.ts` — classifies nodes as added/removed/modified/unchanged by id; edges by from+to pair; `prevCEL`/`nextCEL` snapshot for modified nodes (FR-003/FR-004)
- 12 diff color tokens in `tokens.css` — `--color-diff-added`, `--color-diff-removed`, `--color-diff-modified`, `--color-diff-unchanged` and background/border variants, in both dark and light themes (FR-007)
- `RevisionSelector` — two `<select>` dropdowns (Rev A/B), defaults to latest→second-latest pair, auto-seeds diff on mount (Phase 1)
- `RGDDiffView` — merged DAG SVG with color-coded node/edge overlays; `+`/`−`/`~` diff badges; removed nodes dashed border + 65% opacity; clicking a modified node opens before/after CEL panel with `KroCodeBlock` (FR-005/FR-006)
- `RevisionsTab` updated to wire `RevisionSelector` + `RGDDiffView` above the existing YAML diff section (PR #318 foundation retained as raw-data fallback per spec note)
- 5-step E2E journey `009-rgd-graph-diff.spec.ts` — fully capability-gated (`hasGraphRevisions` check + `test.skip()` + `return` per §XIV), registered in chunk-3

**Tests**: 14 unit tests (all 6 spec-required cases + edge cases + NFR-001 `<100ms` perf assertion); 1458 total frontend tests passing; Go tests clean.

**Closes GH #13**. Satisfies spec 009 SC-001 through SC-004.

## Spec reference

`.specify/specs/009-rgd-graph-diff/spec.md` — FR-001 through FR-007, NFR-001/NFR-002 all satisfied.

## E2E notes

Steps 3 and 4 require the E2E cluster to have `≥2` and exactly `1` GraphRevision respectively on `test-app`. The journey gracefully skips any step where the pre-condition is not met (`test.skip()` + `return`).