### PR TITLE
test(handlers): ListContexts error path + revisionNum all type branches → 88.2%

### DIFF
--- a/internal/api/handlers/contexts_test.go
+++ b/internal/api/handlers/contexts_test.go
@@ -15,6 +15,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -71,6 +72,21 @@ func TestListContexts(t *testing.T) {
 				t.Helper()
 				require.Equal(t, http.StatusOK, rr.Code)
 				assert.Contains(t, rr.Body.String(), `"staging"`)
+			},
+		},
+		{
+			name: "returns 500 when factory.ListContexts fails",
+			build: func(t *testing.T) (*Handler, *stubClientFactory) {
+				t.Helper()
+				stub := &stubClientFactory{
+					listErr: fmt.Errorf("kubeconfig not readable"),
+				}
+				return newTestHandler(stub), stub
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder, stub *stubClientFactory) {
+				t.Helper()
+				require.Equal(t, http.StatusInternalServerError, rr.Code)
+				assert.Contains(t, rr.Body.String(), `"error"`)
 			},
 		},
 	}

--- a/internal/api/handlers/graph_revisions_test.go
+++ b/internal/api/handlers/graph_revisions_test.go
@@ -226,3 +226,50 @@ func indexOf(s, substr string) int {
 	}
 	return -1
 }
+
+// TestRevisionNum tests the revisionNum helper which extracts spec.revision
+// from a GraphRevision object map, handling the three numeric Go type variants
+// produced by json.Unmarshal and unstructured client (int64, float64, int).
+func TestRevisionNum(t *testing.T) {
+	t.Run("float64 value (JSON default)", func(t *testing.T) {
+		obj := map[string]any{"spec": map[string]any{"revision": float64(3)}}
+		if got := revisionNum(obj); got != 3 {
+			t.Errorf("expected 3, got %d", got)
+		}
+	})
+
+	t.Run("int64 value (unstructured client)", func(t *testing.T) {
+		obj := map[string]any{"spec": map[string]any{"revision": int64(7)}}
+		if got := revisionNum(obj); got != 7 {
+			t.Errorf("expected 7, got %d", got)
+		}
+	})
+
+	t.Run("int value", func(t *testing.T) {
+		obj := map[string]any{"spec": map[string]any{"revision": int(42)}}
+		if got := revisionNum(obj); got != 42 {
+			t.Errorf("expected 42, got %d", got)
+		}
+	})
+
+	t.Run("missing spec returns 0", func(t *testing.T) {
+		obj := map[string]any{}
+		if got := revisionNum(obj); got != 0 {
+			t.Errorf("expected 0, got %d", got)
+		}
+	})
+
+	t.Run("missing revision field returns 0", func(t *testing.T) {
+		obj := map[string]any{"spec": map[string]any{}}
+		if got := revisionNum(obj); got != 0 {
+			t.Errorf("expected 0, got %d", got)
+		}
+	})
+
+	t.Run("non-numeric type returns 0", func(t *testing.T) {
+		obj := map[string]any{"spec": map[string]any{"revision": "not-a-number"}}
+		if got := revisionNum(obj); got != 0 {
+			t.Errorf("expected 0, got %d", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Systematic coverage gap closure: two functions were missing specific type branches.

### ListContexts (57.1% → 100%)

The error-return path when `factory.ListContexts()` fails was never tested. Added:
- `"returns 500 when factory.ListContexts fails"` — uses the existing `stubClientFactory.listErr` field

### revisionNum (50% → 100%)

The `int` type branch in the `switch v := spec["revision"].(type)` was never exercised. Added `TestRevisionNum` with 6 cases:
- `float64` (JSON default via `json.Unmarshal`)
- `int64` (from k8s unstructured client)  
- `int` (native Go int — previously untested)
- Missing `spec` key → returns 0
- Missing `revision` field → returns 0
- Non-numeric type → returns 0

### Coverage delta
- `ListContexts`: **57.1% → 100%**
- `revisionNum`: **50% → 100%**
- Overall handler coverage: **87.2% → 88.2%**