### PR TITLE
feat(e2e): post anchor score comment to #439 after E2E run

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,8 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      issues: write
 
     steps:
       - uses: actions/checkout@v6
@@ -118,7 +120,8 @@ jobs:
           fi
           DATE=$(date -u +%Y-%m-%d)
           gh issue comment 439 --repo pnz1990/kro-ui \
-            --body "[ANCHOR | kro-ui | ${DATE}] journeys: ${JOURNEYS} | pass: ${PASS} fail: ${FAIL}"
+            --body "[ANCHOR | kro-ui | ${DATE}] journeys: ${JOURNEYS} | pass: ${PASS} fail: ${FAIL}" \
+            || true  # non-fatal: anchor comment failure must not block CI
 
       # ── Artifacts ─────────────────────────────────────────────────────────
       - name: Upload Playwright report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -90,7 +90,7 @@ jobs:
         working-directory: test/e2e
 
       - name: Run E2E journeys
-        run: bun run test
+        run: bun run test -- --reporter=list,html,json
         working-directory: test/e2e
         env:
           # Tell global-setup to skip kind create (kind-action already did it)
@@ -100,6 +100,25 @@ jobs:
           # Bump this when upgrading the kro controller in CI.
           KRO_CHART_VERSION: "0.9.1"
           CI: "true"
+          # Write JSON results to a file so the anchor step can read pass/fail counts.
+          PLAYWRIGHT_JSON_OUTPUT_NAME: results.json
+
+      - name: Post anchor score
+        if: always()
+        working-directory: test/e2e
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          JOURNEYS=$(ls journeys/*.spec.ts 2>/dev/null | wc -l | tr -d ' ')
+          PASS=0
+          FAIL=0
+          if [ -f results.json ]; then
+            PASS=$(python3 -c "import json,sys; d=json.load(open('results.json')); print(d.get('stats',{}).get('expected',0))" 2>/dev/null || echo 0)
+            FAIL=$(python3 -c "import json,sys; d=json.load(open('results.json')); print(d.get('stats',{}).get('unexpected',0))" 2>/dev/null || echo 0)
+          fi
+          DATE=$(date -u +%Y-%m-%d)
+          gh issue comment 439 --repo pnz1990/kro-ui \
+            --body "[ANCHOR | kro-ui | ${DATE}] journeys: ${JOURNEYS} | pass: ${PASS} fail: ${FAIL}"
 
       # ── Artifacts ─────────────────────────────────────────────────────────
       - name: Upload Playwright report


### PR DESCRIPTION
## Summary

- Adds a `Post anchor score` step to `.github/workflows/e2e.yml` that runs `if: always()`
- Posts `[ANCHOR | kro-ui | YYYY-MM-DD] journeys: J | pass: A fail: B` to issue #439 after every E2E run
- J = number of `.spec.ts` files in `test/e2e/journeys/`; pass/fail counts come from the Playwright JSON reporter (`PLAYWRIGHT_JSON_OUTPUT_NAME=results.json`)
- Uses `--reporter=list,html,json` to keep the existing HTML artifact report plus add JSON for parsing

## Design doc
N/A — workflow infrastructure change with no user-visible UI behavior.

Closes #448