### PR TITLE
test(e2e): journey depth — error + empty states in Tier 1 journeys (003, 004, 005)

### DIFF
--- a/test/e2e/journeys/003-rgd-dag.spec.ts
+++ b/test/e2e/journeys/003-rgd-dag.spec.ts
@@ -253,4 +253,22 @@ test.describe('003: RGD Detail — DAG Visualization', () => {
     const typeBadge = page.locator('[class*="node-type-badge--collection"]')
     await expect(typeBadge).toBeVisible()
   })
+
+  // ── Step 16: error state — non-existent RGD ───────────────────────────────
+
+  test('Step 16: navigating to a non-existent RGD shows the error state (not a blank page)', async ({ page }) => {
+    // The API returns 404 for an unknown RGD name; the page must render an
+    // informative error element, never a blank/crash screen.
+    // Use `page.request.get()` to verify the API first (SPA always returns 200
+    // on page navigation — cannot rely on HTTP status from page.goto).
+    const apiRes = await page.request.get(`${BASE}/api/v1/rgds/does-not-exist-rgd-xyz`)
+    expect(apiRes.status()).toBe(404)
+
+    await page.goto(`${BASE}/rgds/does-not-exist-rgd-xyz`)
+    await expect(page.getByTestId('rgd-detail-error')).toBeVisible({ timeout: 15000 })
+
+    // Error element must contain text — not be blank
+    const errorText = await page.getByTestId('rgd-detail-error').textContent()
+    expect(errorText?.trim().length).toBeGreaterThan(0)
+  })
 })

--- a/test/e2e/journeys/004-instance-list.spec.ts
+++ b/test/e2e/journeys/004-instance-list.spec.ts
@@ -199,4 +199,37 @@ test.describe('004: Instance List', () => {
     await expect(page.getByTestId('instance-table')).toBeVisible()
     await expect(page.getByTestId('instance-row-test-instance')).toBeVisible()
   })
+
+  // ── Step 11: empty state — RGD with no instances ──────────────────────────
+
+  test('Step 11: Instances tab for chain-parent (no instances) shows empty state', async ({ page }) => {
+    // chain-parent RGD is applied in globalSetup step 6f (fire-and-forget).
+    // It has no instance CRs, so the Instances tab must render the empty state.
+    // Verify the API confirms no instances first.
+    const apiRes = await page.request.get(`${BASE}/api/v1/rgds/chain-parent/instances`)
+    // API returns 200 with empty items array (not 404) for a known RGD with no instances
+    if (apiRes.status() !== 200) {
+      test.skip(true, 'chain-parent RGD not yet registered — skipping empty-state check')
+      return
+    }
+    const body = await apiRes.json() as { items: unknown[] }
+    if (!Array.isArray(body.items) || body.items.length > 0) {
+      test.skip(true, 'chain-parent has instances or unknown items shape — skipping')
+      return
+    }
+
+    await page.goto(`${BASE}/rgds/chain-parent?tab=instances`)
+    await expect(page.getByTestId('tab-instances')).toHaveAttribute('aria-selected', 'true')
+
+    // Wait for instance table or empty state (both are valid rendered states)
+    await page.waitForFunction(
+      () =>
+        document.querySelector('[data-testid="instance-table"]') !== null ||
+        document.querySelector('[data-testid="instance-empty-state"]') !== null,
+      { timeout: 15000 }
+    )
+
+    // When items array is empty, the empty state must be rendered
+    await expect(page.getByTestId('instance-empty-state')).toBeVisible({ timeout: 5000 })
+  })
 })

--- a/test/e2e/journeys/005-live-instance.spec.ts
+++ b/test/e2e/journeys/005-live-instance.spec.ts
@@ -275,4 +275,21 @@ test.describe('005: Live Instance Detail', () => {
     // YAML section must render
     await expect(page.getByTestId('node-yaml-section')).toBeVisible()
   })
+
+  // ── Step 12: error state — non-existent instance API ─────────────────────
+
+  test('Step 12: API returns 404 with structured error for non-existent instance', async ({ request }) => {
+    // The instance detail API must return a structured JSON error (not HTML or 500)
+    // when the instance or namespace does not exist.
+    const res = await request.get(
+      `${BASE}/api/v1/instances/does-not-exist-ns/does-not-exist-instance?rgd=test-app`
+    )
+
+    // Must be a client error (404) with a JSON body containing an error key.
+    // Never 500 (server error) or 200 (silently wrong).
+    expect([404, 400]).toContain(res.status())
+    const body = await res.json() as { error: string }
+    expect(typeof body.error).toBe('string')
+    expect(body.error.trim().length).toBeGreaterThan(0)
+  })
 })


### PR DESCRIPTION
## Summary

- Journey 003 **Step 16**: navigating to non-existent RGD `/rgds/does-not-exist-rgd-xyz` renders `data-testid="rgd-detail-error"` (not blank/crash)
- Journey 004 **Step 11**: `chain-parent` Instances tab (no instances) shows `data-testid="instance-empty-state"`  
- Journey 005 **Step 12**: API endpoint for non-existent instance returns 404 with structured JSON `{error: string}` (not HTML or 500)

All steps follow E2E constitution §XIV: use `page.request.get()` to verify API status before SPA navigation, `waitForFunction()` for DOM polling, `test.skip()` guards for fixture dependencies.

## Design doc
N/A — test coverage improvement, no user-visible UI behavior change.

Closes #449