### PR TITLE
feat(e2e): SRE persona journey — Overview SRE dashboard, errors tab, instance events

### DIFF
--- a/.specify/specs/issue-458/spec.md
+++ b/.specify/specs/issue-458/spec.md
@@ -1,0 +1,71 @@
+# Spec: issue-458 — SRE Persona Journey E2E
+
+**Item**: `issue-458`
+**Branch**: `feat/issue-458`
+**Design ref**: `docs/design/26-anchor-kro-ui.md` §Future SRE persona journey
+
+---
+
+## Design reference
+
+- **Design doc**: `docs/design/26-anchor-kro-ui.md`
+- **Section**: `§ Future`
+- **Implements**: SRE persona journey (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations (falsifiable)
+
+1. **O1** — A file `test/e2e/journeys/072-sre-persona-journey.spec.ts` exists
+   and is syntactically valid TypeScript (brace depth = 0).
+
+2. **O2** — The journey file is registered in `test/e2e/playwright.config.ts`
+   under a chunk whose `testMatch` pattern matches `072-*.spec.ts`. The journey
+   is not silently skipped in CI.
+
+3. **O3** — The journey has a `test.describe('072: SRE Persona Journey', ...)` block
+   containing at minimum 5 sequential steps, each as its own `test('Step N: ...')`.
+
+4. **O4** — Step 1 navigates to `/` (Overview) and asserts that the SRE dashboard
+   grid (`[data-testid="widget-instances"]`) or the onboarding state renders.
+   Uses `waitForFunction` to wait for DOM resolution (constitution §XIV).
+
+5. **O5** — Step 2 asserts the W-3 RGD compile errors widget
+   (`[data-testid="widget-rgd-errors"]`) is visible on the Overview page.
+   Skips if the Overview dashboard is not present.
+
+6. **O6** — Step 3 navigates to the RGD detail Errors tab for `test-app`
+   (`/rgds/test-app?tab=errors`) and asserts `[data-testid="errors-tab"]` renders
+   (showing errors, all-healthy, or empty state). Skips if `test-app` not found
+   via `page.request.get` (constitution §XIV SPA-safe check).
+
+7. **O7** — Step 4 navigates to the instance detail page for `test-instance`
+   in namespace `kro-ui-e2e` and asserts `[data-testid="instance-detail-page"]`
+   renders. Skips if instance not found via API check.
+
+8. **O8** — Step 5 asserts the events panel (`[data-testid="events-panel"]`) or
+   events empty state is visible on the instance detail page. Uses `waitForFunction`
+   not `toHaveCount(0)` (constitution §XIV).
+
+9. **O9** — Every `test.skip()` call is followed immediately by `return` so the
+   test body does not continue executing after skip (constitution §XIV).
+
+10. **O10** — No `waitForTimeout` is used; all waits use `waitForFunction` or
+    Playwright built-in locator waits (constitution §XIV).
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- The exact test IDs used must match existing `data-testid` attributes in the codebase.
+- Steps may check for multiple valid DOM states (e.g., errors found OR all-healthy OR empty).
+- The `page.request.get()` checks must use the SPA-safe API endpoint, not `page.goto()` HTTP status.
+
+---
+
+## Zone 3 — Scoped out
+
+- This spec does NOT add new UI components or backend APIs.
+- This spec does NOT modify existing journey files.
+- The journey does NOT test fleet view navigation — that is a separate anchor journey.
+- This spec does NOT implement the Developer persona journey (issue-459).

--- a/docs/aide/metrics.md
+++ b/docs/aide/metrics.md
@@ -1,0 +1,5 @@
+# Autonomous Team Metrics
+
+| Date | Batch | prs_merged | needs_human | ci_red_hours | skills_count | todo_shipped | notes |
+|------|-------|-----------|-------------|--------------|-------------|-------------|-------|
+| 2026-04-20 | 1 | 16 | 0 | 0 | - | 1 | session sess-412931da; merged PR #457 (issue-450) |

--- a/docs/design/26-anchor-kro-ui.md
+++ b/docs/design/26-anchor-kro-ui.md
@@ -52,10 +52,10 @@ They do not map 1:1 to a feature spec; they map to a persona and a dod-journey.
 ## Present
 
 ✅ 26.1 — Operator persona journey (PR #457): deploys RGD, verifies instances, checks health (covers DoD journeys 1 + 2).
+✅ 26.2 — SRE persona journey (PR #TBD): fleet anomaly investigation — Overview SRE dashboard → RGD errors tab → instance detail → events panel.
 
 ---
 
 ## Future
 
-- 🔲 SRE persona journey — fleet anomaly investigation (Overview SRE → error tab → instance detail)
 - 🔲 Developer persona journey — RGD authoring, validation, generate YAML (covers DoD journey 4)

--- a/test/e2e/journeys/072-sre-persona-journey.spec.ts
+++ b/test/e2e/journeys/072-sre-persona-journey.spec.ts
@@ -1,0 +1,178 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Journey 072: SRE Persona Journey
+ *
+ * Spec: .specify/specs/issue-458/spec.md
+ * Design doc: docs/design/26-anchor-kro-ui.md §Present 26.2
+ *
+ * An end-to-end workflow following the SRE persona across the fleet anomaly
+ * investigation path: Overview SRE dashboard → RGD compile-error widget →
+ * RGD detail Errors tab → Instance detail → Events panel.
+ *
+ * This is an "anchor journey" — it validates DoD journeys 1 and 3 in a single
+ * cross-feature workflow, complementing the per-feature journey suite.
+ *
+ * Cluster pre-conditions:
+ * - kind cluster running kro >= v0.9.0
+ * - test-app RGD applied (Ready or Errored — either is valid for this journey)
+ * - test-instance CR in namespace kro-ui-e2e (optional — Step 4/5 skip if absent)
+ * - kro-ui binary running at KRO_UI_BASE_URL
+ *
+ * Constitution §XIV compliance:
+ * - All existence checks via page.request.get() (SPA-safe, never HTTP status)
+ * - All waits via waitForFunction (no waitForTimeout)
+ * - Every test.skip() followed immediately by return
+ * - No locator.or() ambiguity
+ * - Brace depth verified: 0
+ */
+
+import { test, expect } from '@playwright/test'
+
+const BASE = process.env.KRO_UI_BASE_URL || 'http://localhost:40107'
+const RGD_NAME = 'test-app'
+const INSTANCE_NAME = 'test-instance'
+const INSTANCE_NS = 'kro-ui-e2e'
+
+test.describe('072: SRE Persona Journey', () => {
+
+  // ── Step 1: Overview SRE dashboard renders ──────────────────────────────────
+
+  test('Step 1: Overview renders SRE dashboard grid or onboarding empty state', async ({ page }) => {
+    await page.goto(BASE)
+
+    // Wait for the page to finish loading — SRE dashboard grid, onboarding, or error state
+    await page.waitForFunction(() => {
+      const grid = document.querySelector('.home__grid')
+      const onboarding = document.querySelector('.home__onboarding')
+      const err = document.querySelector('.home__error')
+      return grid !== null || onboarding !== null || err !== null
+    }, { timeout: 25000 })
+
+    const gridVisible = await page.locator('.home__grid').isVisible().catch(() => false)
+    const onboardingVisible = await page.locator('.home__onboarding').isVisible().catch(() => false)
+
+    expect(gridVisible || onboardingVisible).toBe(true)
+  })
+
+  // ── Step 2: W-3 RGD compile errors widget is visible ────────────────────────
+
+  test('Step 2: Overview shows W-3 RGD compile errors widget', async ({ page }) => {
+    await page.goto(BASE)
+
+    // Wait for the dashboard grid to load
+    await page.waitForFunction(() => {
+      return document.querySelector('.home__grid') !== null
+    }, { timeout: 25000 })
+
+    const gridVisible = await page.locator('.home__grid').isVisible().catch(() => false)
+    if (!gridVisible) {
+      test.skip(true, 'Overview dashboard grid not present on this cluster (onboarding state)')
+      return
+    }
+
+    // W-3 RGD compile errors widget must be visible
+    await expect(page.getByTestId('widget-rgd-errors')).toBeVisible({ timeout: 15000 })
+
+    // W-1 Instance health widget also visible
+    await expect(page.getByTestId('widget-instances')).toBeVisible()
+  })
+
+  // ── Step 3: RGD detail Errors tab renders ───────────────────────────────────
+
+  test('Step 3: RGD detail Errors tab renders (errors, all-healthy, or empty)', async ({ page }) => {
+    // SPA-safe existence check per constitution §XIV
+    const rgdCheck = await page.request.get(`${BASE}/api/v1/rgds/${RGD_NAME}`)
+    if (!rgdCheck.ok()) {
+      test.skip(true, `${RGD_NAME} not present on this cluster`)
+      return
+    }
+
+    await page.goto(`${BASE}/rgds/${RGD_NAME}?tab=errors`)
+
+    // Wait for the Errors tab to be visible
+    await page.waitForSelector('[data-testid="tab-errors"]', { timeout: 15000 })
+    await expect(page.getByTestId('tab-errors')).toBeVisible()
+
+    // Wait for the errors-tab panel to render (errors, all-healthy, empty, or loading→resolved)
+    await page.waitForFunction(() => {
+      const tab = document.querySelector('[data-testid="errors-tab"]')
+      const empty = document.querySelector('[data-testid="errors-empty"]')
+      const healthy = document.querySelector('[data-testid="errors-all-healthy"]')
+      const group = document.querySelector('[data-testid="error-group"]')
+      return tab !== null || empty !== null || healthy !== null || group !== null
+    }, { timeout: 20000 })
+
+    // At least one of the valid error-tab states is visible
+    const errorsTab = await page.locator('[data-testid="errors-tab"]').isVisible().catch(() => false)
+    const errorsEmpty = await page.locator('[data-testid="errors-empty"]').isVisible().catch(() => false)
+    const errorsHealthy = await page.locator('[data-testid="errors-all-healthy"]').isVisible().catch(() => false)
+
+    expect(errorsTab || errorsEmpty || errorsHealthy).toBe(true)
+  })
+
+  // ── Step 4: Instance detail page loads ──────────────────────────────────────
+
+  test('Step 4: Instance detail page loads with page container', async ({ page }) => {
+    // API-first existence check — SPA always returns 200 per constitution §XIV
+    const instanceCheck = await page.request.get(
+      `${BASE}/api/v1/rgds/${RGD_NAME}/instances/${INSTANCE_NS}/${INSTANCE_NAME}`,
+    )
+    if (!instanceCheck.ok()) {
+      test.skip(true, `${INSTANCE_NAME} in ${INSTANCE_NS} not present on this cluster`)
+      return
+    }
+
+    const instanceUrl = `${BASE}/rgds/${RGD_NAME}/instances/${INSTANCE_NS}/${INSTANCE_NAME}`
+    await page.goto(instanceUrl)
+
+    // Page container renders immediately
+    await expect(page.getByTestId('instance-detail-page')).toBeVisible({ timeout: 15000 })
+
+    // DAG renders after instance + RGD spec fetch
+    await expect(page.getByTestId('dag-svg')).toBeVisible({ timeout: 20000 })
+  })
+
+  // ── Step 5: Events panel visible on instance detail ─────────────────────────
+
+  test('Step 5: Instance detail events panel or empty state is visible', async ({ page }) => {
+    const instanceCheck = await page.request.get(
+      `${BASE}/api/v1/rgds/${RGD_NAME}/instances/${INSTANCE_NS}/${INSTANCE_NAME}`,
+    )
+    if (!instanceCheck.ok()) {
+      test.skip(true, `${INSTANCE_NAME} in ${INSTANCE_NS} not present on this cluster`)
+      return
+    }
+
+    const instanceUrl = `${BASE}/rgds/${RGD_NAME}/instances/${INSTANCE_NS}/${INSTANCE_NAME}`
+    await page.goto(instanceUrl)
+
+    // Wait for DAG to load (proves instance data is fetched)
+    await expect(page.getByTestId('dag-svg')).toBeVisible({ timeout: 20000 })
+
+    // Events panel or empty state renders (constitution §XIV: waitForFunction)
+    await page.waitForFunction(() => {
+      const panel = document.querySelector('[data-testid="events-panel"]')
+      const empty = document.querySelector('[data-testid="events-panel-empty"]')
+      return panel !== null || empty !== null
+    }, { timeout: 20000 })
+
+    const panelVisible = await page.locator('[data-testid="events-panel"]').isVisible().catch(() => false)
+    const emptyVisible = await page.locator('[data-testid="events-panel-empty"]').isVisible().catch(() => false)
+
+    expect(panelVisible || emptyVisible).toBe(true)
+  })
+
+})

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -35,9 +35,9 @@ const BASE_URL = `http://localhost:${PORT}`
 //   chunk-7:  041,045-047  UX audit, designer, kro v0.9.0, ux-improvements, state-map
 //   chunk-8:  051-059   instance diff, response cache, multi-version kro, ux-gaps-round3,
 //                       health-summary, status-tooltip, cache-flush, global-instances, warnings
-//   chunk-9:  060-071   health-filter, fleet-reconciling, instances-filter, health-sort,
+//   chunk-9:  060-072   health-filter, fleet-reconciling, instances-filter, health-sort,
 //                       status-message, error-banner, catalog-status-filter, kro-v091,
-//                       operator-persona-journey
+//                       operator-persona-journey, sre-persona-journey
 //   serial:   007       context-switcher — runs after all chunks complete
 //
 // Each chunk runs with workers: 4 (parallel files); the serial project uses workers: 1.
@@ -144,12 +144,12 @@ export default defineConfig({
       fullyParallel: true,
     },
     {
-      // chunk-9 covers journeys added in specs 060–071
+      // chunk-9 covers journeys added in specs 060–072
        // (health-filter, fleet-reconciling, instances-filter, health-sort,
        //  status-message, error-banner, catalog-status-filter, kro-v091,
-       //  operator-persona-journey)
+       //  operator-persona-journey, sre-persona-journey)
       name: 'chunk-9',
-      testMatch: /(060|062[a-z]?|063|064|065|066|069|070|071)-.*\.spec\.ts/,
+      testMatch: /(060|062[a-z]?|063|064|065|066|069|070|071|072)-.*\.spec\.ts/,
       ...PARALLEL_OPTS,
       workers: 4,
       fullyParallel: true,


### PR DESCRIPTION
## Summary

Journey 072: SRE Persona Journey — fleet anomaly investigation workflow.

Covers the SRE persona across 5 steps:
- Step 1: Overview renders SRE dashboard grid or onboarding empty state
- Step 2: W-3 RGD compile errors widget visible in Overview dashboard
- Step 3: RGD detail Errors tab renders (errors, all-healthy, or empty state)
- Step 4: Instance detail page loads with DAG
- Step 5: Events panel or empty state visible on instance detail

## Design doc
Updated `docs/design/26-anchor-kro-ui.md`: moved SRE persona journey from 🔲 Future to ✅ Present (26.2).