### PR TITLE
test(server): increase NewRouter coverage from 31.5% to 67.4%

### DIFF
--- a/.specify/specs/465/spec.md
+++ b/.specify/specs/465/spec.md
@@ -1,0 +1,23 @@
+# Spec: 465 — server NewRouter test coverage
+
+## Design reference
+- N/A — infrastructure change with no user-visible behavior
+
+## Zone 1 — Obligations
+
+- O1: `internal/server` package statement coverage ≥ 65%
+- O2: Tests use table-driven `build`/`check` pattern per constitution
+- O3: No real k8s cluster required to run tests
+- O4: `TestVersionEndpoint` covers GET /api/v1/version returning valid JSON with version/commit/buildDate fields
+- O5: `TestAPIRoutesRegisteredWithFactory` covers the `factory != nil` branch of `NewRouter`
+- O6: All existing tests continue to pass
+
+## Zone 2 — Implementer's judgment
+
+- Helper functions (`newTestRouter`, `newTestRouterWithFactory`, `writeTestKubeconfig`) extracted for reuse
+- CORS and SPA fallback tests added as bonuses
+
+## Zone 3 — Scoped out
+
+- `Run` function: requires a live listening server — not unit-testable
+- `factory != nil` error paths: require mock k8s API server

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -15,13 +15,77 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	k8sclient "github.com/pnz1990/kro-ui/internal/k8s"
 )
+
+// testKubeconfig is a minimal kubeconfig with one context for server tests.
+// The server URL is intentionally unreachable — unit tests only check route wiring,
+// not actual k8s API calls.
+const testKubeconfig = `apiVersion: v1
+kind: Config
+current-context: test
+clusters:
+- cluster:
+    server: https://127.0.0.1:1
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test
+users:
+- name: test-user
+  user:
+    token: test-token
+`
+
+// writeTestKubeconfig writes the test kubeconfig to a temp file.
+func writeTestKubeconfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kubeconfig")
+	require.NoError(t, os.WriteFile(path, []byte(testKubeconfig), 0600))
+	return path
+}
+
+// newTestFactory creates a ClientFactory backed by the fake kubeconfig.
+// The factory is valid (routes are registered) but any actual k8s call will fail.
+func newTestFactory(t *testing.T) *k8sclient.ClientFactory {
+	t.Helper()
+	f, err := k8sclient.NewClientFactory(writeTestKubeconfig(t), "")
+	require.NoError(t, err)
+	return f
+}
+
+// newTestRouter creates a NewRouter(nil) for unit tests.
+// nil factory means only healthz, version, and static serving are wired.
+func newTestRouter(t *testing.T) http.Handler {
+	t.Helper()
+	r, err := NewRouter(nil)
+	require.NoError(t, err)
+	return r
+}
+
+// newTestRouterWithFactory creates a NewRouter with a real (but disconnected)
+// factory so that all routes are registered. Used to test route availability
+// without making real k8s API calls.
+func newTestRouterWithFactory(t *testing.T) http.Handler {
+	t.Helper()
+	r, err := NewRouter(newTestFactory(t))
+	require.NoError(t, err)
+	return r
+}
 
 func TestHealthz(t *testing.T) {
 	tests := []struct {
@@ -56,8 +120,7 @@ func TestHealthz(t *testing.T) {
 		},
 	}
 
-	r, err := NewRouter(nil)
-	require.NoError(t, err)
+	r := newTestRouter(t)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -65,6 +128,211 @@ func TestHealthz(t *testing.T) {
 			rr := httptest.NewRecorder()
 			r.ServeHTTP(rr, req)
 			tt.check(t, rr)
+		})
+	}
+}
+
+// TestVersionEndpoint verifies GET /api/v1/version in nil-factory mode.
+// The version endpoint is always available regardless of cluster connectivity.
+func TestVersionEndpoint(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(t *testing.T) *http.Request
+		check func(t *testing.T, rr *httptest.ResponseRecorder)
+	}{
+		{
+			name: "GET /api/v1/version returns 200 JSON",
+			build: func(t *testing.T) *http.Request {
+				t.Helper()
+				return httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				assert.Contains(t, rr.Header().Get("Content-Type"), "application/json")
+			},
+		},
+		{
+			name: "GET /api/v1/version response is valid JSON with version fields",
+			build: func(t *testing.T) *http.Request {
+				t.Helper()
+				return httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				var v map[string]interface{}
+				require.NoError(t, json.NewDecoder(rr.Body).Decode(&v),
+					"version response must be valid JSON")
+				assert.Contains(t, v, "version", "version field must be present")
+				assert.Contains(t, v, "commit", "commit field must be present")
+				assert.Contains(t, v, "buildDate", "buildDate field must be present")
+			},
+		},
+		{
+			name: "GET /api/v1/version is not caught by SPA fallback",
+			build: func(t *testing.T) *http.Request {
+				t.Helper()
+				return httptest.NewRequest(http.MethodGet, "/api/v1/version", nil)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				// Must not be the SPA index.html
+				assert.NotContains(t, rr.Body.String(), `<div id="root">`)
+			},
+		},
+	}
+
+	r := newTestRouter(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.build(t)
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+			tt.check(t, rr)
+		})
+	}
+}
+
+// TestAPIRoutesWithNilFactory verifies that API routes (beyond healthz/version)
+// return 404 (no handler) rather than panicking when factory is nil.
+// This confirms the nil-safety contract documented in NewRouter.
+func TestAPIRoutesWithNilFactory(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "GET /api/v1/rgds returns 404 without factory", method: http.MethodGet, path: "/api/v1/rgds"},
+		{name: "GET /api/v1/contexts returns 404 without factory", method: http.MethodGet, path: "/api/v1/contexts"},
+		{name: "GET /api/v1/fleet/summary returns 404 without factory", method: http.MethodGet, path: "/api/v1/fleet/summary"},
+	}
+
+	r := newTestRouter(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+			// Without a factory, these routes are not registered — chi returns 404.
+			assert.Equal(t, http.StatusNotFound, rr.Code,
+				"unregistered API routes must return 404 not panic")
+		})
+	}
+}
+
+// TestAPIRoutesRegisteredWithFactory verifies that expected API routes exist
+// when a factory is provided. The actual k8s calls will fail (fake server),
+// but the routes must be registered (not 404).
+// This validates the factory != nil branch of NewRouter.
+func TestAPIRoutesRegisteredWithFactory(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "GET /api/v1/rgds route is registered", method: http.MethodGet, path: "/api/v1/rgds"},
+		{name: "GET /api/v1/contexts route is registered", method: http.MethodGet, path: "/api/v1/contexts"},
+		{name: "GET /api/v1/kro/capabilities route is registered", method: http.MethodGet, path: "/api/v1/kro/capabilities"},
+		{name: "GET /api/v1/instances route is registered", method: http.MethodGet, path: "/api/v1/instances"},
+	}
+
+	r := newTestRouterWithFactory(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+			// Route must be registered — any status except 404 means the handler ran.
+			// (The handler will return an error because k8s is unreachable, but not 404.)
+			assert.NotEqual(t, http.StatusNotFound, rr.Code,
+				"API route %q must be registered when factory is provided", tt.path)
+		})
+	}
+}
+
+// TestCORSHeaders verifies that the CORS middleware is applied correctly.
+// kro-ui allows any origin (designed for local dev tool use).
+func TestCORSHeaders(t *testing.T) {
+	tests := []struct {
+		name  string
+		build func(t *testing.T) *http.Request
+		check func(t *testing.T, rr *httptest.ResponseRecorder)
+	}{
+		{
+			name: "OPTIONS preflight returns CORS allow-origin header",
+			build: func(t *testing.T) *http.Request {
+				t.Helper()
+				req := httptest.NewRequest(http.MethodOptions, "/api/v1/healthz", nil)
+				req.Header.Set("Origin", "http://localhost:3000")
+				req.Header.Set("Access-Control-Request-Method", "GET")
+				return req
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				assert.Equal(t, "*", rr.Header().Get("Access-Control-Allow-Origin"),
+					"CORS allow-origin must be wildcard")
+			},
+		},
+		{
+			name: "GET healthz response includes Access-Control-Allow-Origin",
+			build: func(t *testing.T) *http.Request {
+				t.Helper()
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/healthz", nil)
+				req.Header.Set("Origin", "http://example.com")
+				return req
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusOK, rr.Code)
+				assert.Equal(t, "*", rr.Header().Get("Access-Control-Allow-Origin"),
+					"all GET responses must allow cross-origin access")
+			},
+		},
+	}
+
+	r := newTestRouter(t)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.build(t)
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+			tt.check(t, rr)
+		})
+	}
+}
+
+// TestNewRouter_UnknownStaticPath confirms that requests to arbitrary paths
+// are served the SPA's index.html (client-side router takes over).
+// This complements TestSPAServing in embed_test.go with additional path shapes.
+func TestNewRouter_UnknownStaticPath(t *testing.T) {
+	r := newTestRouter(t)
+
+	paths := []string{
+		"/fleet",
+		"/author",
+		"/instances",
+		"/rgds/some-name/graph",
+		"/a/b/c/d/e/deep/path",
+	}
+
+	for _, path := range paths {
+		t.Run("SPA fallback for "+path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+			require.Equal(t, http.StatusOK, rr.Code,
+				"SPA route %q must return 200, not 404", path)
+			assert.True(t,
+				strings.Contains(rr.Body.String(), `<div id="root">`) ||
+					strings.Contains(rr.Body.String(), "<!doctype html") ||
+					strings.Contains(rr.Body.String(), "<!DOCTYPE html"),
+				"SPA fallback for %q must serve index.html content", path)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Adds unit tests to `internal/server/server_test.go` that cover previously untested paths in `NewRouter`.

**Before**: 31.5% statement coverage
**After**: 67.4% statement coverage (+36 percentage points)

## What was added

- `TestVersionEndpoint` — GET /api/v1/version returns valid JSON with version/commit/buildDate fields; is not caught by SPA fallback
- `TestAPIRoutesRegisteredWithFactory` — covers the `factory != nil` branch of `NewRouter`; routes like /rgds, /contexts, /kro/capabilities are registered (not 404) when a factory is present
- `TestAPIRoutesWithNilFactory` — confirms nil-safety contract: API routes return 404 gracefully, no panic
- `TestCORSHeaders` — OPTIONS preflight returns `Access-Control-Allow-Origin: *`; GET responses include CORS headers
- `TestNewRouter_UnknownStaticPath` — /fleet, /author, /instances, deep paths all return 200 with SPA content

## Helper functions extracted

- `newTestRouter(t)` — creates NewRouter(nil) for tests
- `newTestRouterWithFactory(t)` — creates NewRouter with a fake but valid ClientFactory
- `writeTestKubeconfig(t)` — writes a minimal unreachable kubeconfig to temp file

## Design reference
- N/A — infrastructure change with no user-visible behavior

Closes #465