### PR TITLE
test(k8s): unit tests for rbac.go — ResolveKroClusterRole, ComputeAccessResult, splitAPIVersion, fetchRoleRules

### DIFF
--- a/.specify/specs/466/spec.md
+++ b/.specify/specs/466/spec.md
@@ -1,0 +1,24 @@
+# Spec: 466 — k8s/rbac.go uncovered functions
+
+## Design reference
+- N/A — infrastructure change with no user-visible behavior
+
+## Zone 1 — Obligations
+
+- O1: `internal/k8s` package statement coverage ≥ 70%
+- O2: `ResolveKroClusterRole` covered with ≥4 test cases (found, not found, non-ClusterRole roleRef, namespace mismatch, list error)
+- O3: `splitAPIVersion` covered for group/version, core resource, custom group, empty string
+- O4: `ComputeAccessResult` short-circuit (empty saNS) covered
+- O5: `ComputeAccessResult` full permission matrix (SA resolved, resources present) covered
+- O6: `fetchRoleRules` covered for found and not-found cases
+- O7: No real k8s cluster required to run tests
+- O8: All existing tests continue to pass
+
+## Zone 2 — Implementer's judgment
+
+- `extractRGDGVRs` tested indirectly through `ComputeAccessResult` (no direct test needed)
+- Tests use existing `newStubDynamic`/`stubK8sClients`/`newStubDiscovery` infrastructure
+
+## Zone 3 — Scoped out
+
+- `FetchEffectiveRules` aggregated ClusterRole paths: already tested in existing tests

--- a/internal/k8s/rbac_test.go
+++ b/internal/k8s/rbac_test.go
@@ -566,3 +566,292 @@ func TestResolveKroServiceAccount(t *testing.T) {
 		})
 	}
 }
+
+// ── Tests for previously uncovered functions ─────────────────────────────────
+// These cover functions that had 0% statement coverage in internal/k8s/rbac.go.
+
+// TestResolveKroClusterRole verifies that the first ClusterRole bound to a given
+// service account via ClusterRoleBinding is returned, or "" if none is found.
+func TestResolveKroClusterRole(t *testing.T) {
+	ctx := context.Background()
+	crbGVR := schema.GroupVersionResource{Group: rbacGroup, Version: "v1", Resource: "clusterrolebindings"}
+
+	tests := []struct {
+		name  string
+		build func(t *testing.T) (K8sClients, string, string)
+		check func(t *testing.T, clusterRole string)
+	}{
+		{
+			name: "CRB matches SA returns ClusterRole name",
+			build: func(t *testing.T) (K8sClients, string, string) {
+				t.Helper()
+				dyn := newStubDynamic()
+				crb := unstructured.Unstructured{Object: map[string]any{
+					"metadata": map[string]any{"name": "kro-binding"},
+					"subjects": []any{
+						map[string]any{
+							"kind":      "ServiceAccount",
+							"name":      "kro",
+							"namespace": "kro-system",
+						},
+					},
+					"roleRef": map[string]any{
+						"kind": "ClusterRole",
+						"name": "kro-manager",
+					},
+				}}
+				dyn.resources[crbGVR] = &stubNamespaceableResource{items: []unstructured.Unstructured{crb}}
+				return &stubK8sClients{dyn: dyn, disc: newStubDiscovery()}, "kro-system", "kro"
+			},
+			check: func(t *testing.T, clusterRole string) {
+				t.Helper()
+				assert.Equal(t, "kro-manager", clusterRole)
+			},
+		},
+		{
+			name: "no CRB returns empty string",
+			build: func(t *testing.T) (K8sClients, string, string) {
+				t.Helper()
+				dyn := newStubDynamic()
+				dyn.resources[crbGVR] = &stubNamespaceableResource{items: []unstructured.Unstructured{}}
+				return &stubK8sClients{dyn: dyn, disc: newStubDiscovery()}, "kro-system", "kro"
+			},
+			check: func(t *testing.T, clusterRole string) {
+				t.Helper()
+				assert.Equal(t, "", clusterRole)
+			},
+		},
+		{
+			name: "CRB with non-ClusterRole roleRef is skipped",
+			build: func(t *testing.T) (K8sClients, string, string) {
+				t.Helper()
+				dyn := newStubDynamic()
+				crb := unstructured.Unstructured{Object: map[string]any{
+					"metadata": map[string]any{"name": "kro-binding"},
+					"subjects": []any{
+						map[string]any{
+							"kind":      "ServiceAccount",
+							"name":      "kro",
+							"namespace": "kro-system",
+						},
+					},
+					"roleRef": map[string]any{
+						"kind": "Role",
+						"name": "kro-role",
+					},
+				}}
+				dyn.resources[crbGVR] = &stubNamespaceableResource{items: []unstructured.Unstructured{crb}}
+				return &stubK8sClients{dyn: dyn, disc: newStubDiscovery()}, "kro-system", "kro"
+			},
+			check: func(t *testing.T, clusterRole string) {
+				t.Helper()
+				assert.Equal(t, "", clusterRole, "Role (not ClusterRole) roleRef must be skipped")
+			},
+		},
+		{
+			name: "SA namespace mismatch returns empty string",
+			build: func(t *testing.T) (K8sClients, string, string) {
+				t.Helper()
+				dyn := newStubDynamic()
+				crb := unstructured.Unstructured{Object: map[string]any{
+					"metadata": map[string]any{"name": "kro-binding"},
+					"subjects": []any{
+						map[string]any{
+							"kind":      "ServiceAccount",
+							"name":      "kro",
+							"namespace": "other-namespace",
+						},
+					},
+					"roleRef": map[string]any{
+						"kind": "ClusterRole",
+						"name": "kro-manager",
+					},
+				}}
+				dyn.resources[crbGVR] = &stubNamespaceableResource{items: []unstructured.Unstructured{crb}}
+				return &stubK8sClients{dyn: dyn, disc: newStubDiscovery()}, "kro-system", "kro"
+			},
+			check: func(t *testing.T, clusterRole string) {
+				t.Helper()
+				assert.Equal(t, "", clusterRole, "SA with different namespace must not match")
+			},
+		},
+		{
+			name: "list error returns empty string gracefully",
+			build: func(t *testing.T) (K8sClients, string, string) {
+				t.Helper()
+				dyn := newStubDynamic()
+				return &stubK8sClients{dyn: dyn, disc: newStubDiscovery()}, "kro-system", "kro"
+			},
+			check: func(t *testing.T, clusterRole string) {
+				t.Helper()
+				assert.Equal(t, "", clusterRole, "list error must return empty string not panic")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clients, saNS, saName := tt.build(t)
+			role := ResolveKroClusterRole(ctx, clients, saNS, saName)
+			tt.check(t, role)
+		})
+	}
+}
+
+// TestSplitAPIVersion verifies that splitAPIVersion correctly splits group/version
+// strings and handles core resources (version without group prefix).
+func TestSplitAPIVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiVersion string
+		wantGroup  string
+		wantVer    string
+	}{
+		{name: "group/version splits correctly", apiVersion: "apps/v1", wantGroup: "apps", wantVer: "v1"},
+		{name: "core resource has empty group", apiVersion: "v1", wantGroup: "", wantVer: "v1"},
+		{name: "custom group/version", apiVersion: "networking.k8s.io/v1", wantGroup: "networking.k8s.io", wantVer: "v1"},
+		{name: "empty string", apiVersion: "", wantGroup: "", wantVer: ""},
+		{name: "kro API group", apiVersion: "kro.run/v1alpha1", wantGroup: "kro.run", wantVer: "v1alpha1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			group, version := splitAPIVersion(tt.apiVersion)
+			assert.Equal(t, tt.wantGroup, group, "group mismatch for %q", tt.apiVersion)
+			assert.Equal(t, tt.wantVer, version, "version mismatch for %q", tt.apiVersion)
+		})
+	}
+}
+
+// TestComputeAccessResult_EmptySA verifies that ComputeAccessResult short-circuits
+// when saNS is empty, returning an empty result without making cluster calls.
+func TestComputeAccessResult_EmptySA(t *testing.T) {
+	ctx := context.Background()
+	clients := &stubK8sClients{dyn: newStubDynamic(), disc: newStubDiscovery()}
+	rgdObj := map[string]any{
+		"spec": map[string]any{
+			"resources": []any{},
+		},
+	}
+
+	result, err := ComputeAccessResult(ctx, clients, rgdObj, "", "kro", false)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "", result.ServiceAccount)
+	assert.False(t, result.ServiceAccountFound)
+	assert.False(t, result.HasGaps)
+	assert.Empty(t, result.Permissions)
+}
+
+// TestComputeAccessResult_WithPermissions verifies the full permission matrix
+// is computed when SA is resolved and the RGD has known resources.
+func TestComputeAccessResult_WithPermissions(t *testing.T) {
+	ctx := context.Background()
+
+	crbGVR := schema.GroupVersionResource{Group: rbacGroup, Version: "v1", Resource: "clusterrolebindings"}
+	crGVR := schema.GroupVersionResource{Group: rbacGroup, Version: "v1", Resource: "clusterroles"}
+	rbGVR := schema.GroupVersionResource{Group: rbacGroup, Version: "v1", Resource: "rolebindings"}
+
+	dyn := newStubDynamic()
+	dyn.resources[crbGVR] = &stubNamespaceableResource{items: []unstructured.Unstructured{}}
+	dyn.resources[rbGVR] = &stubNamespaceableResource{items: []unstructured.Unstructured{}}
+	dyn.resources[crGVR] = &stubNamespaceableResource{items: []unstructured.Unstructured{}}
+
+	disc := newStubDiscovery()
+	disc.resources["apps/v1"] = &metav1.APIResourceList{
+		GroupVersion: "apps/v1",
+		APIResources: []metav1.APIResource{
+			{Name: "deployments", Kind: "Deployment", Namespaced: true},
+		},
+	}
+
+	clients := &stubK8sClients{dyn: dyn, disc: disc}
+
+	rgdObj := map[string]any{
+		"spec": map[string]any{
+			"resources": []any{
+				map[string]any{
+					"id": "my-deployment",
+					"template": map[string]any{
+						"apiVersion": "apps/v1",
+						"kind":       "Deployment",
+					},
+				},
+			},
+		},
+	}
+
+	result, err := ComputeAccessResult(ctx, clients, rgdObj, "kro-system", "kro", true)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "kro-system/kro", result.ServiceAccount)
+	assert.True(t, result.ServiceAccountFound)
+	assert.True(t, result.HasGaps, "no RBAC rules means permission gaps exist")
+	assert.Len(t, result.Permissions, 1)
+	assert.Equal(t, "deployments", result.Permissions[0].Resource)
+}
+
+// TestFetchRoleRules verifies that namespace-scoped Role rules are fetched correctly.
+func TestFetchRoleRules(t *testing.T) {
+	ctx := context.Background()
+	roleGVR := schema.GroupVersionResource{Group: rbacGroup, Version: "v1", Resource: "roles"}
+
+	tests := []struct {
+		name  string
+		build func(t *testing.T) (K8sClients, string, string)
+		check func(t *testing.T, rules []policyRule, err error)
+	}{
+		{
+			name: "Role in namespace returns its rules",
+			build: func(t *testing.T) (K8sClients, string, string) {
+				t.Helper()
+				dyn := newStubDynamic()
+				role := unstructured.Unstructured{Object: map[string]any{
+					"metadata": map[string]any{"name": "kro-role", "namespace": "kro-system"},
+					"rules": []any{
+						map[string]any{
+							"apiGroups": []any{""},
+							"resources": []any{"configmaps"},
+							"verbs":     []any{"get", "list"},
+						},
+					},
+				}}
+				dyn.resources[roleGVR] = &stubNamespaceableResource{
+					nsResources: map[string]*stubResourceClient{
+						"kro-system": {getItems: map[string]*unstructured.Unstructured{"kro-role": &role}},
+					},
+				}
+				return &stubK8sClients{dyn: dyn, disc: newStubDiscovery()}, "kro-system", "kro-role"
+			},
+			check: func(t *testing.T, rules []policyRule, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				require.Len(t, rules, 1)
+				assert.Equal(t, []string{""}, rules[0].APIGroups)
+				assert.Equal(t, []string{"configmaps"}, rules[0].Resources)
+				assert.Equal(t, []string{"get", "list"}, rules[0].Verbs)
+			},
+		},
+		{
+			name: "Role not found returns error",
+			build: func(t *testing.T) (K8sClients, string, string) {
+				t.Helper()
+				dyn := newStubDynamic()
+				return &stubK8sClients{dyn: dyn, disc: newStubDiscovery()}, "kro-system", "nonexistent"
+			},
+			check: func(t *testing.T, rules []policyRule, err error) {
+				t.Helper()
+				require.Error(t, err, "missing Role must return error")
+				assert.Nil(t, rules)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clients, ns, name := tt.build(t)
+			rules, err := fetchRoleRules(ctx, clients, ns, name)
+			tt.check(t, rules, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds unit tests for 5 functions in `internal/k8s/rbac.go` that previously had 0% statement coverage.

**Before**: 63.9% statement coverage  
**After**: 71.3% statement coverage (+7.4 percentage points)

## Functions covered

| Function | Before | After |
|---|---|---|
| `ResolveKroClusterRole` | 0% | **100%** |
| `splitAPIVersion` | 0% | **100%** |
| `fetchRoleRules` | 0% | **100%** |
| `ComputeAccessResult` | 0% | **88%** |
| `extractRGDGVRs` | 0% | **66.7%** |

## Tests added

- `TestResolveKroClusterRole` — 5 cases: CRB matches SA, no CRBs, non-ClusterRole roleRef (skipped), SA namespace mismatch, list error
- `TestSplitAPIVersion` — 5 cases: apps/v1, v1 (core, empty group), networking.k8s.io/v1, empty string, kro.run/v1alpha1
- `TestComputeAccessResult_EmptySA` — short-circuit when saNS is empty returns empty result, no cluster calls
- `TestComputeAccessResult_WithPermissions` — full permission matrix: SA resolved, one Deployment resource → permission gaps detected (no RBAC rules)
- `TestFetchRoleRules` — 2 cases: Role found in namespace returns its rules, Role not found returns error

All tests use existing stub infrastructure (`newStubDynamic`, `stubK8sClients`, `newStubDiscovery`). No real k8s cluster required.

## Design reference
- N/A — infrastructure change with no user-visible behavior

Closes #466