### PR TITLE
fix(ci): add push-noop job to security-checks workflow

### DIFF
--- a/.github/workflows/otherness-security-checks.yml
+++ b/.github/workflows/otherness-security-checks.yml
@@ -9,8 +9,18 @@ on:
     types: [opened, synchronize, reopened]
   issues:
     types: [labeled]
+  push:
+    branches: [main]
 
 jobs:
+  # ── no-op: handle push events gracefully (all real jobs require PR/issue context)
+  push-noop:
+    name: push — no security checks required
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Security checks are PR/issue-scoped. Push to main is not checked here."
+
   # ── M8: AGENTS.md change detection ────────────────────────────────────────
   agents-md-guard:
     name: M8 — AGENTS.md security check

--- a/docs/design/26-anchor-kro-ui.md
+++ b/docs/design/26-anchor-kro-ui.md
@@ -58,7 +58,7 @@ They do not map 1:1 to a feature spec; they map to a persona and a dod-journey.
 
 ## Present (continued)
 
-✅ 26.3 — Developer persona journey (PR #TBD): RGD Designer workflow — /author nav → authoring form → YAML preview → DAG preview → scope configuration.
+✅ 26.3 — Developer persona journey (PR #461): RGD Designer workflow — /author nav → authoring form → YAML preview → DAG preview → scope configuration.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `push` trigger + no-op job to `otherness-security-checks.yml` so the workflow passes on pushes to main
- Fix `docs/design/26-anchor-kro-ui.md` to reference correct PR #461 for developer persona journey

## Problem

Every push to main triggered the `otherness-security-checks.yml` workflow, but all its jobs had `if:` conditions that skipped on push events. When ALL jobs skip, GitHub marks the run as failed with "workflow file issue". This has been failing on every main push since PR #456 introduced the file.

## Fix

Add a `push: branches: [main]` trigger with a `push-noop` job that runs and exits cleanly when the event is a push. This allows the existing PR/issue-scoped jobs to continue working unchanged.

## Design reference
N/A — infrastructure change with no user-visible behavior