### PR TITLE
test(handlers): cover InvalidateCapabilitiesCache, GraphRevision error paths, helper funcs

### DIFF
--- a/.specify/specs/472/spec.md
+++ b/.specify/specs/472/spec.md
@@ -1,0 +1,24 @@
+# Spec: test(handlers): InvalidateCapabilitiesCache, GetCapabilities, GraphRevision coverage
+
+## Zone 1 — Obligations
+
+- O1: `InvalidateCapabilitiesCache()` must be tested — call it after populating the cache and verify cache is nil afterward.
+- O2: `ListGraphRevisions` unexpected server error (non-CRD-absent) must return 500 with "failed to list graph revisions" message.
+- O3: `GetGraphRevision` unexpected server error (non-CRD-absent, non-not-found) must return 500 with "failed to get graph revision" message.
+- O4: `isCRDNotFound(nil)` must return false.
+- O5: `isNotFound(nil)` must return false.
+- O6: All targeted functions must reach 100% statement coverage.
+
+## Zone 2 — Implementer's judgment
+
+- Use existing stub infrastructure (stubDynamic, stubNamespaceableResource, newGRTestHandler).
+- Keep test cases focused and minimal — no duplicate scenarios from existing tests.
+
+## Zone 3 — Scoped out
+
+- GetCapabilities is left at 75% — the remaining 25% requires controlling the output of DetectCapabilities (a package-level function not suitable for direct stubbing without major refactoring).
+- kroVersionFromInstances is left at 89.3% — already covered well by TestKroVersionFallbackFromInstances.
+
+## Design reference
+
+N/A — infrastructure change with no user-visible behavior.

--- a/internal/api/handlers/capabilities_test.go
+++ b/internal/api/handlers/capabilities_test.go
@@ -176,6 +176,21 @@ func TestCapabilitiesCacheInvalidate(t *testing.T) {
 	require.Nil(t, capCache.get(), "cache should be nil after explicit invalidate")
 }
 
+// TestInvalidateCapabilitiesCache verifies the package-level InvalidateCapabilitiesCache
+// helper clears the shared capCache so the next GetCapabilities call re-detects.
+func TestInvalidateCapabilitiesCache(t *testing.T) {
+	// Pre-populate the cache with a known value.
+	baseline := k8sclient.Baseline()
+	capCache.set(baseline)
+	require.NotNil(t, capCache.get(), "pre-condition: cache should be populated")
+
+	// Call the exported helper.
+	InvalidateCapabilitiesCache()
+
+	// Cache should now be nil.
+	require.Nil(t, capCache.get(), "cache should be nil after InvalidateCapabilitiesCache()")
+}
+
 // TestKroVersionFallbackFromInstances tests the version recovery fallback path in
 // GetCapabilities. When DetectCapabilities returns "unknown" (e.g. throttled cluster,
 // RBAC gap), kroVersionFromInstances scans RGD instances for the kro.run/kro-version

--- a/internal/api/handlers/graph_revisions_test.go
+++ b/internal/api/handlers/graph_revisions_test.go
@@ -121,6 +121,23 @@ func TestListGraphRevisions(t *testing.T) {
 				assert.Greater(t, idx1, idx3, "revision 3 must come before revision 1 (descending sort)")
 			},
 		},
+		{
+			name: "returns 500 on unexpected List error (not CRD-absent)",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				dyn := newStubDynamic()
+				dyn.resources[k8sclient.GraphRevisionGVR] = &stubNamespaceableResource{
+					listErr: fmt.Errorf("connection refused: etcd unavailable"),
+				}
+				return newGRTestHandler(dyn)
+			},
+			url: "/api/v1/kro/graph-revisions?rgd=my-app",
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusInternalServerError, rr.Code)
+				assert.Contains(t, rr.Body.String(), "failed to list graph revisions")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -177,6 +194,23 @@ func TestGetGraphRevision(t *testing.T) {
 				t.Helper()
 				require.Equal(t, http.StatusNotFound, rr.Code)
 				assert.Contains(t, rr.Body.String(), "graph revision not found")
+			},
+		},
+		{
+			name:   "returns 500 on unexpected API error (not CRD-absent, not 404)",
+			grName: "my-app-1",
+			build: func(t *testing.T) *Handler {
+				t.Helper()
+				dyn := newStubDynamic()
+				dyn.resources[k8sclient.GraphRevisionGVR] = &stubNamespaceableResource{
+					getErr: fmt.Errorf("connection refused: etcd is down"),
+				}
+				return newGRTestHandler(dyn)
+			},
+			check: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				t.Helper()
+				require.Equal(t, http.StatusInternalServerError, rr.Code)
+				assert.Contains(t, rr.Body.String(), "failed to get graph revision")
 			},
 		},
 		{
@@ -271,5 +305,40 @@ func TestRevisionNum(t *testing.T) {
 		if got := revisionNum(obj); got != 0 {
 			t.Errorf("expected 0, got %d", got)
 		}
+	})
+}
+
+// TestIsCRDNotFound tests the isCRDNotFound helper for known and unknown error strings.
+func TestIsCRDNotFound(t *testing.T) {
+	t.Run("nil error returns false", func(t *testing.T) {
+		assert.False(t, isCRDNotFound(nil))
+	})
+	t.Run("no matches for kind returns true", func(t *testing.T) {
+		assert.True(t, isCRDNotFound(fmt.Errorf("no matches for kind \"GraphRevision\" in group")))
+	})
+	t.Run("no kind returns true", func(t *testing.T) {
+		assert.True(t, isCRDNotFound(fmt.Errorf("no kind GraphRevision is registered")))
+	})
+	t.Run("server could not find resource returns true", func(t *testing.T) {
+		assert.True(t, isCRDNotFound(fmt.Errorf("the server could not find the requested resource")))
+	})
+	t.Run("not found in group returns true", func(t *testing.T) {
+		assert.True(t, isCRDNotFound(fmt.Errorf("GraphRevision not found in group internal.kro.run")))
+	})
+	t.Run("generic error returns false", func(t *testing.T) {
+		assert.False(t, isCRDNotFound(fmt.Errorf("connection refused")))
+	})
+}
+
+// TestIsNotFound tests the isNotFound helper.
+func TestIsNotFound(t *testing.T) {
+	t.Run("nil error returns false", func(t *testing.T) {
+		assert.False(t, isNotFound(nil))
+	})
+	t.Run("not found string returns true", func(t *testing.T) {
+		assert.True(t, isNotFound(fmt.Errorf("my-revision not found")))
+	})
+	t.Run("generic error returns false", func(t *testing.T) {
+		assert.False(t, isNotFound(fmt.Errorf("connection refused")))
 	})
 }


### PR DESCRIPTION
## Summary

- handlers coverage **88.2% → 89.5%**
- `InvalidateCapabilitiesCache`: 0% → 100%
- `ListGraphRevisions`: 87% → 100% (add 500 error path)
- `GetGraphRevision`: 78.6% → 100% (add 500 error path)
- `isCRDNotFound`: 75% → 100% (all branches + nil)
- `isNotFound`: 66.7% → 100% (nil + error cases)

## Design reference
N/A — infrastructure change with no user-visible behavior

Closes #472