### PR TITLE
fix(ci): move multi-line --body strings to env vars in security-checks workflow

### DIFF
--- a/.github/workflows/otherness-security-checks.yml
+++ b/.github/workflows/otherness-security-checks.yml
@@ -37,6 +37,24 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           AUTHOR: ${{ github.event.pull_request.user.login }}
+          NOTICE_BODY: |
+            ⚠️ **Security notice**: `AGENTS.md` was modified in this PR.
+
+            This file is read by the autonomous agent on every scheduled run. Changes to it affect how the agent behaves — effectively changing the agent's instructions.
+
+            **Reviewer checklist:**
+            - [ ] No instructions that redirect `agents_path` to an external location
+            - [ ] No instructions that exfiltrate environment variables or secrets
+            - [ ] No instructions that push to repos outside `pnz1990/`
+            - [ ] Changes are consistent with the project's documented SDLC process
+
+            See `docs/design/27-security-model.md §2A` for the full threat model.
+          BLOCK_BODY: |
+            🚫 **Security block**: `AGENTS.md` was modified by a non-collaborator.
+
+            `AGENTS.md` is read by the autonomous agent on every run. Modifications by external contributors could inject malicious instructions that run with full repository credentials.
+
+            This check must pass before this PR can be merged. See `docs/design/27-security-model.md §M8`.
         run: |
           # Check if AGENTS.md is in the changed files
           CHANGED=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" \
@@ -55,26 +73,10 @@ jobs:
 
           if [[ "$PERM" == "admin" || "$PERM" == "write" || "$PERM" == "maintain" ]]; then
             echo "✅ AGENTS.md modified by collaborator ($AUTHOR, $PERM) — permitted."
-            gh pr comment $PR_NUMBER --repo $REPO \
-              --body "⚠️ **Security notice**: \`AGENTS.md\` was modified in this PR.
-
-This file is read by the autonomous agent on every scheduled run. Changes to it affect how the agent behaves — effectively changing the agent's instructions.
-
-**Reviewer checklist:**
-- [ ] No instructions that redirect \`agents_path\` to an external location
-- [ ] No instructions that exfiltrate environment variables or secrets
-- [ ] No instructions that push to repos outside \`pnz1990/\`
-- [ ] Changes are consistent with the project's documented SDLC process
-
-See \`docs/design/27-security-model.md §2A\` for the full threat model." 2>/dev/null || true
+            gh pr comment $PR_NUMBER --repo $REPO --body "$NOTICE_BODY" 2>/dev/null || true
           else
             echo "::error::AGENTS.md modified by non-collaborator ($AUTHOR, permission=$PERM). This is a security risk."
-            gh pr comment $PR_NUMBER --repo $REPO \
-              --body "🚫 **Security block**: \`AGENTS.md\` was modified by \`$AUTHOR\` who does not have collaborator access.
-
-\`AGENTS.md\` is read by the autonomous agent on every run. Modifications by external contributors could inject malicious instructions that run with full repository credentials.
-
-This check must pass before this PR can be merged. See \`docs/design/27-security-model.md §M8\`." 2>/dev/null || true
+            gh pr comment $PR_NUMBER --repo $REPO --body "$BLOCK_BODY" 2>/dev/null || true
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- Move multi-line \`--body\` strings in \`agents-md-guard\` step to \`env:\` variables (\`NOTICE_BODY\`, \`BLOCK_BODY\`)
- Fix YAML parse error that caused the workflow to fail with 0 jobs on every push to main

## Problem

The \`otherness-security-checks.yml\` workflow has been failing on every push to main since PR #456 introduced it. The push-noop job (added in PR #471) never ran because the YAML parser itself was failing.

Root cause: the \`run:\` block contained multi-line shell strings with lines starting with \`- [ ]\` at column 0, which confuses YAML parsers (both Python's yaml.safe_load and GitHub's Go parser report a parse error).

## Fix

Move the two multi-line comment body strings into \`env:\` variables. The \`run:\` block now references them as \`"$NOTICE_BODY"\` and \`"$BLOCK_BODY"\`, keeping the shell logic clean and avoiding YAML ambiguity.

## Test

YAML validates cleanly:
\`\`\`
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/otherness-security-checks.yml').read()); print('OK')"
# OK
\`\`\`

The push-noop job will now run on push events (exit 0), and agents-md-guard/label-guard remain correctly conditional on PR/issue events.

## Design reference

INFRA — no user-visible behavior change. CI fix.