### PR TITLE
test(k8s): cover fleet.go ContextClients, BuildContextClient, KubeconfigPath, buildRESTConfig and MetricsDiscoverer (85.4%→92.0%)

### DIFF
--- a/internal/k8s/fleet_test.go
+++ b/internal/k8s/fleet_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	fakeDynamic "k8s.io/client-go/dynamic/fake"
+	kubetesting "k8s.io/client-go/testing"
+)
+
+// ── TestContextClients_Accessors (T020) ───────────────────────────────────────
+
+// TestContextClients_Accessors covers Dynamic(), Discovery(), and
+// CachedServerGroupsAndResources() on a ContextClients built directly
+// (avoiding a real kubeconfig and real cluster call).
+func TestContextClients_Accessors(t *testing.T) {
+	t.Run("Dynamic returns the injected dynamic client", func(t *testing.T) {
+		dyn := fakeDynamic.NewSimpleDynamicClient(runtime.NewScheme())
+		cc := &ContextClients{dyn: dyn}
+		assert.Same(t, dyn, cc.Dynamic())
+	})
+
+	t.Run("Discovery returns the injected discovery client", func(t *testing.T) {
+		fakeDisc := &fakediscovery.FakeDiscovery{Fake: &kubetesting.Fake{}}
+		cc := &ContextClients{disc: fakeDisc}
+		assert.Same(t, fakeDisc, cc.Discovery())
+	})
+
+	t.Run("CachedServerGroupsAndResources — cache hit — no discovery call", func(t *testing.T) {
+		fakeDisc := &fakediscovery.FakeDiscovery{Fake: &kubetesting.Fake{}}
+		lists := []*metav1.APIResourceList{
+			{
+				GroupVersion: "apps/v1",
+				APIResources: []metav1.APIResource{{Name: "deployments", Kind: "Deployment"}},
+			},
+		}
+		cc := &ContextClients{disc: fakeDisc}
+		// Prime the cache directly.
+		cc.discCache.set(lists)
+
+		got, err := cc.CachedServerGroupsAndResources()
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "apps/v1", got[0].GroupVersion)
+		// No discovery calls were made.
+		assert.Empty(t, fakeDisc.Actions(), "cache hit must not call discovery")
+	})
+
+	t.Run("CachedServerGroupsAndResources — cache miss — calls discovery and caches result", func(t *testing.T) {
+		fakeDisc := &fakediscovery.FakeDiscovery{Fake: &kubetesting.Fake{}}
+		fakeDisc.Resources = []*metav1.APIResourceList{
+			{
+				GroupVersion: "v1",
+				APIResources: []metav1.APIResource{{Name: "pods", Kind: "Pod"}},
+			},
+		}
+		cc := &ContextClients{disc: fakeDisc}
+
+		got, err := cc.CachedServerGroupsAndResources()
+		require.NoError(t, err)
+		require.NotEmpty(t, got, "must return at least one resource list")
+
+		// Second call must hit the cache (same number of discovery actions).
+		actionsAfterFirst := len(fakeDisc.Actions())
+		_, err = cc.CachedServerGroupsAndResources()
+		require.NoError(t, err)
+		assert.Equal(t, actionsAfterFirst, len(fakeDisc.Actions()), "second call must use cache")
+	})
+}
+
+// ── TestBuildContextClient_ErrorPaths (T021) ──────────────────────────────────
+
+// TestBuildContextClient_ErrorPaths covers the error returns from BuildContextClient
+// without attempting to connect to a real cluster.
+func TestBuildContextClient_ErrorPaths(t *testing.T) {
+	t.Run("missing kubeconfig file returns error", func(t *testing.T) {
+		_, err := BuildContextClient("/nonexistent/kubeconfig", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "build rest config")
+	})
+
+	t.Run("invalid kubeconfig YAML returns error", func(t *testing.T) {
+		dir := t.TempDir()
+		path := dir + "/kubeconfig"
+		require.NoError(t, writeFile(t, path, "not: valid: kubeconfig: yaml: :::"))
+
+		_, err := BuildContextClient(path, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "build rest config")
+	})
+
+	t.Run("valid kubeconfig — builds client successfully", func(t *testing.T) {
+		path := writeTestKubeconfigForFleet(t)
+		cc, err := BuildContextClient(path, "dev")
+		require.NoError(t, err)
+		assert.NotNil(t, cc.Dynamic())
+		assert.NotNil(t, cc.Discovery())
+	})
+
+	t.Run("valid kubeconfig — empty context uses current context", func(t *testing.T) {
+		path := writeTestKubeconfigForFleet(t)
+		cc, err := BuildContextClient(path, "")
+		require.NoError(t, err)
+		assert.NotNil(t, cc)
+	})
+}
+
+// ── TestKubeconfigPath (T022) ─────────────────────────────────────────────────
+
+// TestKubeconfigPath covers ClientFactory.KubeconfigPath().
+func TestKubeconfigPath(t *testing.T) {
+	path := writeTestKubeconfigForFleet(t)
+	f, err := NewClientFactory(path, "dev")
+	require.NoError(t, err)
+	assert.Equal(t, path, f.KubeconfigPath())
+}
+
+// ── TestBuildRESTConfig_ErrorPaths (T023) ─────────────────────────────────────
+
+// TestBuildRESTConfig_ErrorPaths covers buildRESTConfig() error and success paths.
+func TestBuildRESTConfig_ErrorPaths(t *testing.T) {
+	t.Run("missing kubeconfig returns error", func(t *testing.T) {
+		_, err := buildRESTConfig("/nonexistent/path", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "build rest config")
+	})
+
+	t.Run("valid kubeconfig with explicit context returns REST config", func(t *testing.T) {
+		path := writeTestKubeconfigForFleet(t)
+		cfg, err := buildRESTConfig(path, "dev")
+		require.NoError(t, err)
+		assert.Contains(t, cfg.Host, "dev.example.com")
+	})
+
+	t.Run("valid kubeconfig with empty context uses current context", func(t *testing.T) {
+		path := writeTestKubeconfigForFleet(t)
+		cfg, err := buildRESTConfig(path, "")
+		require.NoError(t, err)
+		assert.NotEmpty(t, cfg.Host)
+	})
+
+	t.Run("valid kubeconfig with second context returns correct server", func(t *testing.T) {
+		path := writeTestKubeconfigForFleet(t)
+		cfg, err := buildRESTConfig(path, "prod")
+		require.NoError(t, err)
+		assert.Contains(t, cfg.Host, "prod.example.com")
+	})
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// writeTestKubeconfigForFleet writes the shared test kubeconfig (from client_test.go)
+// to a temp file. Uses the same testKubeconfig constant.
+func writeTestKubeconfigForFleet(t *testing.T) string {
+	t.Helper()
+	path := writeTestKubeconfig(t)
+	return path
+}
+
+// writeFile is a helper that writes content to path for tests.
+func writeFile(t *testing.T, path, content string) error {
+	t.Helper()
+	return os.WriteFile(path, []byte(content), 0600)
+}

--- a/internal/k8s/metrics_test.go
+++ b/internal/k8s/metrics_test.go
@@ -651,3 +651,197 @@ func TestErrorTypes(t *testing.T) {
 		assert.Equal(t, 404, target.StatusCode)
 	})
 }
+
+// ── TestNewMetricsDiscoverer (T016) ────────────────────────────────────────────
+
+// TestNewMetricsDiscoverer verifies that NewMetricsDiscoverer constructs a
+// MetricsDiscoverer with the correct kubeconfigPath and that the context-switch
+// hook is wired (cache is invalidated when SwitchContext is called).
+func TestNewMetricsDiscoverer(t *testing.T) {
+	t.Run("creates discoverer with correct kubeconfigPath from factory", func(t *testing.T) {
+		path := writeTestKubeconfig(t)
+		f, err := NewClientFactory(path, "")
+		require.NoError(t, err)
+
+		md := NewMetricsDiscoverer(f)
+		assert.NotNil(t, md)
+		assert.Equal(t, path, md.kubeconfigPath)
+		assert.NotNil(t, md.cache)
+		assert.NotNil(t, md.factory)
+	})
+
+	t.Run("context-switch hook invalidates cache", func(t *testing.T) {
+		path := writeTestKubeconfig(t)
+		f, err := NewClientFactory(path, "dev")
+		require.NoError(t, err)
+
+		md := NewMetricsDiscoverer(f)
+
+		// Prime the cache with a fake pod ref.
+		md.cache.set("dev", PodRef{Namespace: "kro-system", PodName: "kro-0"})
+		_, ok := md.cache.get("dev")
+		require.True(t, ok, "cache should contain pod ref before context switch")
+
+		// Switch context — should trigger invalidateAll via hook.
+		require.NoError(t, f.SwitchContext("prod"))
+
+		_, ok = md.cache.get("dev")
+		assert.False(t, ok, "cache must be cleared after context switch")
+	})
+}
+
+// ── TestScrapeMetrics (T017) ───────────────────────────────────────────────────
+
+// TestScrapeMetrics tests the ScrapeMetrics entry point, focusing on the
+// empty-contextName path (uses factory) and the bad-kubeconfig error path
+// (non-empty contextName with broken kubeconfig).
+func TestScrapeMetrics(t *testing.T) {
+	t.Run("empty contextName — no kro pod found — returns empty metrics (200 OK)", func(t *testing.T) {
+		path := writeTestKubeconfig(t)
+		f, err := NewClientFactory(path, "dev")
+		require.NoError(t, err)
+
+		md := NewMetricsDiscoverer(f)
+		// factory.Dynamic() is a real client pointed at a fake server that
+		// returns no pods. discoverKroPod will find nothing → empty result.
+		result, err := md.ScrapeMetrics(context.Background(), "")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		// All metric fields nil when no pod is found.
+		assert.Nil(t, result.WatchCount)
+		assert.Nil(t, result.GVRCount)
+		assert.False(t, result.ScrapedAt.IsZero(), "ScrapedAt must be set")
+	})
+
+	t.Run("non-empty contextName with broken kubeconfig — returns error", func(t *testing.T) {
+		path := writeTestKubeconfig(t)
+		f, err := NewClientFactory(path, "dev")
+		require.NoError(t, err)
+
+		// Point kubeconfigPath at a missing file so BuildContextClient fails.
+		md := NewMetricsDiscoverer(f)
+		md.kubeconfigPath = "/nonexistent/kubeconfig"
+
+		_, err = md.ScrapeMetrics(context.Background(), "some-context")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "build client")
+	})
+}
+
+// ── TestScrapeWithCache (T018) ─────────────────────────────────────────────────
+
+// TestScrapeWithCache tests scrapeWithCache directly, covering:
+//   - cache miss → pod not found → empty metrics
+//   - cache hit → successful scrape (via httptest server)
+//   - 404 response → cache invalidate → re-discover → pod not found → empty metrics
+func TestScrapeWithCache(t *testing.T) {
+	t.Run("cache miss — pod not found — returns empty metrics", func(t *testing.T) {
+		path := writeTestKubeconfig(t)
+		f, err := NewClientFactory(path, "dev")
+		require.NoError(t, err)
+		md := NewMetricsDiscoverer(f)
+
+		// Use an empty stub dynamic client (no pods).
+		dyn := newStubDynamicMetrics()
+		dyn.resources[podGVR] = &stubNSResourceForMetrics{}
+
+		result, err := md.scrapeWithCache(context.Background(), dyn, &rest.Config{Host: "http://127.0.0.1:1"}, "test-key")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Nil(t, result.WatchCount, "no pod means nil watch count")
+		assert.False(t, result.ScrapedAt.IsZero())
+	})
+
+	t.Run("cache hit — successful scrape", func(t *testing.T) {
+		path := writeTestKubeconfig(t)
+		f, err := NewClientFactory(path, "dev")
+		require.NoError(t, err)
+		md := NewMetricsDiscoverer(f)
+
+		// Serve a metrics response from an httptest server.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(metricsProxyBody))
+		}))
+		t.Cleanup(srv.Close)
+
+		// Prime cache with the pod ref.
+		ref := PodRef{Namespace: "kro-system", PodName: "kro-0"}
+		md.cache.set("test-key", ref)
+
+		restCfg := &rest.Config{Host: srv.URL}
+		result, err := md.scrapeWithCache(context.Background(), newStubDynamicMetrics(), restCfg, "test-key")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.NotNil(t, result.WatchCount)
+		assert.Equal(t, int64(7), *result.WatchCount)
+	})
+
+	t.Run("404 response — re-discover fails — returns empty metrics", func(t *testing.T) {
+		path := writeTestKubeconfig(t)
+		f, err := NewClientFactory(path, "dev")
+		require.NoError(t, err)
+		md := NewMetricsDiscoverer(f)
+
+		// httptest server returns 404 (simulates pod restarted and proxy returns not found).
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		t.Cleanup(srv.Close)
+
+		// Prime cache so first lookup uses cached ref → gets 404.
+		ref := PodRef{Namespace: "kro-system", PodName: "kro-gone"}
+		md.cache.set("test-key", ref)
+
+		// No pods in the dynamic stub → re-discover finds nothing.
+		dyn := newStubDynamicMetrics()
+		dyn.resources[podGVR] = &stubNSResourceForMetrics{}
+
+		restCfg := &rest.Config{Host: srv.URL}
+		result, err := md.scrapeWithCache(context.Background(), dyn, restCfg, "test-key")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Nil(t, result.WatchCount, "re-discover found nothing — nil metrics")
+	})
+
+	t.Run("404 response — re-discover succeeds — single retry scrape", func(t *testing.T) {
+		path := writeTestKubeconfig(t)
+		f, err := NewClientFactory(path, "dev")
+		require.NoError(t, err)
+		md := NewMetricsDiscoverer(f)
+
+		// First request returns 404; second returns valid metrics.
+		callCount := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			if callCount == 1 {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(metricsProxyBody))
+		}))
+		t.Cleanup(srv.Close)
+
+		// Prime cache with stale pod ref → causes first 404.
+		ref := PodRef{Namespace: "kro-system", PodName: "kro-stale"}
+		md.cache.set("test-key", ref)
+
+		// Re-discover will find a new pod.
+		newPod := makePod("kro-new", "kro-system", "Running")
+		dyn := newStubDynamicMetrics()
+		dyn.resources[podGVR] = &stubNSResourceForMetrics{
+			nsItems: map[string][]unstructured.Unstructured{
+				"kro-system": {newPod},
+			},
+		}
+
+		restCfg := &rest.Config{Host: srv.URL}
+		result, err := md.scrapeWithCache(context.Background(), dyn, restCfg, "test-key")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.NotNil(t, result.WatchCount)
+		assert.Equal(t, int64(7), *result.WatchCount)
+		assert.Equal(t, 2, callCount, "must have called scrape twice (initial + retry)")
+	})
+}


### PR DESCRIPTION
## Summary

Closes #497

Adds unit tests for the only 0%-covered functions in `internal/k8s/`:

### fleet_test.go (new file)
- `ContextClients.Dynamic()` — returns injected client
- `ContextClients.Discovery()` — returns injected discovery client
- `ContextClients.CachedServerGroupsAndResources()` — cache hit (no discovery call) + cache miss (calls discovery, caches result)
- `BuildContextClient()` — missing kubeconfig, invalid YAML, valid kubeconfig with explicit/empty context
- `ClientFactory.KubeconfigPath()` — returns correct path
- `buildRESTConfig()` — missing kubeconfig error, valid kubeconfig explicit/empty/second context

### metrics_test.go (additions)
- `NewMetricsDiscoverer()` — kubeconfigPath wired from factory, context-switch hook invalidates cache
- `MetricsDiscoverer.ScrapeMetrics()` — empty contextName + no pod → empty metrics; broken kubeconfig → error
- `MetricsDiscoverer.scrapeWithCache()` — cache miss/pod-not-found, cache hit success, 404→re-discover fails, 404→re-discover succeeds single retry

## Coverage delta

| Package | Before | After |
|---------|--------|-------|
| `internal/k8s` | 85.4% | 92.0% |

All previously 0% fleet.go and metrics.go functions are now covered.