### PR TITLE
test(handlers): cover Handler.New, BuildClient, GetCapabilities cache hit and edge cases (94.5%→95.5%)

### DIFF
--- a/docs/aide/metrics.md
+++ b/docs/aide/metrics.md
@@ -4,3 +4,4 @@
 |------|-------|-----------|-------------|--------------|-------------|-------------|-------|
 | 2026-04-20 | 1 | 16 | 0 | 0 | - | 1 | session sess-412931da; merged PR #457 (issue-450) |
 | 2026-04-20 | 2 | 3 | 0 | 0 | - | 3 | session sess-412931da; merged PRs #460,#461 (SRE+Dev journeys) |
+| 2026-04-20 | 3 | 31 | 0 | 0 | 12 | 1 | session sess-475a6159; merged PR #498 (fleet/metrics coverage 85.4%→92.0%); stale state cleanup |

--- a/internal/api/handlers/capabilities_test.go
+++ b/internal/api/handlers/capabilities_test.go
@@ -339,3 +339,122 @@ func TestKroVersionFallbackFromInstances(t *testing.T) {
 		assert.Equal(t, "unknown", caps.Version)
 	})
 }
+
+// ── TestGetCapabilities_CacheHitServes (T032) ──────────────────────────────────
+
+// TestGetCapabilities_CacheHitServes explicitly tests the cache-hit branch
+// (lines 87-90 of capabilities.go). Populate the cache, then call GetCapabilities
+// and verify the pre-populated value is returned without calling discovery.
+func TestGetCapabilities_CacheHitServes(t *testing.T) {
+	capCache.invalidate()
+
+	// Pre-populate cache with a known version.
+	preset := k8sclient.Baseline()
+	preset.Version = "v0.9.1-cached"
+	capCache.set(preset)
+
+	// Any handler will do — discovery should NOT be called.
+	h := newRGDTestHandler(newStubDynamic(), newStubDiscovery())
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/kro/capabilities", nil)
+	w := httptest.NewRecorder()
+	h.GetCapabilities(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var caps k8sclient.KroCapabilities
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&caps))
+	assert.Equal(t, "v0.9.1-cached", caps.Version,
+		"cache hit must return the pre-populated version without re-detecting")
+}
+
+// ── TestKroVersionFromInstances_EdgeCases (T033) ───────────────────────────────
+
+// TestKroVersionFromInstances_EdgeCases covers branches in kroVersionFromInstances
+// that are not exercised by TestKroVersionFallbackFromInstances:
+// - RGD item with spec that is not a map (lines 135-136)
+// - RGD item with schema that is not a map (lines 139-140)
+// - Instance list error (lines 164-165)
+func TestKroVersionFromInstances_EdgeCases(t *testing.T) {
+	t.Run("RGD with non-map spec is skipped gracefully", func(t *testing.T) {
+		capCache.invalidate()
+
+		disc := newStubDiscovery()
+		disc.err = fmt.Errorf("connection refused") // caps.Version = "unknown"
+
+		dyn := newStubDynamic()
+		// RGD with spec as a string (not a map) — type assertion fails
+		badRGD := unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "bad-rgd"},
+			"spec":     "not-a-map", // ← forces spec type assertion failure
+		}}
+		dyn.resources[rgdGVR] = &stubNamespaceableResource{items: []unstructured.Unstructured{badRGD}}
+
+		h := newRGDTestHandler(dyn, disc)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/kro/capabilities", nil)
+		w := httptest.NewRecorder()
+		h.GetCapabilities(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		var caps k8sclient.KroCapabilities
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&caps))
+		assert.Equal(t, "unknown", caps.Version, "non-map spec must be skipped, version stays unknown")
+	})
+
+	t.Run("RGD with non-map schema is skipped gracefully", func(t *testing.T) {
+		capCache.invalidate()
+
+		disc := newStubDiscovery()
+		disc.err = fmt.Errorf("connection refused")
+
+		dyn := newStubDynamic()
+		// RGD with valid spec map but schema as a string (not a map)
+		badRGD := unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "bad-schema-rgd"},
+			"spec":     map[string]any{"schema": "not-a-map"}, // ← schema type assertion failure
+		}}
+		dyn.resources[rgdGVR] = &stubNamespaceableResource{items: []unstructured.Unstructured{badRGD}}
+
+		h := newRGDTestHandler(dyn, disc)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/kro/capabilities", nil)
+		w := httptest.NewRecorder()
+		h.GetCapabilities(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		var caps k8sclient.KroCapabilities
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&caps))
+		assert.Equal(t, "unknown", caps.Version, "non-map schema must be skipped, version stays unknown")
+	})
+
+	t.Run("instance list error causes RGD to be skipped, returns unknown", func(t *testing.T) {
+		capCache.invalidate()
+
+		disc := newStubDiscovery()
+		disc.err = fmt.Errorf("connection refused")
+
+		dyn := newStubDynamic()
+		// Valid RGD pointing to a kind whose instance list will error.
+		rgd := unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "test-rgd"},
+			"spec": map[string]any{
+				"schema": map[string]any{
+					"kind":       "Broken",
+					"group":      "test.example.com",
+					"apiVersion": "v1",
+				},
+			},
+		}}
+		dyn.resources[rgdGVR] = &stubNamespaceableResource{items: []unstructured.Unstructured{rgd}}
+		// Instance resource for "brokens" returns list error.
+		instGVR := schema.GroupVersionResource{Group: "test.example.com", Version: "v1", Resource: "brokens"}
+		dyn.resources[instGVR] = &stubNamespaceableResource{listErr: fmt.Errorf("instance list failed")}
+
+		h := newRGDTestHandler(dyn, disc)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/kro/capabilities", nil)
+		w := httptest.NewRecorder()
+		h.GetCapabilities(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		var caps k8sclient.KroCapabilities
+		require.NoError(t, json.NewDecoder(w.Body).Decode(&caps))
+		assert.Equal(t, "unknown", caps.Version, "instance list error must be skipped, version stays unknown")
+	})
+}

--- a/internal/api/handlers/fleet_test.go
+++ b/internal/api/handlers/fleet_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -402,4 +403,29 @@ func TestFleetSummary_AuthErrorShownAsAuthFailed(t *testing.T) {
 	body := rr.Body.String()
 	assert.Contains(t, body, `"restricted"`)
 	assert.Contains(t, body, string(types.ClusterAuthFailed))
+}
+
+// ── TestRealFleetClientBuilder_BuildClient (T031) ──────────────────────────────
+
+// TestRealFleetClientBuilder_BuildClient covers realFleetClientBuilder.BuildClient,
+// which is a thin adapter over k8sclient.BuildContextClient. Tests error and success paths.
+func TestRealFleetClientBuilder_BuildClient(t *testing.T) {
+	t.Run("returns error on missing kubeconfig", func(t *testing.T) {
+		b := &realFleetClientBuilder{kubeconfigPath: "/nonexistent/kubeconfig"}
+		_, err := b.BuildClient("/nonexistent/kubeconfig", "any-context")
+		require.Error(t, err, "must propagate BuildContextClient error")
+		assert.Contains(t, err.Error(), "build rest config")
+	})
+
+	t.Run("succeeds with a valid kubeconfig", func(t *testing.T) {
+		dir := t.TempDir()
+		path := dir + "/kubeconfig"
+		require.NoError(t, os.WriteFile(path, []byte(testKubeconfigForHandlerNew), 0600))
+
+		b := &realFleetClientBuilder{kubeconfigPath: path}
+		clients, err := b.BuildClient(path, "test")
+		require.NoError(t, err)
+		assert.NotNil(t, clients.Dynamic())
+		assert.NotNil(t, clients.Discovery())
+	})
 }

--- a/internal/api/handlers/handler_test.go
+++ b/internal/api/handlers/handler_test.go
@@ -17,7 +17,11 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"os"
+	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	openapi_v2 "github.com/google/gnostic-models/openapiv2"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -351,3 +355,48 @@ func makeRGDObject(name, kind, group, apiVersion string) *unstructured.Unstructu
 	}
 	return obj
 }
+
+// ── TestHandlerNew (T030) ──────────────────────────────────────────────────────
+
+// TestHandlerNew verifies that handlers.New constructs a Handler with the correct
+// dependencies wired (factory, ctxMgr, fleetBuilder, metrics discoverer).
+// Uses a real ClientFactory backed by a test kubeconfig (no cluster call).
+func TestHandlerNew(t *testing.T) {
+	t.Run("New wires factory and returns non-nil Handler", func(t *testing.T) {
+		// Write a minimal kubeconfig to a temp dir.
+		dir := t.TempDir()
+		kubeconfig := dir + "/kubeconfig"
+		err := os.WriteFile(kubeconfig, []byte(testKubeconfigForHandlerNew), 0600)
+		require.NoError(t, err)
+
+		f, err := k8sclient.NewClientFactory(kubeconfig, "")
+		require.NoError(t, err, "factory must be created from test kubeconfig")
+
+		h := New(f)
+		require.NotNil(t, h)
+		assert.NotNil(t, h.factory, "factory must be wired")
+		assert.NotNil(t, h.ctxMgr, "ctxMgr must be wired")
+		assert.NotNil(t, h.fleetBuilder, "fleetBuilder must be wired")
+		assert.NotNil(t, h.metrics, "metrics discoverer must be wired")
+	})
+}
+
+// testKubeconfigForHandlerNew is a minimal kubeconfig that can be loaded without
+// a running cluster (only used to build clients, not to make API calls).
+const testKubeconfigForHandlerNew = `apiVersion: v1
+kind: Config
+current-context: test
+clusters:
+- cluster:
+    server: https://localhost:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test
+users:
+- name: test-user
+  user:
+    token: test-token
+`


### PR DESCRIPTION
## Summary

Closes #500

Covers the remaining 0% functions and key uncovered branches in `internal/api/handlers/`:

### handler_test.go
- `TestHandlerNew` — verifies `handlers.New()` wires factory, ctxMgr, fleetBuilder, and metrics discoverer (was 0%)

### fleet_test.go
- `TestRealFleetClientBuilder_BuildClient` — error path (missing kubeconfig) and success path (valid kubeconfig) for the `realFleetClientBuilder.BuildClient` adapter method (was 0%)

### capabilities_test.go
- `TestGetCapabilities_CacheHitServes` — covers lines 87-90 (cache-hit return path, previously untested)
- `TestKroVersionFromInstances_EdgeCases` — covers 3 previously untested branches:
  - Lines 135-136: RGD `spec` is not a map → skipped gracefully
  - Lines 139-140: RGD `schema` is not a map → skipped gracefully
  - Lines 164-165: instance list error → continue to next RGD

## Coverage delta

| Package | Before | After |
|---------|--------|-------|
| `internal/api/handlers` | 94.5% | 95.5% |