### PR TITLE
test(e2e): add error resilience coverage to journeys 063-066

### DIFF
--- a/test/e2e/journeys/063-kro-v091-upgrade.spec.ts
+++ b/test/e2e/journeys/063-kro-v091-upgrade.spec.ts
@@ -237,3 +237,21 @@ test.describe('Journey 063 — US3: CEL hash functions in Designer help text', (
 
 // ── Brace balance check ───────────────────────────────────────────────────────
 // This file uses only test.describe + test (no extra closing braces needed)
+
+// ── Error resilience: capabilities API unavailable ───────────────────────────
+
+test.describe('Journey 063 — Error resilience: capabilities API unavailable', () => {
+  test('Step E1: page renders layout without crash when capabilities API fails', async ({ page }) => {
+    // Mock capabilities endpoint to return 503
+    await page.route('**/api/v1/kro/capabilities', async route => {
+      await route.fulfill({ status: 503, body: JSON.stringify({ error: 'service unavailable' }) })
+    })
+    await page.goto(`${BASE}/rgds`)
+    // Page must not show raw error strings
+    await expect(page.locator('body')).not.toContainText('[object Object]', { timeout: 15000 })
+    await expect(page.locator('body')).not.toContainText('undefined')
+    // Layout chrome must render
+    const layout = page.locator('header, nav, main, [class*="layout"]').first()
+    await expect(layout).toBeVisible({ timeout: 10000 })
+  })
+})

--- a/test/e2e/journeys/064-fleet-reconciling-count.spec.ts
+++ b/test/e2e/journeys/064-fleet-reconciling-count.spec.ts
@@ -112,3 +112,21 @@ test.describe('Journey 064: Fleet cluster card reconciling count badge', () => {
     }
   })
 })
+
+// ── Error resilience: fleet summary API unavailable ──────────────────────────
+
+test.describe('Journey 064 — Error resilience: fleet summary API unavailable', () => {
+  test('Step E1: Fleet page renders gracefully when /api/v1/fleet/summary fails', async ({ page }) => {
+    // Mock fleet summary endpoint to return 503
+    await page.route('**/api/v1/fleet/summary', async route => {
+      await route.fulfill({ status: 503, body: JSON.stringify({ error: 'service unavailable' }) })
+    })
+    await page.goto(`${BASE}/fleet`)
+    // Page must not show raw error strings
+    await expect(page.locator('body')).not.toContainText('[object Object]', { timeout: 15000 })
+    await expect(page.locator('body')).not.toContainText('undefined')
+    // Layout chrome must render
+    const layout = page.locator('header, nav, main, [class*="layout"]').first()
+    await expect(layout).toBeVisible({ timeout: 10000 })
+  })
+})

--- a/test/e2e/journeys/065-instances-health-sort.spec.ts
+++ b/test/e2e/journeys/065-instances-health-sort.spec.ts
@@ -109,3 +109,21 @@ test.describe('Journey 065: /instances default health-priority sort', () => {
     expect(tableText).toMatch(/↑|↓|⇅/)
   })
 })
+
+// ── Error resilience: instances API unavailable ──────────────────────────────
+
+test.describe('Journey 065 — Error resilience: instances API unavailable', () => {
+  test('Step E1: Instances page renders gracefully when /api/v1/instances fails', async ({ page }) => {
+    // Mock instances endpoint to return 503
+    await page.route('**/api/v1/instances', async route => {
+      await route.fulfill({ status: 503, body: JSON.stringify({ error: 'service unavailable' }) })
+    })
+    await page.goto(`${BASE}/instances`)
+    // Page must not show raw error strings
+    await expect(page.locator('body')).not.toContainText('[object Object]', { timeout: 15000 })
+    await expect(page.locator('body')).not.toContainText('undefined')
+    // Layout chrome must render
+    const layout = page.locator('header, nav, main, [class*="layout"]').first()
+    await expect(layout).toBeVisible({ timeout: 10000 })
+  })
+})

--- a/test/e2e/journeys/066-instance-status-message.spec.ts
+++ b/test/e2e/journeys/066-instance-status-message.spec.ts
@@ -132,3 +132,21 @@ test.describe('Journey 066: /instances status dot tooltip with condition message
     }
   })
 })
+
+// ── Error resilience: instance detail API unavailable ────────────────────────
+
+test.describe('Journey 066 — Error resilience: instance detail API unavailable', () => {
+  test('Step E1: Instance detail renders gracefully when instances API fails', async ({ page }) => {
+    // Mock instances endpoint to return 503
+    await page.route('**/api/v1/instances**', async route => {
+      await route.fulfill({ status: 503, body: JSON.stringify({ error: 'service unavailable' }) })
+    })
+    await page.goto(`${BASE}/instances`)
+    // Page must not show raw error strings
+    await expect(page.locator('body')).not.toContainText('[object Object]', { timeout: 15000 })
+    await expect(page.locator('body')).not.toContainText('undefined')
+    // Layout chrome must render
+    const layout = page.locator('header, nav, main, [class*="layout"]').first()
+    await expect(layout).toBeVisible({ timeout: 10000 })
+  })
+})


### PR DESCRIPTION
## Summary

Adds error resilience test to journeys 063, 064, 065, 066 (kro v0.9.1 features).

Each journey gets a new `Error resilience` describe block with a test that:
- Mocks the primary API endpoint to return HTTP 503
- Navigates to the relevant page
- Asserts: no raw error strings ([object Object], undefined)
- Asserts: layout chrome renders (page does not crash)

## Design reference
Implements 🔲 Future item from `otherness: docs/design/26-anchor-kro-ui.md §Future`:
> Journey depth: add error state coverage to journeys 063-070 (kro v0.9.1 features)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>