### PR TITLE
test(handlers): cover GetMetrics ?context= ListContexts error path (86.7%→96.7%)

### DIFF
--- a/.specify/specs/issue-505/spec.md
+++ b/.specify/specs/issue-505/spec.md
@@ -1,0 +1,43 @@
+# spec: handler coverage — GetMetrics ListContexts error + GetCapabilities gaps
+
+## Design reference
+
+- **Design doc**: N/A — test coverage improvement, no user-visible behavior change
+- **Implements**: close remaining handler coverage gaps in GetMetrics and GetCapabilities
+
+---
+
+## Zone 1 — Obligations
+
+### O1 — GetMetrics ListContexts-error path covered
+
+A test must verify that when `?context=` is provided and `h.ctxMgr.ListContexts()`
+returns an error, `GetMetrics` returns HTTP 500 with a JSON error body.
+
+Violation: `TestGetMetrics_ContextListFails` is absent or does not assert 500.
+
+### O2 — GetMetrics coverage ≥ 90%
+
+After the new test, `GetMetrics` statement coverage must be ≥ 90%.
+
+Violation: `go tool cover` shows < 90%.
+
+### O3 — No regressions
+
+`go vet ./...` clean. All pre-existing tests pass.
+
+Violation: any pre-existing test fails.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Use `stubClientFactory{listErr: assert.AnError}` to simulate the failure
+- One test function is sufficient; no table-driven test needed
+
+---
+
+## Zone 3 — Scoped out
+
+- No production code changes
+- GetCapabilities gap investigation only if easy; leave complex gaps for future items

--- a/docs/aide/metrics.md
+++ b/docs/aide/metrics.md
@@ -5,3 +5,4 @@
 | 2026-04-20 | 1 | 16 | 0 | 0 | - | 1 | session sess-412931da; merged PR #457 (issue-450) |
 | 2026-04-20 | 2 | 3 | 0 | 0 | - | 3 | session sess-412931da; merged PRs #460,#461 (SRE+Dev journeys) |
 | 2026-04-20 | 3 | 31 | 0 | 0 | 12 | 1 | session sess-475a6159; merged PR #498 (fleet/metrics coverage 85.4%→92.0%); stale state cleanup |
+| 2026-04-20 | 4 | 44 | 0 | 0 | 12 | 1 | session sess-7780ed82; merged PR #503 (usePageTitle test + cache WriteHeader 94.3%→98.6%) |

--- a/internal/api/handlers/metrics_test.go
+++ b/internal/api/handlers/metrics_test.go
@@ -332,6 +332,27 @@ func TestGetMetrics_ContextNotFound(t *testing.T) {
 	assert.Contains(t, errResp.Error, "no-such-context")
 }
 
+// TestGetMetrics_ContextListFails verifies that when ?context= is provided
+// and ListContexts returns an error, GetMetrics returns 500.
+func TestGetMetrics_ContextListFails(t *testing.T) {
+	h := &Handler{
+		metrics: &stubMetricsDiscoverer{result: &k8s.ControllerMetrics{ScrapedAt: time.Now().UTC()}},
+		ctxMgr: &stubClientFactory{
+			listErr: assert.AnError,
+		},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/kro/metrics?context=any-context", nil)
+	rr := httptest.NewRecorder()
+	h.GetMetrics(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+
+	var errResp types.ErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&errResp))
+	assert.Contains(t, errResp.Error, "failed to list contexts")
+}
+
 // metricsFixture is retained for documentation purposes and potential future
 // integration tests that wire a real httptest.Server to a stub MetricsDiscoverer.
 // The blank reference below prevents the compiler from removing the httptest import


### PR DESCRIPTION
## Summary

Closes #505

### GetMetrics ListContexts error path (metrics.go:47-51)

**Before**:  at 86.7% — when  is provided and  itself fails (e.g. kubeconfig parse error), the error path was untested.

**After**:  at 96.7%, handlers package at 95.9%.

**Test added**: `TestGetMetrics_ContextListFails`
- Uses `stubClientFactory{listErr: assert.AnError}` to simulate `ListContexts` failure
- Asserts 500 Internal Server Error with `"failed to list contexts"` in the JSON error body

## Design doc

- **Design doc**: N/A — test-only change, no production code modified