### PR TITLE
test(k8s): pickPod empty-list guard + pickPodFromClusterList ns='' paths (100%)

### DIFF
--- a/.specify/specs/issue-507/spec.md
+++ b/.specify/specs/issue-507/spec.md
@@ -1,0 +1,40 @@
+# spec: pickPod and pickPodFromClusterList 100% coverage
+
+## Design reference
+
+- **Design doc**: N/A — test coverage improvement, no user-visible behavior change
+- **Implements**: close pickPod/pickPodFromClusterList coverage gaps
+
+---
+
+## Zone 1 — Obligations
+
+### O1 — pickPod coverage = 100%
+
+After changes, `pickPod` must be at 100% statement coverage.
+The empty-list guard (`len(items)==0 → return false`) is the uncovered path
+because `discoverKroPod` never passes an empty slice.
+
+### O2 — pickPodFromClusterList coverage = 100%
+
+The `if ns == ""` branches for both Running and fallback pod paths must be covered.
+These are exercised by pods where `Object["metadata"]` has no `"namespace"` key
+(so both `GetNamespace()` and `NestedString` return `""`).
+
+### O3 — No regressions
+
+`go vet ./...` clean. All pre-existing tests pass.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Direct calls to `pickPod` and `pickPodFromClusterList` with targeted inputs
+- No production code changes
+
+---
+
+## Zone 3 — Scoped out
+
+- No changes to discoverKroPod
+- No changes to production code

--- a/docs/aide/metrics.md
+++ b/docs/aide/metrics.md
@@ -5,3 +5,4 @@
 | 2026-04-20 | 1 | 16 | 0 | 0 | - | 1 | session sess-412931da; merged PR #457 (issue-450) |
 | 2026-04-20 | 2 | 3 | 0 | 0 | - | 3 | session sess-412931da; merged PRs #460,#461 (SRE+Dev journeys) |
 | 2026-04-20 | 3 | 31 | 0 | 0 | 12 | 1 | session sess-475a6159; merged PR #498 (fleet/metrics coverage 85.4%→92.0%); stale state cleanup |
+| 2026-04-20 | 4 | 44 | 0 | 0 | 12 | 1 | session sess-7780ed82; merged PR #503 (usePageTitle test + cache WriteHeader 94.3%→98.6%) |

--- a/docs/aide/metrics.md
+++ b/docs/aide/metrics.md
@@ -6,3 +6,4 @@
 | 2026-04-20 | 2 | 3 | 0 | 0 | - | 3 | session sess-412931da; merged PRs #460,#461 (SRE+Dev journeys) |
 | 2026-04-20 | 3 | 31 | 0 | 0 | 12 | 1 | session sess-475a6159; merged PR #498 (fleet/metrics coverage 85.4%→92.0%); stale state cleanup |
 | 2026-04-20 | 4 | 44 | 0 | 0 | 12 | 1 | session sess-7780ed82; merged PR #503 (usePageTitle test + cache WriteHeader 94.3%→98.6%) |
+| 2026-04-20 | 5 | 45 | 0 | 0 | 12 | 1 | session sess-7780ed82; merged PR #506 (GetMetrics ListContexts error path 86.7%→96.7%) |

--- a/internal/k8s/metrics_test.go
+++ b/internal/k8s/metrics_test.go
@@ -500,6 +500,22 @@ func TestPickPodFromClusterList(t *testing.T) {
 		assert.Equal(t, "fleet-ns", ref.Namespace)
 	})
 
+	// Cover the ns=="" branch in the Running pod path: pod with no namespace field
+	// in the Object map (GetNamespace() returns "", NestedString returns "").
+	t.Run("Running pod — GetNamespace returns empty and no metadata.namespace", func(t *testing.T) {
+		pod := unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"name": "kro-no-ns",
+				// deliberately no "namespace" key
+			},
+			"status": map[string]any{"phase": "Running"},
+		}}
+		ref, ok := pickPodFromClusterList([]unstructured.Unstructured{pod})
+		require.True(t, ok)
+		assert.Equal(t, "kro-no-ns", ref.PodName)
+		assert.Equal(t, "", ref.Namespace) // both GetNamespace and NestedString return ""
+	})
+
 	t.Run("no Running pod — falls back to first pod", func(t *testing.T) {
 		items := []unstructured.Unstructured{
 			makePod("kro-a", "kro-system", "Pending"),
@@ -523,6 +539,55 @@ func TestPickPodFromClusterList(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, "kro-fallback", ref.PodName)
 		assert.Equal(t, "other-ns", ref.Namespace)
+	})
+
+	// Cover the ns=="" branch in the fallback path: pod with no namespace field.
+	t.Run("fallback pod — GetNamespace returns empty and no metadata.namespace", func(t *testing.T) {
+		pod := unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{
+				"name": "kro-fallback-no-ns",
+				// deliberately no "namespace" key
+			},
+			"status": map[string]any{"phase": "Pending"},
+		}}
+		ref, ok := pickPodFromClusterList([]unstructured.Unstructured{pod})
+		require.True(t, ok)
+		assert.Equal(t, "kro-fallback-no-ns", ref.PodName)
+		assert.Equal(t, "", ref.Namespace)
+	})
+}
+
+// TestPickPod covers the pickPod helper directly, including the empty-list guard
+// that is not reachable from discoverKroPod (which only calls pickPod with
+// non-empty slices).
+func TestPickPod(t *testing.T) {
+	t.Run("empty list returns false", func(t *testing.T) {
+		_, ok := pickPod("kro-system", nil)
+		assert.False(t, ok)
+
+		_, ok = pickPod("kro-system", []unstructured.Unstructured{})
+		assert.False(t, ok)
+	})
+
+	t.Run("Running pod returned first", func(t *testing.T) {
+		items := []unstructured.Unstructured{
+			makePod("kro-pending", "kro-system", "Pending"),
+			makePod("kro-running", "kro-system", "Running"),
+		}
+		ref, ok := pickPod("kro-system", items)
+		require.True(t, ok)
+		assert.Equal(t, "kro-running", ref.PodName)
+		assert.Equal(t, "kro-system", ref.Namespace)
+	})
+
+	t.Run("no Running pod falls back to first", func(t *testing.T) {
+		items := []unstructured.Unstructured{
+			makePod("kro-a", "kro-system", "Pending"),
+		}
+		ref, ok := pickPod("kro-system", items)
+		require.True(t, ok)
+		assert.Equal(t, "kro-a", ref.PodName)
+		assert.Equal(t, "kro-system", ref.Namespace)
 	})
 }
 


### PR DESCRIPTION
## Summary

Closes #507

### pickPod — empty-list guard (85.7% → 100%)

`discoverKroPod` skips `pickPod` entirely when the namespace returns no pods, so the `len(items)==0 → return false` guard was never reached via `TestDiscoverKroPod`. Added `TestPickPod` with direct calls using empty/nil slices.

### pickPodFromClusterList — `ns == ""` branches (84.6% → 100%)

All existing test pods use `makePod` which sets `metadata.namespace` in the Object map, so `GetNamespace()` always returns a non-empty value. The `if ns == ""` fallback branches were never exercised.

Added 2 new sub-tests with pods that have **no** `namespace` key in the Object map:
- Running pod: `GetNamespace()` returns `""`, exercises line 198 (`NestedString` fallback)
- Fallback pod: `GetNamespace()` returns `""`, exercises line 206 (`NestedString` fallback)

Both correctly return `Namespace=""` — correct defensive behavior when pod has no namespace.

## Coverage delta

| Function | Before | After |
|---|---|---|
| `pickPod` | 85.7% | **100%** |
| `pickPodFromClusterList` | 84.6% | **100%** |
| `internal/k8s` (total) | 92.0% | 92.4% |

## Design doc

N/A — test-only change, no production code modified