### PR TITLE
test(k8s): pickPod and pickPodFromClusterList 84.6%→100% coverage

### DIFF
--- a/.specify/specs/507/spec.md
+++ b/.specify/specs/507/spec.md
@@ -1,0 +1,33 @@
+# Spec: pickPod and pickPodFromClusterList coverage (84.6% → 100%)
+
+## Design reference
+- N/A — infrastructure change with no user-visible behavior
+
+## Zone 1 — Obligations
+
+O1. `pickPod` coverage is 100% after this change.
+    Violation: `go test -coverprofile=... ./internal/k8s/...` shows `pickPod` < 100%.
+
+O2. `pickPodFromClusterList` coverage is 100% after this change.
+    Violation: `go test -coverprofile=... ./internal/k8s/...` shows `pickPodFromClusterList` < 100%.
+
+O3. Dead code (`if ns == ""` NestedString fallback) is removed from `pickPodFromClusterList`.
+    Rationale: `GetNamespace()` = `NestedString(Object, "metadata", "namespace")` — both
+    read from the same field. The fallback can never return a different value.
+    Violation: The `if ns == ""` NestedString branches still exist after the change.
+
+O4. `TestPickPod` is added with a direct call with empty slice returning `(PodRef{}, false)`.
+    Violation: No test exercises the `len(items) == 0` guard in `pickPod` directly.
+
+O5. All existing tests continue to pass.
+    Violation: Any test regression.
+
+## Zone 2 — Implementer's judgment
+
+- The test can be added to the existing `TestDiscoverKroPod` table or as a standalone `TestPickPod`.
+  A standalone `TestPickPod` is preferred — it directly documents the function contract.
+
+## Zone 3 — Scoped out
+
+- No changes to `discoverKroPod`, `discoverWithSelector`, `scrapeViaProxy`, or any other function.
+- No changes to `metrics.go` beyond removing the two dead `if ns == ""` branches in `pickPodFromClusterList`.

--- a/internal/k8s/metrics.go
+++ b/internal/k8s/metrics.go
@@ -195,19 +195,11 @@ func pickPodFromClusterList(items []unstructured.Unstructured) (PodRef, bool) {
 	for i := range items {
 		phase, _, _ := unstructured.NestedString(items[i].Object, "status", "phase")
 		if phase == "Running" {
-			ns := items[i].GetNamespace()
-			if ns == "" {
-				ns, _, _ = unstructured.NestedString(items[i].Object, "metadata", "namespace")
-			}
-			return PodRef{Namespace: ns, PodName: items[i].GetName()}, true
+			return PodRef{Namespace: items[i].GetNamespace(), PodName: items[i].GetName()}, true
 		}
 	}
 	// Any phase fallback.
-	ns := items[0].GetNamespace()
-	if ns == "" {
-		ns, _, _ = unstructured.NestedString(items[0].Object, "metadata", "namespace")
-	}
-	return PodRef{Namespace: ns, PodName: items[0].GetName()}, true
+	return PodRef{Namespace: items[0].GetNamespace(), PodName: items[0].GetName()}, true
 }
 
 // ── Pod-proxy scrape ──────────────────────────────────────────────────────────

--- a/internal/k8s/metrics_test.go
+++ b/internal/k8s/metrics_test.go
@@ -453,6 +453,41 @@ func TestPodRefCache(t *testing.T) {
 	})
 }
 
+// ── TestPickPod ───────────────────────────────────────────────────────────────
+
+// TestPickPod verifies that pickPod handles an empty slice and the Running-phase
+// preference directly, without going through discoverKroPod.
+func TestPickPod(t *testing.T) {
+	t.Run("empty slice — returns false", func(t *testing.T) {
+		_, ok := pickPod("kro-system", nil)
+		assert.False(t, ok)
+
+		_, ok = pickPod("kro-system", []unstructured.Unstructured{})
+		assert.False(t, ok)
+	})
+
+	t.Run("Running pod returned when present", func(t *testing.T) {
+		items := []unstructured.Unstructured{
+			makePod("kro-pending", "kro-system", "Pending"),
+			makePod("kro-running", "kro-system", "Running"),
+		}
+		ref, ok := pickPod("kro-system", items)
+		require.True(t, ok)
+		assert.Equal(t, "kro-running", ref.PodName)
+		assert.Equal(t, "kro-system", ref.Namespace)
+	})
+
+	t.Run("no Running pod — falls back to first", func(t *testing.T) {
+		items := []unstructured.Unstructured{
+			makePod("kro-pending", "kro-system", "Pending"),
+		}
+		ref, ok := pickPod("kro-system", items)
+		require.True(t, ok)
+		assert.Equal(t, "kro-pending", ref.PodName)
+		assert.Equal(t, "kro-system", ref.Namespace)
+	})
+}
+
 // ── TestPickPodFromClusterList ─────────────────────────────────────────────────
 
 // TestPickPodFromClusterList tests the cluster-scoped pod selection, including the


### PR DESCRIPTION
## Summary

- Add `TestPickPod` with direct empty-slice call — exercises the `len(items)==0` guard that was only reachable indirectly through `discoverKroPod` (which never calls `pickPod` with an empty slice).
- Remove unreachable `if ns == ""` NestedString fallback branches in `pickPodFromClusterList`. `GetNamespace()` is `getNestedString(Object, "metadata", "namespace")` — identical to the fallback — so the branches can never return a different value and were dead code by construction.

## Coverage

| Function | Before | After |
|---|---|---|
| `pickPod` | 85.7% | **100%** |
| `pickPodFromClusterList` | 84.6% | **100%** |

## Design doc
- N/A — infrastructure change with no user-visible behavior

Closes #507