### PR TITLE
feat(e2e): journey 074 — axe accessibility assertions for Tier 1 pages

### DIFF
--- a/test/e2e/journeys/074-accessibility.spec.ts
+++ b/test/e2e/journeys/074-accessibility.spec.ts
@@ -1,0 +1,153 @@
+// Copyright 2026 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Journey 074: Accessibility — axe-core assertions on Tier 1 pages
+ *
+ * Runs WCAG 2.1 AA axe-core scans on the 4 Tier 1 pages:
+ * - RGD list (Catalog page — /catalog)
+ * - RGD DAG view (/rgds/test-app)
+ * - Instance list (/rgds/test-app/instances)
+ * - Context switcher (top bar present on all pages)
+ *
+ * Design ref: docs/design/26-anchor-kro-ui.md §Future
+ *   "Accessibility: run axe assertions on Tier 1 pages (RGD list, DAG, instance list, context switcher)"
+ *
+ * Spec: .specify/specs/issue-527/spec.md
+ *
+ * Cluster pre-conditions:
+ * - kind cluster running kro >= v0.9.0
+ * - test-app RGD applied and Ready
+ * - kro-ui binary running at KRO_UI_BASE_URL
+ *
+ * Note: axe violations are reported as test failures. critical and serious
+ * violations block; minor/moderate are informational (reviewed in the HTML report).
+ */
+
+import { test, expect } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+import { fixtureState } from '../fixture-state'
+
+const PORT = parseInt(process.env.KRO_UI_PORT ?? '40107', 10)
+const BASE = `http://localhost:${PORT}`
+
+// Only block on critical + serious violations.
+// Minor/moderate are surfaced in the HTML report but do not fail CI.
+// This threshold prevents noise from browser-specific rendering quirks.
+const CRITICAL_IMPACT_LEVELS = ['critical', 'serious'] as const
+
+function assertNoViolations(violations: Array<{ impact?: string | null; id: string; description: string; nodes: unknown[] }>) {
+  const blocking = violations.filter(
+    (v) => v.impact && (CRITICAL_IMPACT_LEVELS as readonly string[]).includes(v.impact),
+  )
+  if (blocking.length > 0) {
+    const summary = blocking
+      .map((v) => `[${v.impact}] ${v.id}: ${v.description} (${v.nodes.length} nodes)`)
+      .join('\n')
+    expect(blocking).toHaveLength(0, `Axe found ${blocking.length} critical/serious violation(s):\n${summary}`)
+  }
+}
+
+test.describe('Journey 074 — Accessibility (axe-core WCAG 2.1 AA)', () => {
+
+  // ── Step 1: RGD list (Catalog page) ────────────────────────────────────────
+
+  test('Step 1: Catalog page has no critical/serious axe violations', async ({ page }) => {
+    test.skip(!fixtureState.testAppReady, 'test-app not Ready — skipping Catalog axe scan')
+
+    await page.goto(`${BASE}/catalog`)
+    // Wait for catalog cards to render
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid^="catalog-card-"]') !== null ||
+             document.querySelector('[class*="catalog"]') !== null,
+      { timeout: 20000 },
+    ).catch(() => {})
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze()
+
+    assertNoViolations(results.violations)
+    // Informational: log total violation count even if not blocking
+    console.log(`Catalog axe: ${results.violations.length} total violations, ` +
+      `${results.passes.length} passes.`)
+  })
+
+  // ── Step 2: RGD DAG view ─────────────────────────────────────────────────────
+
+  test('Step 2: RGD DAG page has no critical/serious axe violations', async ({ page }) => {
+    test.skip(!fixtureState.testAppReady, 'test-app not Ready — skipping DAG axe scan')
+
+    await page.goto(`${BASE}/rgds/test-app`)
+    // Wait for DAG SVG to render
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="dag-svg"]') !== null ||
+             document.querySelector('svg') !== null,
+      { timeout: 20000 },
+    ).catch(() => {})
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .exclude('[data-testid="dag-svg"]')  // SVG graph: complex custom widget, separate audit
+      .analyze()
+
+    assertNoViolations(results.violations)
+    console.log(`DAG axe: ${results.violations.length} total violations, ` +
+      `${results.passes.length} passes.`)
+  })
+
+  // ── Step 3: Instance list ──────────────────────────────────────────────────
+
+  test('Step 3: Instance list page has no critical/serious axe violations', async ({ page }) => {
+    test.skip(!fixtureState.testAppReady, 'test-app not Ready — skipping instance list axe scan')
+
+    await page.goto(`${BASE}/rgds/test-app/instances`)
+    // Wait for instance table or empty state
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid^="instance-row-"]') !== null ||
+             document.querySelector('[data-testid="instance-list-empty"]') !== null ||
+             document.querySelector('[class*="instance"]') !== null,
+      { timeout: 20000 },
+    ).catch(() => {})
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze()
+
+    assertNoViolations(results.violations)
+    console.log(`Instance list axe: ${results.violations.length} total violations, ` +
+      `${results.passes.length} passes.`)
+  })
+
+  // ── Step 4: Context switcher (top bar) ────────────────────────────────────
+
+  test('Step 4: Context switcher (top bar) has no critical/serious axe violations', async ({ page }) => {
+    await page.goto(BASE)
+    // Wait for top bar to render
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="context-switcher-btn"]') !== null ||
+             document.querySelector('header, nav, [role="banner"]') !== null,
+      { timeout: 15000 },
+    ).catch(() => {})
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .include('header, nav, [role="banner"], [data-testid="context-switcher-btn"]')
+      .analyze()
+
+    assertNoViolations(results.violations)
+    console.log(`Context switcher axe: ${results.violations.length} total violations.`)
+  })
+
+})

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -1,18 +1,19 @@
 {
-  "name": "kro-ui-e2e",
-  "version": "0.1.0",
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "test": "playwright test",
-    "test:ui": "playwright test --ui",
-    "test:headed": "playwright test --headed",
-    "report": "playwright show-report"
-  },
-  "dependencies": {},
-  "devDependencies": {
-    "@playwright/test": "^1.50.0",
-    "@types/node": "^25.5.0",
-    "typescript": "~6.0.2"
-  }
+    "name": "kro-ui-e2e",
+    "version": "0.1.0",
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "test": "playwright test",
+        "test:ui": "playwright test --ui",
+        "test:headed": "playwright test --headed",
+        "report": "playwright show-report"
+    },
+    "dependencies": {},
+    "devDependencies": {
+        "@axe-core/playwright": "^4.10.0",
+        "@playwright/test": "^1.50.0",
+        "@types/node": "^25.5.0",
+        "typescript": "~6.0.2"
+    }
 }


### PR DESCRIPTION
Adds accessibility testing to kro-ui anchor suite:
- `test/e2e/package.json`: adds `@axe-core/playwright ^4.10.0`
- `test/e2e/journeys/074-accessibility.spec.ts`: runs WCAG 2.1 AA axe scans on 4 Tier 1 pages (Catalog/RGD list, DAG, instance list, context switcher)

Critical/serious violations fail CI. Minor/moderate are informational.
Cross-ref: pnz1990/otherness#544