### PR TITLE
feat(config): add anchor: section to otherness-config.yaml

### DIFF
--- a/otherness-config.yaml
+++ b/otherness-config.yaml
@@ -56,3 +56,14 @@ hygiene:
   enabled: true
   max_issues_per_scan: 3
   cycle_interval: 3
+
+# ── Anchor framework ──────────────────────────────────────────────────────────
+# kro-ui's anchor is its Playwright E2E suite. The anchor score is posted to issue #439
+# by the SM phase after each E2E run. See docs/design/26-anchor-kro-ui.md.
+anchor:
+  workflow: "e2e.yml"                                          # Playwright E2E workflow
+  score_pattern: "journeys: (\\d+) \\| pass: (\\d+) fail: (\\d+)"  # matches [ANCHOR | kro-ui | DATE] lines
+  coverage_target: 60                                          # minimum depth score % for kro-ui
+  stagnation_sessions: 5                                       # sessions without anchor growth before COORD prioritizes
+  journeys_dir: "test/e2e/journeys"                            # used by SM §4g-anchor-parity for feature→journey gap detection
+


### PR DESCRIPTION
## Summary

Adds the `anchor:` section to `otherness-config.yaml` for kro-ui, enabling SM §4g-anchor to read kro-ui's anchor score and detect stagnation.

## Changes

- **`anchor.workflow`**: `e2e.yml` — kro-ui's Playwright E2E workflow
- **`anchor.score_pattern`**: regex matching `[ANCHOR | kro-ui | DATE] journeys: J | pass: A fail: B` format
- **`anchor.coverage_target`**: 60 — minimum depth score % per docs/design/26-anchor-kro-ui.md
- **`anchor.stagnation_sessions`**: 5 — sessions without anchor growth before COORD prioritizes
- **`anchor.journeys_dir`**: `test/e2e/journeys` — used by SM §4g-anchor-parity for feature→journey gap detection

## Design doc

Implements: `docs/design/26-anchor-kro-ui.md` §Future item (🔲 → ✅):
> otherness-config.yaml: `anchor:` section — score_pattern for `[ANCHOR | kro-ui]`, coverage_target: 60, stagnation_sessions: 5

Tracked in: pnz1990/otherness#567