### PR TITLE
docs(design): add design docs for major feature areas (28-31)

### DIFF
--- a/docs/design/28-rgd-display.md
+++ b/docs/design/28-rgd-display.md
@@ -1,0 +1,58 @@
+# 28 — RGD Display
+
+> Status: Active | Created: 2026-04-20
+> Applies to: pnz1990/kro-ui
+
+---
+
+## What RGD Display covers
+
+The RGD display surface is the primary way users understand their ResourceGroupDefinitions:
+the home/overview list, the detail page with DAG and YAML tabs, the catalog/registry, and
+the graph diff view. This is the most heavily exercised surface in kro-ui.
+
+---
+
+## Present (✅)
+
+- ✅ RGD list (Overview): card grid, health chips, compile-error banner, error-only filter (PR #35, #356, 2026-04)
+- ✅ RGD card error hint: one-line compile error tooltip on error-state cards (PR #325, 2026-04)
+- ✅ RGD detail: DAG visualization, node inspection, YAML tab, Kind badge, status dot (PR #38, #140, 2026-04)
+- ✅ RGD catalog: searchable registry, filtering, chaining detection, compile-status filter (PR #47, #357, 2026-04)
+- ✅ Overview health summary bar: aggregate fleet instance health chips with clickable filter (PR #324, #329, 2026-04)
+- ✅ Home search + DAG node hover tooltip (PR #77, 2026-04)
+- ✅ RGD list virtualization for 5,000+ RGDs (PR #80, 2026-04)
+- ✅ RGD validation linting: surface validation conditions in the UI (PR #50, 2026-04)
+- ✅ RGD schema doc generator: auto-generated API docs from RGD schema (PR #55, 2026-04)
+- ✅ Home/Catalog IA rename: Home→Overview, subtitles (PR #179, 2026-04)
+- ✅ Graph Revisions tab: revision history, compiled status, age, expand YAML (PR #314, 2026-04)
+- ✅ Overview SRE dashboard: 7-widget single-cluster health view (PR #405, 2026-04)
+
+## Future (🔲)
+
+- 🔲 RGD detail: full side-by-side YAML diff for graph revisions (spec 009 — foundation in PR #318)
+- 🔲 RGD list: bulk operations (delete multiple, export selected)
+- 🔲 Catalog: saved searches and filter presets
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: RGD list MUST display health state for each RGD without requiring a detail page visit.
+**O2**: DAG MUST show node type, readyWhen CEL, and includeWhen conditions when present.
+**O3**: Compile errors MUST be surfaced inline (not only in logs).
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- DAG layout algorithm: use existing D3 force layout; do not replace without benchmarking.
+- Error tooltip format: one-line is intentional — do not expand to multi-line without UX review.
+
+---
+
+## Zone 3 — Scoped out
+
+- Server-side RGD diff storage (frontend-only diff from fetched revisions)
+- RGD YAML editing directly from the list view
+

--- a/docs/design/29-instance-management.md
+++ b/docs/design/29-instance-management.md
@@ -1,0 +1,57 @@
+# 29 — Instance Management
+
+> Status: Active | Created: 2026-04-20
+> Applies to: pnz1990/kro-ui
+
+---
+
+## What Instance Management covers
+
+The instance management surface spans the global instance list, per-RGD instance tables,
+instance detail with live DAG, and tools for debugging stuck or terminating instances.
+
+---
+
+## Present (✅)
+
+- ✅ Instance list: table with namespace filter per RGD (PR #46, 2026-04)
+- ✅ Instance detail live: Live DAG with 5s polling, node YAML (PR #48, 2026-04)
+- ✅ Instance telemetry panel: age, state, children health (PR #134, 2026-04)
+- ✅ Instance health rollup: 5-state badges, error count on cards (PR #136, 2026-04)
+- ✅ Instance deletion debugger: Terminating banner, finalizers, events tab (PR #142, 2026-04)
+- ✅ Live DAG per-node state: pending state, per-child conditions, tooltip wiring (PR #180, 2026-04)
+- ✅ DAG instance overlay: overlay active/excluded nodes on RGD DAG (PR #137, 2026-04)
+- ✅ Global instance search: /instances page + GET /api/v1/instances fan-out (PR #327, 2026-04)
+- ✅ Instance namespace filter: /instances namespace dropdown + health state filter chips (PR #345, 2026-04)
+- ✅ Instance diff: F-8 snooze error DAG nodes; YAML diff foundation (PR #318, 2026-04)
+- ✅ Degraded health state (6th state), multi-segment health bar, copy instance YAML button (PR #277, 2026-04)
+- ✅ WARNINGS counter includes failed/unknown conditions (PR #328, 2026-04)
+
+## Future (🔲)
+
+- 🔲 Instance bulk operations: select multiple instances, bulk delete with confirmation
+- 🔲 Instance diff: full side-by-side comparison between two instance snapshots
+- 🔲 Instance resource graph: show all k8s resources owned by this instance
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: Instance health state MUST be visible without entering the detail page.
+**O2**: Terminating instances MUST surface the blocking finalizers and their resolution path.
+**O3**: Instance YAML copy MUST produce valid kubectl-apply-able YAML.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Polling interval for live DAG: 5s is the established default; configurable via feature flag.
+- Health state machine: 6 states (unknown, pending, reconciling, degraded, ready, error); do not add states without design review.
+
+---
+
+## Zone 3 — Scoped out
+
+- Instance mutation (editing YAML and applying to cluster) — read-only UI
+- Instance resource quota / resource usage metrics
+

--- a/docs/design/30-health-system.md
+++ b/docs/design/30-health-system.md
@@ -1,0 +1,56 @@
+# 30 — Health System
+
+> Status: Active | Created: 2026-04-20
+> Applies to: pnz1990/kro-ui
+
+---
+
+## What the Health System covers
+
+The health system is the cross-cutting concern that surfaces resource health throughout
+kro-ui: from individual instance badges to fleet-wide aggregates, error pattern analysis,
+and the SRE dashboard. It provides the primary signal for operators monitoring at scale.
+
+---
+
+## Present (✅)
+
+- ✅ Instance health rollup: 5-state → 6-state badges (unknown/pending/reconciling/degraded/ready/error), error count on cards (PR #136, #277, 2026-04)
+- ✅ Error patterns tab: cross-instance error aggregation, Errors tab on RGD detail (PR #135, 2026-04)
+- ✅ Overview health summary bar: aggregate fleet instance health chips (PR #324, 2026-04)
+- ✅ Clickable health chips: filter Overview by health state (PR #329, 2026-04)
+- ✅ Degraded health state (6th state) with multi-segment health bar (PR #277, 2026-04)
+- ✅ WARNINGS counter includes failed/unknown conditions (PR #328, 2026-04)
+- ✅ Fleet cluster card reconciling count (PR #347, 2026-04)
+- ✅ Overview SRE dashboard: 7-widget view including health summary, error patterns, degraded trends (PR #405, 2026-04)
+- ✅ Overview RGD error banner: compile-error count + error-only filter (PR #356, 2026-04)
+- ✅ Error states UX audit: translateApiError, enriched empty states (PR #208, 2026-04)
+
+## Future (🔲)
+
+- 🔲 Health trend chart: sparkline showing health state changes over last 24h per RGD
+- 🔲 Health alert subscriptions: notify when RGD/instance enters error state
+- 🔲 Condition detail drill-down: expand each condition with message, last transition time, reason
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: Health state MUST be computed and displayed without requiring a page reload.
+**O2**: Error states MUST show the error message or a human-readable translation — never raw k8s error codes alone.
+**O3**: The 6-state health model (unknown/pending/reconciling/degraded/ready/error) is the canonical model; do not add states without updating the state machine.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Health chip color scheme: established in PR #136; follow existing Tailwind color conventions.
+- Error message translation: translateApiError() is the canonical path — extend it, do not create new translation paths.
+
+---
+
+## Zone 3 — Scoped out
+
+- Prometheus/metric scraping for health (k8s API only, no metrics server required)
+- Health history persistence beyond the current session
+

--- a/docs/design/31-rgd-designer.md
+++ b/docs/design/31-rgd-designer.md
@@ -1,0 +1,55 @@
+# 31 — RGD Designer
+
+> Status: Active | Created: 2026-04-20
+> Applies to: pnz1990/kro-ui
+
+---
+
+## What the RGD Designer covers
+
+The RGD Designer is the authoring surface for creating and editing ResourceGroupDefinitions:
+the /author route, the generate form, YAML preview, CEL/schema editing, validation, and the
+optimization advisor. It is the primary tool for developers creating new kro workloads.
+
+---
+
+## Present (✅)
+
+- ✅ RGD YAML generator: instance form, batch mode, YAML preview (PR #144, 2026-04)
+- ✅ Generate form polish: required field indicator, aria-required (PR #144, 2026-04)
+- ✅ RGD Designer nav: /author promoted to nav, New RGD mode removed, live DAG preview (PR #206, 2026-04)
+- ✅ Global /author route + New RGD top bar entrypoint (PR #181, 2026-04)
+- ✅ RGD Designer full feature coverage: all 5 node types, includeWhen, readyWhen CEL, schema field editor (PR #144, 2026-04)
+- ✅ RGD Designer YAML validation, editable YAML panel, expanded optimization advisor (PR #273, 2026-04)
+- ✅ forEach collapse suggestions in catalog (optimization advisor) (PR #78, 2026-04)
+- ✅ CEL highlighter: pure TS kro CEL/schema tokenizer (PR #34, 2026-04)
+- ✅ RGD validation linting: surface validation conditions in the UI (PR #50, 2026-04)
+
+## Future (🔲)
+
+- 🔲 Designer: import existing RGD from cluster (load from live cluster → editable form)
+- 🔲 Designer: node library — drag-and-drop from common resource templates
+- 🔲 Designer: collaboration mode — share designer URL with readonly view
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: Designer MUST validate RGD YAML before showing an apply/export button — invalid YAML must block submission.
+**O2**: CEL expressions MUST be highlighted with the kro-specific tokenizer — not generic YAML highlighting.
+**O3**: The live DAG preview MUST update within 2s of schema changes without a page reload.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- YAML editor: CodeMirror with kro CEL extension is the established choice; do not replace without benchmarking.
+- Optimization advisor: suggestion thresholds (e.g. forEach collapse at N resources) are configurable via feature flags.
+
+---
+
+## Zone 3 — Scoped out
+
+- Server-side RGD template storage (browser-local only for now)
+- AI-assisted YAML generation (deferred — no LLM integration in kro-ui)
+


### PR DESCRIPTION
## Summary

Adds 4 design docs covering major kro-ui feature areas. This enables the generic gap detection
algorithm (SM §4g) to identify coverage gaps by reading Present/Future markers.

## New design docs

| Doc | Feature area | Present items | Future items |
|-----|-------------|---------------|--------------|
| docs/design/28-rgd-display.md | RGD Display | 11 | 3 |
| docs/design/29-instance-management.md | Instance Management | 12 | 3 |
| docs/design/30-health-system.md | Health System | 10 | 3 |
| docs/design/31-rgd-designer.md | RGD Designer | 9 | 3 |

All Present items reference actual merged PRs from the spec inventory.

## Why

Design doc gap: docs/design/26-anchor-kro-ui.md §N+1 documented this bottleneck:
> 'The gap detection algorithm reads ✅ Present items from docs/design/*.md.
> kro-ui has 1 design doc. The feature registry lives in AGENTS.md. Before gap detection
> works, design docs must be created for major feature areas.'

Tracked in: pnz1990/otherness#568