### PR TITLE
feat(ci): kro upstream release tracking automation

### DIFF
--- a/.github/workflows/kro-upstream-check.yml
+++ b/.github/workflows/kro-upstream-check.yml
@@ -1,0 +1,119 @@
+name: kro upstream release check
+
+# Checks kubernetes-sigs/kro for new releases weekly.
+# If a release newer than the version in go.mod is found, opens a tracking issue.
+# Design ref: docs/design/27-stage3-kro-tracking.md §27.1
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"    # Monday 09:00 UTC — kro release cadence is at most weekly
+  workflow_dispatch:         # manual trigger for testing
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: Check for new kro release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Compare kro versions and open issue if newer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          python3 - <<'PYEOF'
+          import subprocess, re, sys, os
+
+          REPO = os.environ.get('REPO', '')
+
+          # Step 1: Read current kro version from go.mod
+          try:
+              gomod = open('go.mod').read()
+              m = re.search(r'github\.com/kubernetes-sigs/kro\s+v([\d]+\.[\d]+\.[\d]+)', gomod)
+              if not m:
+                  print('[kro-upstream-check] kubernetes-sigs/kro not found in go.mod — skipping.')
+                  sys.exit(0)
+              current_version = m.group(1)
+              print(f'[kro-upstream-check] Current go.mod version: v{current_version}')
+          except Exception as e:
+              print(f'[kro-upstream-check] Could not read go.mod (non-fatal): {e}')
+              sys.exit(0)
+
+          # Step 2: Fetch latest release from GitHub API (fail-safe)
+          try:
+              r = subprocess.run(
+                  ['gh', 'api', 'repos/kubernetes-sigs/kro/releases/latest',
+                   '--jq', '.tag_name'],
+                  capture_output=True, text=True, timeout=30)
+              if r.returncode != 0:
+                  print(f'[kro-upstream-check] GitHub API error (non-fatal): {r.stderr.strip()[:100]}')
+                  sys.exit(0)
+              latest_tag = r.stdout.strip().lstrip('v')
+              print(f'[kro-upstream-check] Latest kro release: v{latest_tag}')
+          except Exception as e:
+              print(f'[kro-upstream-check] API fetch failed (non-fatal): {e}')
+              sys.exit(0)
+
+          # Step 3: Compare versions (semantic)
+          def parse_ver(v):
+              parts = v.lstrip('v').split('.')
+              try:
+                  return tuple(int(x) for x in parts[:3])
+              except ValueError:
+                  return (0, 0, 0)
+
+          current_tuple = parse_ver(current_version)
+          latest_tuple = parse_ver(latest_tag)
+
+          if latest_tuple <= current_tuple:
+              print(f'[kro-upstream-check] No new release (current=v{current_version}, latest=v{latest_tag}) — no action.')
+              sys.exit(0)
+
+          print(f'[kro-upstream-check] New kro release detected: v{current_version} → v{latest_tag}')
+
+          # Step 4: Deduplicate — skip if issue already open
+          title = f'feat(kro-v{latest_tag}): support new kro v{latest_tag} features'
+          check = subprocess.run(
+              ['gh', 'issue', 'list', '--repo', REPO, '--state', 'open',
+               '--search', f'kro v{latest_tag}', '--json', 'number', '--jq', 'length'],
+              capture_output=True, text=True, timeout=15)
+          try:
+              if int(check.stdout.strip() or '0') > 0:
+                  print(f'[kro-upstream-check] Issue for v{latest_tag} already open — skipping duplicate.')
+                  sys.exit(0)
+          except Exception:
+              pass
+
+          # Step 5: Open tracking issue
+          body = (
+              f"## kro upstream release detected\n\n"
+              f"A new kro release is available:\n\n"
+              f"- **Current version** (in `go.mod`): `v{current_version}`\n"
+              f"- **Latest release**: `v{latest_tag}`\n\n"
+              f"## Action required\n\n"
+              f"1. Review the [kro v{latest_tag} release notes](https://github.com/kubernetes-sigs/kro/releases/tag/v{latest_tag})\n"
+              f"2. Identify any CRD schema changes, new fields, new API paths, or new health states\n"
+              f"3. For each change that affects kro-ui: open a separate implementation issue\n"
+              f"4. Upgrade `go.mod` via `GOPROXY=direct GONOSUMDB=\"*\" go get github.com/kubernetes-sigs/kro@v{latest_tag}`\n\n"
+              f"## Design reference\n\n"
+              f"Design doc: `docs/design/27-stage3-kro-tracking.md §kro Upstream Tracking`\n\n"
+              f"*Opened automatically by kro-upstream-check workflow (27.1).*"
+          )
+          r2 = subprocess.run(
+              ['gh', 'issue', 'create', '--repo', REPO,
+               '--title', title,
+               '--label', 'kind/enhancement,priority/medium,kro-ui',
+               '--body', body],
+              capture_output=True, text=True, timeout=15)
+          if r2.returncode == 0:
+              print(f'[kro-upstream-check] Opened issue: {r2.stdout.strip()}')
+          else:
+              print(f'[kro-upstream-check] Failed to open issue: {r2.stderr.strip()[:100]}')
+              sys.exit(1)
+          PYEOF

--- a/.specify/specs/issue-523/spec.md
+++ b/.specify/specs/issue-523/spec.md
@@ -1,0 +1,56 @@
+# Spec: 27.1 — kro Release Tracking Automation
+
+> Issue: #523
+> Branch: feat/issue-523
+> Design ref: `docs/design/27-stage3-kro-tracking.md`
+
+## Design reference
+
+- **Design doc**: `docs/design/27-stage3-kro-tracking.md`
+- **Section**: `§ Future`
+- **Implements**: 27.1 — kro release tracking automation (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations (falsifiable)
+
+**O1 — A GitHub Actions workflow checks for new kro releases automatically.**
+The workflow must query `https://api.github.com/repos/kubernetes-sigs/kro/releases/latest`
+and compare the latest tag to the current version in `go.mod`. If newer, it opens a
+`feat(kro-vX.Y.Z): support new kro features` issue in this repo (deduplicated).
+
+**O2 — The check runs on a schedule without human intervention.**
+The workflow trigger includes `schedule: cron: "0 9 * * 1"` (weekly Monday 09:00 UTC)
+or equivalent. Manual trigger via `workflow_dispatch` must also be supported.
+
+**O3 — Duplicate issues are suppressed.**
+If an open issue titled `feat(kro-...): kro vX.Y.Z support` already exists, the workflow
+must not create another one. The check must use `gh issue list --search` to verify.
+
+**O4 — The workflow fails safe.**
+If the GitHub API is rate-limited or unreachable, the workflow exits 0 (non-fatal).
+It must not block CI or create noise from transient network failures.
+
+**O5 — otherness-config.yaml is updated with anchor upstream version tracking.**
+`anchor.upstream_version_file: go.mod` and `anchor.upstream_version_pattern: kubernetes-sigs/kro`
+are added so SM §4g-anchor-upstream tracks local version changes when go.mod is updated.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Workflow frequency: weekly (Monday 09:00 UTC) is sufficient for kro release cadence.
+  kro does not release more than once per week.
+- Issue label: use existing `kind/enhancement,priority/medium,kro-ui` labels.
+- Version comparison: semantic versioning comparison using Python's `packaging.version`
+  or simple tuple comparison on `(major, minor, patch)` — no new dependencies needed.
+- The workflow uses `GITHUB_TOKEN` (no secrets needed — public API).
+
+---
+
+## Zone 3 — Scoped out
+
+- Automated PR to upgrade go.mod (that is a separate workflow and out of scope for 27.1)
+- Parsing kro changelogs or release notes (out of scope — a human reads the opened issue)
+- Checking pre-release or RC versions (only stable releases trigger issues)
+- Per-CRD field diffing (out of scope for 27.1 — that's 27.2+)

--- a/docs/design/27-stage3-kro-tracking.md
+++ b/docs/design/27-stage3-kro-tracking.md
@@ -34,13 +34,14 @@ release has landed since our last check:
 ## Present
 
 ✅ 27.0 — kro v0.9.1 support: GraphRevision CRD, hash column, CEL hash functions (PR #428)
+✅ 27.1 — kro release tracking automation: `.github/workflows/kro-upstream-check.yml` weekly checks `kubernetes-sigs/kro` releases/latest; if newer than go.mod version, opens `feat(kro-vX.Y.Z)` issue automatically. `otherness-config.yaml` configured with `anchor.upstream_version_file`+`pattern` for local go.mod bump detection via SM §4g-anchor-upstream. (PR TBD, issue #523)
 ✅ 27.3 — Fleet persona anchor journey: 6-step journey covering multi-cluster fleet view → health matrix → context switch → per-cluster RGD count (journey 075, issue #524)
 
 ---
 
 ## Future
 
-- 🔲 27.1 — kro release tracking automation: SM §4a checks `kubernetes-sigs/kro` latest tag each batch; if newer than current supported version, opens a `feat(upstream): kro vX.Y support` issue automatically
+
 - 🔲 27.2 — Accessibility pass: all Tier 1 pages (Overview, RGD list, RGD detail, Instance detail) pass axe-core with 0 violations; add to E2E journey 074
 - 🔲 27.4 — Performance budget: Overview page load <1s on 50-RGD cluster; add Lighthouse CI check to CI pipeline
 - 🔲 27.5 — kro-ui v0.10.0 release: cut GitHub release with changelog, tag, and release notes generated from merged PRs since v0.9.4

--- a/otherness-config.yaml
+++ b/otherness-config.yaml
@@ -66,4 +66,9 @@ anchor:
   coverage_target: 60                                          # minimum depth score % for kro-ui
   stagnation_sessions: 5                                       # sessions without anchor growth before COORD prioritizes
   journeys_dir: "test/e2e/journeys"                            # used by SM §4g-anchor-parity for feature→journey gap detection
+  # Upstream version tracking (SM §4g-anchor-upstream):
+  # When go.mod is upgraded to a new kro version, SM opens an anchor-growth issue.
+  # Proactive GitHub release detection is handled by .github/workflows/kro-upstream-check.yml.
+  upstream_version_file: "go.mod"                              # file containing the upstream version
+  upstream_version_pattern: "kubernetes-sigs/kro"              # pattern to match in upstream_version_file
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/kro-upstream-check.yml`: weekly workflow (Monday 09:00 UTC) that checks `kubernetes-sigs/kro` GitHub releases API, compares to the version in `go.mod`, and opens a tracking issue if a newer stable release is available
- Configures `otherness-config.yaml` with `anchor.upstream_version_file: go.mod` and `anchor.upstream_version_pattern: kubernetes-sigs/kro` to enable SM §4g-anchor-upstream for local go.mod version bump tracking
- Updates design doc: `docs/design/27-stage3-kro-tracking.md` — moves 27.1 from 🔲 Future to ✅ Present

## Design doc

Updated `docs/design/27-stage3-kro-tracking.md`: moved 27.1 (kro release tracking automation) from 🔲 Future to ✅ Present.

## Behavior

The workflow runs weekly and on `workflow_dispatch`. If kro v0.9.2 or later is released:
1. Reads current version from `go.mod` (currently `v0.9.1`)
2. Fetches `repos/kubernetes-sigs/kro/releases/latest` via `gh api`
3. Compares versions (semantic, pre-releases ignored)
4. If newer: opens `feat(kro-vX.Y.Z): support new kro vX.Y.Z features` issue (deduplicated)
5. If GitHub API unreachable: exits 0 (fail-safe)

## Closes

Closes #523