### PR TITLE
test(e2e): register journey 074 (accessibility) in Playwright chunk-9

### DIFF
--- a/.specify/specs/issue-529/spec.md
+++ b/.specify/specs/issue-529/spec.md
@@ -1,0 +1,45 @@
+# Spec: 27.2 — Accessibility Pass
+
+> Issue: #529
+> Branch: feat/issue-529
+> Design ref: `docs/design/27-stage3-kro-tracking.md`
+
+## Design reference
+
+- **Design doc**: `docs/design/27-stage3-kro-tracking.md`
+- **Section**: `§ Future`
+- **Implements**: 27.2 — Accessibility pass (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations (falsifiable)
+
+**O1 — Journey 074 runs in CI.**
+`test/e2e/journeys/074-accessibility.spec.ts` must be assigned to a Playwright
+chunk in `playwright.config.ts`. A file without a `testMatch` chunk is silently
+skipped. After this PR: running `make test-e2e` must execute all 4 steps in 074.
+
+**O2 — The chunk comment matches what's included.**
+The chunk-9 comment header (`// chunk-9: 060-075`) must be updated to reference
+journey 074 (accessibility) alongside the existing entries.
+
+**O3 — The journey covers all 4 Tier 1 pages.**
+`074-accessibility.spec.ts` already contains 4 steps: Catalog page, RGD DAG,
+Instance list, Context switcher. No new steps needed — just chunk registration.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Journey 074 already exists with complete axe-core assertions for all Tier 1 pages.
+- The only change required is adding `074` to chunk-9's `testMatch` regex.
+- No modifications to the journey file itself — it is already correct.
+
+---
+
+## Zone 3 — Scoped out
+
+- Fixing any actual axe violations found (those will be separate PRs per page/component)
+- Adding the Overview page axe scan (Overview = `/` route; already covered by context-switcher
+  step which scans the header/nav; full page scan is Zone 3 for 27.2)
+- WCAG AAA compliance (only AA required)

--- a/docs/design/27-stage3-kro-tracking.md
+++ b/docs/design/27-stage3-kro-tracking.md
@@ -34,7 +34,8 @@ release has landed since our last check:
 ## Present
 
 ✅ 27.0 — kro v0.9.1 support: GraphRevision CRD, hash column, CEL hash functions (PR #428)
-✅ 27.1 — kro release tracking automation: `.github/workflows/kro-upstream-check.yml` weekly checks `kubernetes-sigs/kro` releases/latest; if newer than go.mod version, opens `feat(kro-vX.Y.Z)` issue automatically. `otherness-config.yaml` configured with `anchor.upstream_version_file`+`pattern` for local go.mod bump detection via SM §4g-anchor-upstream. (PR TBD, issue #523)
+✅ 27.1 — kro release tracking automation: `.github/workflows/kro-upstream-check.yml` weekly checks `kubernetes-sigs/kro` releases/latest; if newer than go.mod version, opens `feat(kro-vX.Y.Z)` issue automatically. `otherness-config.yaml` configured with `anchor.upstream_version_file`+`pattern` for local go.mod bump detection via SM §4g-anchor-upstream. (PR #545, issue #523)
+✅ 27.2 — Accessibility pass: journey `074-accessibility.spec.ts` registered in Playwright chunk-9 testMatch pattern; axe-core WCAG 2.1 AA scan runs on Catalog, RGD DAG, Instance list, and Context switcher pages in CI. (PR TBD, issue #529)
 ✅ 27.3 — Fleet persona anchor journey: 6-step journey covering multi-cluster fleet view → health matrix → context switch → per-cluster RGD count (journey 075, issue #524)
 
 ---

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -149,9 +149,9 @@ export default defineConfig({
        // (health-filter, fleet-reconciling, instances-filter, health-sort,
        //  status-message, error-banner, catalog-status-filter, kro-v091,
        //  operator-persona-journey, sre-persona-journey, developer-persona-journey,
-       //  fleet-persona-journey)
+       //  accessibility (074), fleet-persona-journey)
       name: 'chunk-9',
-      testMatch: /(060|062[a-z]?|063|064|065|066|069|070|071|072|073|075)-.*\.spec\.ts/,
+      testMatch: /(060|062[a-z]?|063|064|065|066|069|070|071|072|073|074|075)-.*\.spec\.ts/,
       ...PARALLEL_OPTS,
       workers: 4,
       fullyParallel: true,


### PR DESCRIPTION
## Summary

- Adds journey 074 (`074-accessibility.spec.ts`) to chunk-9's `testMatch` regex in `playwright.config.ts`
- Journey was silently skipped in CI because it was not assigned to any chunk (AGENTS.md anti-pattern)
- The journey runs axe-core WCAG 2.1 AA scans on 4 Tier 1 pages: Catalog, RGD DAG, Instance list, Context switcher
- Updates chunk-9 comment to include `accessibility (074)`

## Design doc

Updated `docs/design/27-stage3-kro-tracking.md`: moved 27.2 (Accessibility pass) from 🔲 Future to ✅ Present.

## Root cause

`074-accessibility.spec.ts` was created in a prior PR but the chunk-9 `testMatch` pattern was never updated to include `074`. Per AGENTS.md: *"E2E journey files not assigned to any Playwright chunk are silently skipped."*

## Change scope

1-line change to `playwright.config.ts` testMatch regex (074 added), plus design doc and spec.

Closes #529