### PR TITLE
feat(conditions): condition detail drill-down — per-row expand/collapse

### DIFF
--- a/.specify/specs/pr-565/spec.md
+++ b/.specify/specs/pr-565/spec.md
@@ -1,0 +1,43 @@
+# spec pr-565 — Condition detail drill-down
+
+## Design reference
+- **Design doc**: `docs/design/30-health-system.md`
+- **Section**: `§ Future`
+- **Implements**: Condition detail drill-down — expand each condition with message, last transition time, reason (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: Each condition row in `ConditionsPanel` MUST default to collapsed state, showing only the condition type and status badge.
+
+**O2**: Clicking a collapsed condition row MUST expand it in-place to reveal message, reason, and lastTransitionTime (when present).
+
+**O3**: Clicking an expanded condition row MUST collapse it back.
+
+**O4**: Unhealthy conditions (status≠True, or negation-polarity False-is-healthy) MUST default to **expanded** so operators immediately see the error detail without a click.
+
+**O5**: The expand/collapse toggle MUST be keyboard accessible (Enter/Space activates it; the row carries `role="button"` and `tabIndex={0}`).
+
+**O6**: Absent optional fields (message, reason, lastTransitionTime) MUST NOT render their labels/containers when empty or missing.
+
+**O7**: The existing `data-testid="conditions-panel"`, `data-testid="conditions-panel-empty"`, and `data-testid="conditions-summary"` MUST remain for backward compatibility.
+
+**O8**: Each expandable row MUST carry `data-testid="condition-row-{type}"` and `data-testid="condition-row-{type}-detail"` for the expanded detail section.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Use a `Set<string>` of expanded condition types in local React state.
+- The toggle chevron (▼/▶) is a reasonable affordance — or inline CSS rotation.
+- Whether to auto-expand ALL conditions when there is only 1 condition is left to judgment.
+- CSS transitions for expand/collapse are optional (prefer simplicity).
+
+---
+
+## Zone 3 — Scoped out
+
+- Persisting the expand/collapse state across page navigations.
+- Expanding conditions in other panels (ConditionItem, ValidationTab).
+- Any server-side changes.

--- a/docs/design/30-health-system.md
+++ b/docs/design/30-health-system.md
@@ -26,11 +26,14 @@ and the SRE dashboard. It provides the primary signal for operators monitoring a
 - ✅ Overview RGD error banner: compile-error count + error-only filter (PR #356, 2026-04)
 - ✅ Error states UX audit: translateApiError, enriched empty states (PR #208, 2026-04)
 
+## Present (✅) — continued
+
+- ✅ Condition detail drill-down: per-condition expand/collapse — unhealthy conditions auto-expand; healthy conditions collapsed by default; keyboard accessible (PR #565, 2026-04)
+
 ## Future (🔲)
 
 - 🔲 Health trend chart: sparkline showing health state changes over last 24h per RGD
 - 🔲 Health alert subscriptions: notify when RGD/instance enters error state
-- 🔲 Condition detail drill-down: expand each condition with message, last transition time, reason
 
 ---
 

--- a/web/src/components/ConditionsPanel.css
+++ b/web/src/components/ConditionsPanel.css
@@ -1,7 +1,8 @@
-/* ConditionsPanel.css — Conditions list panel.
+/* ConditionsPanel.css — Conditions list panel with expand/collapse drill-down.
  *
  * All colors from tokens.css custom properties.
  * Spec: .specify/specs/028-instance-health-rollup/
+ * Spec: .specify/specs/pr-565/ — condition detail drill-down
  */
 
 .conditions-panel {
@@ -25,22 +26,48 @@
 }
 
 .condition-row {
-  padding: 10px 16px;
   border-bottom: 1px solid var(--color-border-subtle);
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
 }
 
 .condition-row:last-child {
   border-bottom: none;
 }
 
+/* Collapsed header — always shown */
 .condition-header {
   display: flex;
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
+  padding: 10px 16px;
+  user-select: none;
+}
+
+/* Clickable header when the row has detail content */
+.condition-header--clickable {
+  cursor: pointer;
+}
+
+.condition-header--clickable:hover {
+  background: var(--color-surface-raised, var(--color-bg-subtle, rgba(0,0,0,.03)));
+}
+
+.condition-header--clickable:focus-visible {
+  outline: 2px solid var(--color-focus-ring, var(--color-primary));
+  outline-offset: -2px;
+}
+
+/* Expand/collapse chevron */
+.condition-chevron {
+  font-size: 9px;
+  color: var(--color-text-faint);
+  transition: transform 0.15s ease;
+  flex-shrink: 0;
+  display: inline-block;
+}
+
+.condition-chevron--open {
+  transform: rotate(90deg);
 }
 
 .condition-type {
@@ -81,10 +108,44 @@
   font-family: var(--font-mono);
 }
 
+/* Inline reason shown in the collapsed header (truncated) */
+.condition-reason--inline {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Expanded detail section */
+.condition-detail {
+  padding: 0 16px 10px 34px; /* left-indent aligns with text after chevron */
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.condition-detail-row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.condition-detail-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-text-faint);
+  min-width: 90px;
+  flex-shrink: 0;
+  padding-top: 1px;
+}
+
 .condition-message {
   font-size: 12px;
   color: var(--color-text-muted);
   line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .condition-time {

--- a/web/src/components/ConditionsPanel.test.tsx
+++ b/web/src/components/ConditionsPanel.test.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import ConditionsPanel from './ConditionsPanel'
 import type { K8sObject } from '@/lib/api'
 
@@ -60,13 +60,114 @@ describe('ConditionsPanel', () => {
     expect(screen.getByTestId('conditions-summary').textContent).toContain('2 / 2')
   })
 
-  it('renders condition type and reason', () => {
+  it('renders condition type and status badge in collapsed state', () => {
     const conditions = [
       { type: 'Ready', status: 'True', reason: 'AllGood', message: 'all resources ready' },
     ]
     render(<ConditionsPanel instance={makeInstance(conditions)} />)
     expect(screen.getByText('Ready')).toBeTruthy()
-    expect(screen.getByText('AllGood')).toBeTruthy()
+    // Healthy conditions start collapsed — message NOT visible yet
+    expect(screen.queryByText('all resources ready')).toBeNull()
+  })
+
+  it('renders condition row testid', () => {
+    const conditions = [{ type: 'Ready', status: 'True', reason: 'OK' }]
+    render(<ConditionsPanel instance={makeInstance(conditions)} />)
+    expect(screen.getByTestId('condition-row-Ready')).toBeTruthy()
+  })
+
+  // spec O1: healthy conditions start collapsed
+  it('healthy conditions start collapsed (no detail visible)', () => {
+    const conditions = [
+      { type: 'Ready', status: 'True', reason: 'OK', message: 'all good', lastTransitionTime: '2026-01-01T00:00:00Z' },
+    ]
+    render(<ConditionsPanel instance={makeInstance(conditions)} />)
+    expect(screen.queryByTestId('condition-row-Ready-detail')).toBeNull()
+  })
+
+  // spec O4: unhealthy conditions start expanded
+  it('unhealthy conditions auto-expand on mount', () => {
+    const conditions = [
+      { type: 'ResourcesReady', status: 'False', reason: 'NotReady', message: 'waiting for node', lastTransitionTime: '2026-01-01T00:00:00Z' },
+    ]
+    render(<ConditionsPanel instance={makeInstance(conditions)} />)
+    expect(screen.getByTestId('condition-row-ResourcesReady-detail')).toBeTruthy()
+    expect(screen.getByText('waiting for node')).toBeTruthy()
+  })
+
+  // spec O2: click expands a collapsed row
+  it('clicking a collapsed healthy row expands it', () => {
+    const conditions = [
+      { type: 'Ready', status: 'True', reason: 'OK', message: 'all resources ready' },
+    ]
+    render(<ConditionsPanel instance={makeInstance(conditions)} />)
+    // Detail hidden initially
+    expect(screen.queryByTestId('condition-row-Ready-detail')).toBeNull()
+    // Click the header
+    const header = screen.getByTestId('condition-row-Ready').querySelector('.condition-header--clickable')
+    expect(header).toBeTruthy()
+    fireEvent.click(header!)
+    // Detail now visible
+    expect(screen.getByTestId('condition-row-Ready-detail')).toBeTruthy()
     expect(screen.getByText('all resources ready')).toBeTruthy()
+  })
+
+  // spec O3: click collapses an expanded row
+  it('clicking an expanded unhealthy row collapses it', () => {
+    const conditions = [
+      { type: 'ResourcesReady', status: 'False', reason: 'NotReady', message: 'waiting', lastTransitionTime: '2026-01-01T00:00:00Z' },
+    ]
+    render(<ConditionsPanel instance={makeInstance(conditions)} />)
+    // Auto-expanded
+    expect(screen.getByTestId('condition-row-ResourcesReady-detail')).toBeTruthy()
+    // Click to collapse
+    const header = screen.getByTestId('condition-row-ResourcesReady').querySelector('.condition-header--clickable')
+    fireEvent.click(header!)
+    expect(screen.queryByTestId('condition-row-ResourcesReady-detail')).toBeNull()
+  })
+
+  // spec O5: keyboard activation
+  it('Enter key expands a collapsed row', () => {
+    const conditions = [
+      { type: 'Ready', status: 'True', message: 'ok' },
+    ]
+    render(<ConditionsPanel instance={makeInstance(conditions)} />)
+    const header = screen.getByTestId('condition-row-Ready').querySelector('.condition-header--clickable')!
+    fireEvent.keyDown(header, { key: 'Enter' })
+    expect(screen.getByTestId('condition-row-Ready-detail')).toBeTruthy()
+  })
+
+  it('Space key expands a collapsed row', () => {
+    const conditions = [
+      { type: 'Ready', status: 'True', message: 'ok' },
+    ]
+    render(<ConditionsPanel instance={makeInstance(conditions)} />)
+    const header = screen.getByTestId('condition-row-Ready').querySelector('.condition-header--clickable')!
+    fireEvent.keyDown(header, { key: ' ' })
+    expect(screen.getByTestId('condition-row-Ready-detail')).toBeTruthy()
+  })
+
+  // spec O6: absent fields not rendered
+  it('absent message not rendered in detail', () => {
+    const conditions = [
+      { type: 'Ready', status: 'True', reason: 'OK' }, // no message, no lastTransitionTime
+    ]
+    render(<ConditionsPanel instance={makeInstance(conditions)} />)
+    const header = screen.getByTestId('condition-row-Ready').querySelector('.condition-header--clickable')!
+    fireEvent.click(header!)
+    // reason IS present
+    expect(screen.getByText('OK')).toBeTruthy()
+    // No lastTransitionTime row
+    expect(screen.queryByText(/Last transition/)).toBeNull()
+  })
+
+  // No clickable header when condition has no detail
+  it('condition with no detail has no clickable header', () => {
+    const conditions = [
+      { type: 'Ready', status: 'True' }, // no reason, message, or lastTransitionTime
+    ]
+    render(<ConditionsPanel instance={makeInstance(conditions)} />)
+    const header = screen.getByTestId('condition-row-Ready').querySelector('.condition-header--clickable')
+    expect(header).toBeNull()
   })
 })

--- a/web/src/components/ConditionsPanel.tsx
+++ b/web/src/components/ConditionsPanel.tsx
@@ -1,14 +1,33 @@
-// ConditionsPanel.tsx — Table of Kubernetes conditions for an instance.
+// Copyright 2026 The Kubernetes Authors.
 //
-// Renders type, status, reason, message, last transition time.
-// Updates on every poll cycle via props.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ConditionsPanel.tsx — Collapsible condition drill-down for Kubernetes conditions.
+//
+// Each condition row is collapsed by default (type + status badge only).
+// Unhealthy conditions (non-healthy status) are auto-expanded on mount so operators
+// see error details without a click.
+// Clicking a row header expands/collapses the full detail: message, reason,
+// lastTransitionTime.
+//
+// spec pr-565: condition detail drill-down (🔲 → ✅)
 // spec 028: "Not reported" empty state, summary header, absent-field omission.
 // spec 028 US5: negation-polarity conditions counted correctly via isHealthyCondition.
 //
 // Issue #159: ReconciliationSuspended=False is healthy (Kubernetes inversion convention).
 // isHealthyCondition() lives in @/lib/conditions and is reused here and in ErrorsTab.
 
+import { useState, useCallback } from 'react'
 import type { K8sObject } from '@/lib/api'
 import { isHealthyCondition, conditionStatusLabel } from '@/lib/conditions'
 import './ConditionsPanel.css'
@@ -54,8 +73,17 @@ function statusClass(type: string, status: string): string {
   return 'condition-status--false'
 }
 
+/** Returns true when a condition's detail section has any content to show. */
+function hasDetail(c: K8sCondition): boolean {
+  return !!(c.message || c.reason || c.lastTransitionTime)
+}
+
 /**
- * ConditionsPanel — renders all status.conditions fields.
+ * ConditionsPanel — renders all status.conditions fields with expand/collapse drill-down.
+ *
+ * Collapsed view (default): condition type + status badge only.
+ * Expanded view (click to toggle): adds message, reason, lastTransitionTime.
+ * Unhealthy conditions auto-expand on mount so errors are immediately visible.
  *
  * Empty state: "Not reported" (constitution §XII — absent data is "not reported",
  * never "No conditions." which implies the data was checked and found empty).
@@ -65,10 +93,34 @@ function statusClass(type: string, status: string): string {
  * Absent optional fields (reason, message, lastTransitionTime) are omitted
  * entirely — never rendered as empty strings, undefined, or placeholders.
  *
+ * Spec: .specify/specs/pr-565/ O1-O8
  * Spec: .specify/specs/028-instance-health-rollup/ US4 FR-009, FR-010
  */
 export default function ConditionsPanel({ instance }: ConditionsPanelProps) {
   const conditions = extractConditions(instance)
+
+  // Initialize: unhealthy conditions are expanded by default (spec O4).
+  const [expandedTypes, setExpandedTypes] = useState<Set<string>>(() => {
+    const initial = new Set<string>()
+    for (const c of conditions) {
+      if (!isHealthyCondition(c.type, c.status) && hasDetail(c)) {
+        initial.add(c.type)
+      }
+    }
+    return initial
+  })
+
+  const toggle = useCallback((type: string) => {
+    setExpandedTypes((prev) => {
+      const next = new Set(prev)
+      if (next.has(type)) {
+        next.delete(type)
+      } else {
+        next.add(type)
+      }
+      return next
+    })
+  }, [])
 
   if (conditions.length === 0) {
     return (
@@ -92,27 +144,78 @@ export default function ConditionsPanel({ instance }: ConditionsPanelProps) {
         {trueCount} / {conditions.length} conditions healthy
       </div>
       <div className="conditions-list">
-        {conditions.map((c, i) => (
-          <div key={`${c.type}-${i}`} className="condition-row">
-            <div className="condition-header">
-              <span className="condition-type">{c.type}</span>
-              <span className={`condition-status ${statusClass(c.type, c.status)}`}>
-                {conditionStatusLabel(c.type, c.status)}
-              </span>
-              {c.reason && c.reason !== '' && (
-                <span className="condition-reason">{c.reason}</span>
+        {conditions.map((c, i) => {
+          const expanded = expandedTypes.has(c.type)
+          const expandable = hasDetail(c)
+          const sClass = statusClass(c.type, c.status)
+
+          return (
+            <div
+              key={`${c.type}-${i}`}
+              data-testid={`condition-row-${c.type}`}
+              className={`condition-row${expanded ? ' condition-row--expanded' : ''}`}
+            >
+              {/* Header row — always visible; click to expand if detail exists */}
+              <div
+                className={`condition-header${expandable ? ' condition-header--clickable' : ''}`}
+                role={expandable ? 'button' : undefined}
+                tabIndex={expandable ? 0 : undefined}
+                aria-expanded={expandable ? expanded : undefined}
+                onClick={expandable ? () => toggle(c.type) : undefined}
+                onKeyDown={expandable ? (e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    toggle(c.type)
+                  }
+                } : undefined}
+              >
+                {expandable && (
+                  <span
+                    className={`condition-chevron${expanded ? ' condition-chevron--open' : ''}`}
+                    aria-hidden="true"
+                  >
+                    ▶
+                  </span>
+                )}
+                <span className="condition-type">{c.type}</span>
+                <span className={`condition-status ${sClass}`}>
+                  {conditionStatusLabel(c.type, c.status)}
+                </span>
+                {/* Reason shown inline in collapsed state for quick scan */}
+                {!expanded && c.reason && c.reason !== '' && (
+                  <span className="condition-reason condition-reason--inline">{c.reason}</span>
+                )}
+              </div>
+
+              {/* Detail section — visible only when expanded */}
+              {expanded && (
+                <div
+                  data-testid={`condition-row-${c.type}-detail`}
+                  className="condition-detail"
+                >
+                  {c.reason && c.reason !== '' && (
+                    <div className="condition-detail-row">
+                      <span className="condition-detail-label">Reason</span>
+                      <span className="condition-reason">{c.reason}</span>
+                    </div>
+                  )}
+                  {c.message && c.message !== '' && (
+                    <div className="condition-detail-row">
+                      <span className="condition-detail-label">Message</span>
+                      <span className="condition-message">{c.message}</span>
+                    </div>
+                  )}
+                  {c.lastTransitionTime && (
+                    <div className="condition-detail-row">
+                      <span className="condition-detail-label">Last transition</span>
+                      <span className="condition-time">{formatTime(c.lastTransitionTime)}</span>
+                    </div>
+                  )}
+                </div>
               )}
             </div>
-            {c.message && c.message !== '' && (
-              <div className="condition-message">{c.message}</div>
-            )}
-            {c.lastTransitionTime && (
-              <div className="condition-time">
-                Last transition: {formatTime(c.lastTransitionTime)}
-              </div>
-            )}
-          </div>
-        ))}
+          )
+        })}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- Each condition row in `ConditionsPanel` now collapses by default (type + status badge only), reducing visual noise when all conditions are healthy
- Unhealthy conditions (False/Unknown status) **auto-expand on mount** so error messages are immediately visible without a click
- Clicking a condition header toggles the detail section: message, reason, and lastTransitionTime

## UX behavior

| State | Default | Click |
|-------|---------|-------|
| Healthy (True) | Collapsed | Expands detail |
| Unhealthy (False/Unknown) | **Auto-expanded** | Collapses |
| No detail fields | No chevron, no toggle | — |

## Accessibility

- Toggle rows carry `role="button"`, `tabIndex={0}`, `aria-expanded`
- Enter and Space keys activate toggle
- Chevron icon is `aria-hidden`

## Design doc

Updated `docs/design/30-health-system.md`: moved condition detail drill-down from 🔲 Future to ✅ Present.

## Tests

- 14 unit tests covering O1–O8: collapsed default, auto-expand unhealthy, click toggle, keyboard access, absent fields, no-chevron when no detail
- All 1552 existing tests pass