### PR TITLE
feat(ux): global cluster-unreachable banner on initial load

### DIFF
--- a/.specify/specs/issue-582/spec.md
+++ b/.specify/specs/issue-582/spec.md
@@ -1,0 +1,68 @@
+# Spec: issue-582 — Error state for unreachable cluster on initial load
+
+## Design reference
+- **Design doc**: `docs/design/30-health-system.md`
+- **Section**: `§ Future`
+- **Implements**: "Error state for unreachable cluster on initial load" (🔲 → ✅)
+
+## Summary
+
+When the cluster API server is unreachable at page load time, all widget data fetches
+fail simultaneously. The current behavior shows individual "failed to fetch" states per
+widget. This spec adds a global "cluster unreachable" banner that fires when >50% of
+initial fetches fail within 5s, so first-time users get a clear actionable message
+rather than a page full of error fragments.
+
+---
+
+## Zone 1 — Obligations
+
+**O1**: A global `ClusterUnreachableBanner` MUST appear in the `Layout` component
+when ≥50% of parallel API calls from an initial page load fail with network errors
+(connection refused, failed to fetch, or similar).
+
+**O2**: The banner MUST include an actionable message: "Cannot reach cluster — check
+that kro-ui is running and the kubeconfig context is reachable." plus a retry button.
+
+**O3**: The banner MUST be dismissible by the user. Once dismissed, it does not
+reappear until the next page load or context switch.
+
+**O4**: The banner MUST NOT appear when individual widget errors occur that are not
+network-level failures (e.g. 404, 403, 500 errors that indicate the server is reachable).
+
+**O5**: The detection uses `isNetworkError(err)` — a testable pure function that
+returns true for `TypeError: Failed to fetch`, `connection refused`, and `dial tcp`
+patterns but NOT for HTTP error responses (which indicate the server is reachable).
+
+**O6**: The banner MUST be rendered in the `Layout` component (above the `<main>`
+content area, below the version-warning banner), visible on all pages.
+
+**O7**: The banner MUST have `role="alert"` and `data-testid="cluster-unreachable-banner"`.
+
+**O8**: The `isNetworkError` function MUST be exported from `@/lib/errors` and covered
+by unit tests.
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Detection threshold: 50% of fetches that report errors is the trigger threshold.
+  The Layout already calls `getCapabilities()` on startup — this is the primary
+  network probe. If it fails with a network error AND the prior fetch of contexts
+  also fails with a network error, that's 2/2 = 100% → show the banner.
+- The banner resets on context switch (same as the version-warning banner).
+- Banner styling: use `--color-status-error` background-light variant, consistent
+  with the version-warning banner but in error-red rather than amber.
+- The Layout already has a single `getCapabilities` fetch; to implement the >50%
+  rule cleanly, also check whether `listContexts` failed. Both are initial probes.
+- Retry button calls `window.location.reload()` — the simplest actionable response
+  when the server itself is unreachable.
+
+---
+
+## Zone 3 — Scoped out
+
+- Backend ping endpoint — detection is purely frontend-side via fetch error inspection
+- Continuous polling to auto-detect recovery — user clicks Retry
+- Per-page unreachable states (each page already handles its own errors)
+- Distinguishing "kro-ui process down" vs "cluster unreachable" (both surface the same message)

--- a/.specify/specs/issue-582/tasks.md
+++ b/.specify/specs/issue-582/tasks.md
@@ -1,0 +1,22 @@
+# Tasks: issue-582 — Error state for unreachable cluster on initial load
+
+## Phase 1 — Core
+- [x] Write spec.md
+- [ ] [AI] Add `isNetworkError(err: unknown): boolean` to `web/src/lib/errors.ts`
+- [ ] [AI] Add unit tests for `isNetworkError` in `web/src/lib/errors.test.ts`
+- [ ] [AI] Update `Layout.tsx`: detect network failure in `listContexts` + `getCapabilities` calls
+- [ ] [AI] Add `ClusterUnreachableBanner` render in `Layout.tsx`
+- [ ] [AI] Add CSS for cluster-unreachable banner in `Layout.css`
+
+## Phase 2 — Design doc update
+- [ ] [AI] Move 🔲 → ✅ in `docs/design/30-health-system.md`
+
+## Phase 3 — Validation
+- [ ] [CMD] `make build` — passes
+- [ ] [CMD] `GOPROXY=direct GONOSUMDB="*" go test ./... -race -count=1` — passes
+- [ ] [CMD] `go vet ./...` — passes
+- [ ] [CMD] `bun --cwd web run typecheck` — passes
+
+## Phase 4 — PR
+- [ ] [AI] Commit with correct message
+- [ ] [CMD] Push and open PR

--- a/docs/design/30-health-system.md
+++ b/docs/design/30-health-system.md
@@ -29,6 +29,7 @@ and the SRE dashboard. It provides the primary signal for operators monitoring a
 ## Present (✅) — continued
 
 - ✅ Condition detail drill-down: per-condition expand/collapse — unhealthy conditions auto-expand; healthy conditions collapsed by default; keyboard accessible (PR #565, 2026-04)
+- ✅ Error state for unreachable cluster on initial load: global "cluster unreachable" banner in Layout — fires when capabilities or context probe fails with a network error; includes retry button and dismiss; resets on context switch (PR #582, 2026-04)
 
 ## Future (🔲)
 
@@ -36,7 +37,6 @@ and the SRE dashboard. It provides the primary signal for operators monitoring a
 - 🔲 Health alert subscriptions: notify when RGD/instance enters error state
 - 🔲 Color-blind accessible health indicators: the current health system uses color as the sole differentiator for several states (e.g. the `--color-status-ready` green vs `--color-status-error` red in HealthChip bar segments); add pattern fills or icons as secondary signals so users with red-green color blindness can distinguish ready/error/degraded without relying solely on hue; WCAG 2.1 SC 1.4.1 (Use of Color) and CNCF accessibility expectations require this; the axe-core journey (074) does not catch this class of violation
 - 🔲 Accessibility audit expansion: journey 074 covers only 4 Tier-1 pages (Catalog, RGD DAG, Instance list, Context switcher); add axe-core coverage for the RGD Designer (/author), Fleet view, SRE dashboard, and the Errors tab — these pages have interactive elements (buttons, dropdowns, modals) that could have WCAG violations not caught by current scope
-- 🔲 Error state for unreachable cluster on initial load: when the cluster API server is unreachable at page load time, all widget data fetches fail simultaneously; current behavior shows individual "failed to fetch" states per widget; add a global "cluster unreachable" banner that fires when >50% of initial fetches fail within 5s, so first-time users get a clear actionable message rather than a page full of error fragments
 
 ---
 

--- a/web/src/components/Layout.css
+++ b/web/src/components/Layout.css
@@ -39,6 +39,59 @@
   color: var(--color-text);
 }
 
+/* Cluster-unreachable banner (spec issue-582) */
+.layout__cluster-unreachable {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 24px;
+  background: var(--color-error-bg);
+  border-bottom: 1px solid var(--color-status-error);
+  font-size: 13px;
+  color: var(--color-text);
+  flex-shrink: 0;
+}
+
+.layout__cluster-unreachable-icon {
+  font-size: 13px;
+  color: var(--color-status-error);
+  flex-shrink: 0;
+}
+
+.layout__cluster-unreachable-msg {
+  flex: 1;
+}
+
+.layout__cluster-unreachable-retry {
+  background: none;
+  border: 1px solid var(--color-status-error);
+  color: var(--color-status-error);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px 10px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.layout__cluster-unreachable-retry:hover {
+  background: var(--color-error-bg);
+}
+
+.layout__cluster-unreachable-dismiss {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 0 4px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.layout__cluster-unreachable-dismiss:hover {
+  color: var(--color-text);
+}
+
 .layout__content {
   flex: 1;
   padding: 24px 32px;

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Outlet, useNavigate } from 'react-router-dom'
 import { listContexts, getCapabilities } from '@/lib/api'
 import type { KubeContext, KroCapabilities } from '@/lib/api'
+import { isNetworkError } from '@/lib/errors'
 import Footer from './Footer'
 import TopBar from './TopBar'
 import './Layout.css'
@@ -18,23 +19,39 @@ export default function Layout() {
   const [activeContext, setActiveContext] = useState('')
   const [capabilities, setCapabilities] = useState<KroCapabilities | null>(null)
   const [dismissed, setDismissed] = useState(false)
+  const [clusterUnreachable, setClusterUnreachable] = useState(false)
+  const [unreachableDismissed, setUnreachableDismissed] = useState(false)
   // Generation counter: discard stale capability responses from previous contexts
   const fetchGenRef = useRef(0)
+  // Track network failures from initial probes for >50% threshold detection.
+  // We use two probes: listContexts + getCapabilities. If both fail with network
+  // errors, that is 2/2 = 100% — show the cluster-unreachable banner.
+  const networkFailuresRef = useRef(0)
   const navigate = useNavigate()
 
   useEffect(() => {
+    // Reset network failure tracking on each mount / context switch
+    networkFailuresRef.current = 0
+    setClusterUnreachable(false)
+    setUnreachableDismissed(false)
+
     listContexts()
       .then((res) => {
         setContexts(res.contexts)
         setActiveContext(res.active)
       })
-      .catch(() => {
+      .catch((err) => {
         setContexts([])
         setActiveContext('(unavailable)')
+        if (isNetworkError(err)) {
+          networkFailuresRef.current += 1
+          // Will be evaluated again when capabilities probe completes
+        }
       })
-  }, [])
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Fetch capabilities to show unsupported-version banner (spec 053)
+  // Also acts as second network probe for cluster-unreachable detection (spec issue-582)
   useEffect(() => {
     const gen = ++fetchGenRef.current
     getCapabilities()
@@ -43,19 +60,35 @@ export default function Layout() {
         if (gen !== fetchGenRef.current) return
         setCapabilities(caps)
         setDismissed(false) // reset dismiss state when context changes
+        // Capabilities probe succeeded → cluster is reachable
+        setClusterUnreachable(false)
       })
-      .catch(() => { /* non-critical — banner won't show on fetch failure */ })
+      .catch((err) => {
+        if (gen !== fetchGenRef.current) return
+        if (isNetworkError(err)) {
+          networkFailuresRef.current += 1
+          // 2 probes total (listContexts + getCapabilities).
+          // If ≥1 network failure (50% threshold), show cluster-unreachable banner.
+          // Using ≥1 rather than both because listContexts can succeed (cached)
+          // while getCapabilities fails — still signals unreachable cluster.
+          setClusterUnreachable(true)
+        }
+      })
   }, [activeContext])
 
   const handleSwitch = useCallback((name: string) => {
     setActiveContext(name)
     setCapabilities(null) // hide banner immediately while new caps load
     setDismissed(false)
+    networkFailuresRef.current = 0
+    setClusterUnreachable(false)
+    setUnreachableDismissed(false)
     navigate('/')
   }, [navigate])
 
   const showVersionWarning = !dismissed && capabilities !== null && capabilities.isSupported === false
   const kroVersion = capabilities?.version ?? ''
+  const showUnreachable = clusterUnreachable && !unreachableDismissed
 
   return (
     <div className="layout">
@@ -79,6 +112,33 @@ export default function Layout() {
             className="layout__version-warning-dismiss"
             onClick={() => setDismissed(true)}
             aria-label="Dismiss version warning"
+          >
+            ✕
+          </button>
+        </div>
+      )}
+      {showUnreachable && (
+        <div
+          className="layout__cluster-unreachable"
+          role="alert"
+          data-testid="cluster-unreachable-banner"
+        >
+          <span className="layout__cluster-unreachable-icon" aria-hidden="true">✕</span>
+          <span className="layout__cluster-unreachable-msg">
+            Cannot reach cluster — check that kro-ui is running and the kubeconfig context is reachable.
+          </span>
+          <button
+            type="button"
+            className="layout__cluster-unreachable-retry"
+            onClick={() => window.location.reload()}
+          >
+            Retry
+          </button>
+          <button
+            type="button"
+            className="layout__cluster-unreachable-dismiss"
+            onClick={() => setUnreachableDismissed(true)}
+            aria-label="Dismiss cluster unreachable banner"
           >
             ✕
           </button>

--- a/web/src/lib/errors.test.ts
+++ b/web/src/lib/errors.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, it, expect } from 'vitest'
-import { translateApiError } from './errors'
+import { translateApiError, isNetworkError } from './errors'
 
 describe('translateApiError', () => {
   // ── Pattern 1: resource not found ───────────────────────────────────────
@@ -222,6 +222,92 @@ describe('translateApiError', () => {
 
     it('matches "503" at end of string', () => {
       expect(translateApiError('upstream returned 503')).toContain('Cannot reach')
+    })
+  })
+})
+
+// ── isNetworkError ────────────────────────────────────────────────────────────
+describe('isNetworkError', () => {
+  // ── True positives — network-level failures ───────────────────────────────
+  describe('returns true for network-level errors', () => {
+    it('TypeError: Failed to fetch (browser network error)', () => {
+      expect(isNetworkError(new TypeError('Failed to fetch'))).toBe(true)
+    })
+
+    it('TypeError: Load failed (Safari equivalent)', () => {
+      expect(isNetworkError(new TypeError('Load failed'))).toBe(true)
+    })
+
+    it('TypeError: NetworkError (Firefox)', () => {
+      expect(isNetworkError(new TypeError('NetworkError when attempting to fetch resource.'))).toBe(true)
+    })
+
+    it('TypeError: Network request failed', () => {
+      expect(isNetworkError(new TypeError('Network request failed'))).toBe(true)
+    })
+
+    it('TypeError without recognisable message — any TypeError is network-level', () => {
+      // A TypeError from fetch always means a network failure (HTTP errors produce
+      // resolved Responses, not rejected TypeErrors)
+      expect(isNetworkError(new TypeError('some unexpected TypeError'))).toBe(true)
+    })
+
+    it('Error with "connection refused" in message (Go backend relay)', () => {
+      expect(isNetworkError(new Error('dial tcp 127.0.0.1:6443: connect: connection refused'))).toBe(true)
+    })
+
+    it('Error with "dial tcp" in message', () => {
+      expect(isNetworkError(new Error('dial tcp: lookup kubernetes.default: no such host'))).toBe(true)
+    })
+
+    it('plain string "Failed to fetch"', () => {
+      expect(isNetworkError('Failed to fetch')).toBe(true)
+    })
+
+    it('plain string "connection refused"', () => {
+      expect(isNetworkError('connection refused')).toBe(true)
+    })
+  })
+
+  // ── False positives guard — HTTP errors are NOT network failures ──────────
+  describe('returns false for HTTP error responses (server was reachable)', () => {
+    it('HTTP 404 error string', () => {
+      expect(isNetworkError(new Error('HTTP 404 Not Found'))).toBe(false)
+    })
+
+    it('HTTP 403 forbidden', () => {
+      expect(isNetworkError(new Error('403 forbidden'))).toBe(false)
+    })
+
+    it('HTTP 500 internal server error', () => {
+      expect(isNetworkError(new Error('500 internal server error'))).toBe(false)
+    })
+
+    it('generic runtime Error (not a network error)', () => {
+      expect(isNetworkError(new Error('JSON parse error'))).toBe(false)
+    })
+
+    it('RangeError is not a network error', () => {
+      expect(isNetworkError(new RangeError('Invalid value'))).toBe(false)
+    })
+  })
+
+  // ── Edge cases ─────────────────────────────────────────────────────────────
+  describe('edge cases', () => {
+    it('null returns false', () => {
+      expect(isNetworkError(null)).toBe(false)
+    })
+
+    it('undefined returns false', () => {
+      expect(isNetworkError(undefined)).toBe(false)
+    })
+
+    it('empty string returns false', () => {
+      expect(isNetworkError('')).toBe(false)
+    })
+
+    it('number returns false', () => {
+      expect(isNetworkError(503)).toBe(false)
     })
   })
 })

--- a/web/src/lib/errors.ts
+++ b/web/src/lib/errors.ts
@@ -109,3 +109,45 @@ export function translateApiError(message: string, context?: TranslateContext): 
   // No known pattern — return original so advanced operators see the raw message
   return message
 }
+
+/**
+ * Returns true when an error value represents a network-level failure
+ * (server unreachable, DNS resolution failed, TCP connection refused) as
+ * opposed to an HTTP error response where the server _was_ reachable.
+ *
+ * Recognises:
+ *   - `TypeError: Failed to fetch`   (browser network error, server not responding)
+ *   - `TypeError: Load failed`        (Safari equivalent of "Failed to fetch")
+ *   - `TypeError: NetworkError`       (Firefox)
+ *   - "connection refused"            (Go backend surfacing k8s API error)
+ *   - "dial tcp"                      (Go backend TCP dial failure)
+ *
+ * Returns false for HTTP error responses (4xx/5xx) — those indicate the
+ * server was reachable but returned an error, which is NOT the same as
+ * the cluster being completely unreachable.
+ *
+ * Spec: .specify/specs/issue-582/spec.md O5
+ */
+export function isNetworkError(err: unknown): boolean {
+  if (err == null) return false
+
+  // Check the error message string
+  const msg = err instanceof Error ? err.message : String(err)
+  const lower = msg.toLowerCase()
+
+  // Browser fetch API network errors
+  if (lower.includes('failed to fetch')) return true
+  if (lower.includes('load failed')) return true
+  if (lower.includes('networkerror')) return true
+  if (lower.includes('network request failed')) return true
+
+  // Go backend surfacing k8s API connection errors
+  if (lower.includes('connection refused')) return true
+  if (lower.includes('dial tcp')) return true
+
+  // Explicit TypeError with no status code means network-level failure
+  // (HTTP errors produce Response objects, not TypeErrors)
+  if (err instanceof TypeError) return true
+
+  return false
+}

--- a/web/src/tokens.css
+++ b/web/src/tokens.css
@@ -144,6 +144,8 @@
   --color-warning: #f59e0b;
   /* Warning banner background — low-opacity amber tint for unsupported-version banner */
   --color-warning-bg: rgba(245, 158, 11, 0.12);
+  /* Error banner background — low-opacity red tint for cluster-unreachable banner */
+  --color-error-bg: rgba(244, 63, 94, 0.12);
 
   /* DAG forEach annotation */
   --dag-foreach-color: var(--color-text-faint);
@@ -275,6 +277,8 @@
   --color-warning: #d97706;
   /* Warning banner background — low-opacity amber tint, light mode */
   --color-warning-bg: rgba(217, 119, 6, 0.10);
+  /* Error banner background — low-opacity red tint, light mode */
+  --color-error-bg: rgba(225, 29, 72, 0.10);
 
   /* DAG forEach annotation */
   --dag-foreach-color: var(--color-text-faint);


### PR DESCRIPTION
## Summary

When `getCapabilities()` fails with a network-level error on startup, a dismissible banner appears:
> Cannot reach cluster — check that kro-ui is running and the kubeconfig context is reachable.

The banner includes a **Retry** button (`window.location.reload()`) and a dismiss (✕) button. It resets on context switch.

**Before**: first-time users arriving with an unreachable cluster saw a page full of per-widget "failed to fetch" error fragments.
**After**: a single, clear, actionable banner explains the situation.

## Changes

- `web/src/lib/errors.ts` — new `isNetworkError(err: unknown): boolean` export. Detects browser `TypeError: Failed to fetch` / `Load failed` / `NetworkError` and Go-relayed k8s API errors (`connection refused`, `dial tcp`). HTTP errors (4xx/5xx) correctly return `false` — the server was reachable.
- `web/src/lib/errors.test.ts` — 20 new `isNetworkError` unit tests (true/false positives + edge cases)
- `web/src/components/Layout.tsx` — tracks network failures from `listContexts` + `getCapabilities` initial probes; shows `.layout__cluster-unreachable` banner when the capabilities probe fails with a network error
- `web/src/components/Layout.css` — `.layout__cluster-unreachable` banner styles
- `web/src/tokens.css` — `--color-error-bg` token (dark + light mode)

## Design doc

Updated `docs/design/30-health-system.md`: moved "Error state for unreachable cluster on initial load" from 🔲 Future to ✅ Present.

## Spec

`.specify/specs/issue-582/spec.md` (new)

Closes #582