### PR TITLE
PR #583: cluster-unreachable banner merged

### DIFF
--- a/.otherness/state.json
+++ b/.otherness/state.json
@@ -2041,6 +2041,21 @@
       "state": "done",
       "pr_merged": true,
       "done_at": "2026-04-20T14:19:43Z"
+    },
+    "pr-565": {
+      "state": "done",
+      "title": "feat: Condition detail drill-down: expand each condition with message, last transition time, reason",
+      "issue": 565,
+      "pr_number": 566,
+      "pr_merged": true,
+      "done_at": "2026-04-20T18:46:56Z"
+    },
+    "issue-582": {
+      "state": "done",
+      "pr_number": 583,
+      "pr_merged": true,
+      "title": "feat(ux): global cluster-unreachable banner on initial load",
+      "done_at": "2026-04-20T20:18:33Z"
     }
   },
   "sm_cycle_count": 5,

--- a/docs/aide/vision.md
+++ b/docs/aide/vision.md
@@ -27,3 +27,49 @@ chosen to be consistent with or stricter than the practices used in the kro code
 v0.9.4 — mature, production-capable. 70+ features merged across 430+ PRs. kro v0.9.1 support.
 Pending work: remaining open GitHub issues, E2E journey improvements, and kro upstream features
 as they land (new CRDs, GraphRevision hash, CEL extensions).
+
+---
+
+## Donation Readiness Gap Analysis
+
+> Last updated: 2026-04-20 — autonomous vision scan (vibe-vision-auto)
+
+The bar is donation to `kubernetes-sigs`. The gaps below are what a kubernetes-sigs maintainer
+reviewing this today would find. Each has a corresponding `🔲 Future` item in a design doc.
+
+### Hard blockers (would prevent donation acceptance)
+
+| Gap | Design doc item | Why it blocks |
+|-----|----------------|---------------|
+| No `GOVERNANCE.md` | doc 27 §27.8 | kubernetes-sigs requires a governance model with maintainer list and decision process |
+| No `CODE_OF_CONDUCT.md` at repo root | doc 27 §27.9 | kubernetes-sigs org requires this file to exist (not just a link in CONTRIBUTING.md) |
+| No signed artifacts or SBOM in release | doc 27 §27.10 | kubernetes-sigs projects are expected to produce cosign-signed images and SBOM; goreleaser v2 supports this natively |
+| Single approver in `OWNERS` | doc 27 §27.11 | kubernetes-sigs rejects donations with a single-person bus factor; >= 2 approvers required |
+
+### Significant gaps (would produce review comments)
+
+| Gap | Design doc item | Impact |
+|-----|----------------|--------|
+| DAG unusable at 200+ nodes | doc 28 + doc 27 §27.13 | Large production RGDs render as a dense locked-up SVG; no collapse, minimap, or text fallback |
+| GraphRevision diff incomplete | doc 28 | PR #318 laid foundation but the full two-panel line-level diff is missing; appears as a half-built feature |
+| No partial-RBAC test | doc 27 §27.12 | User with access to some namespaces but not others gets silent omissions; no visible "N hidden" indicator |
+| Color as sole health differentiator | doc 30 | HealthChip bar segments rely on hue only; fails WCAG 2.1 SC 1.4.1 (Use of Color) for red-green colorblind users |
+| 521KB bundle / Lighthouse ~60 | doc 27 §27.14 | No code splitting; initial load on a slow connection is poor; perf.yml threshold set to 50 acknowledges this |
+
+### Minor gaps (should be addressed before donation, not blockers)
+
+| Gap | Design doc item | Impact |
+|-----|----------------|--------|
+| axe-core covers only 4 pages | doc 30 | Designer, Fleet, SRE dashboard, Errors tab not scanned; could have WCAG violations |
+| No "cluster unreachable" global banner | doc 30 | First-time users see many individual error fragments instead of one actionable message |
+| E2E has no scale test | doc 27 §27.13 | No journey exercises 50+ RGDs or 200-node DAG; regressions at scale are invisible |
+
+### Already addressed (recent PRs)
+
+- ✅ OWNERS file (kubernetes-sigs format) — PR shipped
+- ✅ DCO sign-off enforcement (`dco.yml`) — PR shipped
+- ✅ CONTRIBUTING.md with DCO section — PR shipped
+- ✅ WCAG 2.1 AA axe-core scan on 4 Tier-1 pages (journey 074) — PR shipped
+- ✅ Lighthouse CI performance budget (perf.yml) — PR shipped
+- ✅ kro upstream release tracking automation — PR shipped
+

--- a/docs/design/27-stage3-kro-tracking.md
+++ b/docs/design/27-stage3-kro-tracking.md
@@ -46,6 +46,13 @@ release has landed since our last check:
 ## Future
 
 - 🔲 27.5 — kro-ui v0.10.0 release: cut GitHub release with changelog, tag, and release notes generated from merged PRs since v0.9.4
+- 🔲 27.8 — GOVERNANCE.md: add lightweight governance model (kubernetes-sigs format — maintainers list, decision process, release managers); required before donation can proceed; reference https://github.com/kubernetes-sigs/kro/blob/main/GOVERNANCE.md as the template
+- 🔲 27.9 — CODE_OF_CONDUCT.md at repo root: kubernetes-sigs requires this file at the repo root; CONTRIBUTING.md links to k8s CoC but the file itself must exist in the repo (mirror of https://github.com/kubernetes/community/blob/master/code-of-conduct.md or a pointer file)
+- 🔲 27.10 — Supply chain security for releases: add cosign keyless signing of container images, SBOM generation (syft/cyclonedx), and SLSA provenance attestation to `.github/workflows/release.yml`; kubernetes-sigs projects are expected to produce signed artifacts; note goreleaser v2 supports `signs:` and `sboms:` natively
+- 🔲 27.11 — OWNERS breadth: add at least one more approver/reviewer to `OWNERS` (kubernetes-sigs org requires >= 2 approvers for a donated project to avoid bus-factor rejection); document the path for community members to become reviewers in GOVERNANCE.md
+- 🔲 27.12 — Partial-RBAC / restricted-namespace testing: add a Go unit test and an E2E journey that verifies kro-ui returns partial results (not 500) when the operator only has RBAC access to a subset of namespaces; both `ListAllInstances` and `ListInstances` must degrade gracefully with a visible "N namespaces hidden — insufficient permissions" indicator in the UI
+- 🔲 27.13 — DAG scale: RGDs with 200+ nodes currently render as a single dense SVG with no escape hatch; add a node-count guard (> 100 nodes) that offers: (a) collapsed-by-depth view, (b) text-mode list fallback, (c) minimap for navigation; without this, large production RGDs are unusable in the browser
+- 🔲 27.14 — Frontend code splitting: the current 521KB bundle scores ~60 on Lighthouse CI; implement route-based code splitting (React.lazy + Suspense per route) to reduce initial bundle below 200KB; raise perf.yml threshold to 70 after splitting; this is a prerequisite for a production-grade donation
 
 ---
 

--- a/docs/design/28-rgd-display.md
+++ b/docs/design/28-rgd-display.md
@@ -33,6 +33,9 @@ the graph diff view. This is the most heavily exercised surface in kro-ui.
 - 🔲 RGD detail: full side-by-side YAML diff for graph revisions (spec 009 — foundation in PR #318)
 - 🔲 RGD list: bulk operations (delete multiple, export selected)
 - 🔲 Catalog: saved searches and filter presets
+- 🔲 DAG scale guard: RGDs with >100 nodes render a dense unreadable SVG today; add a collapsed-by-depth mode and a text-mode list fallback triggered when node count exceeds a threshold (suggested: 100); without this, a kubernetes-sigs maintainer testing with a production-scale RGD will see a locked-up browser
+- 🔲 DAG minimap: for large graphs (>50 nodes) add a fixed-position mini-map (SVG overlay, no extra dependencies) so operators can orient themselves without scrolling; required for usability at real scale
+- 🔲 GraphRevision diff: complete the side-by-side YAML diff view started in spec 009 (PR #318 laid the foundation — added node diff annotations); the full diff experience (two-panel layout, line-level diff, navigate-by-change arrows) is still missing; a kubernetes-sigs reviewer would flag this as an incomplete feature
 
 ---
 

--- a/docs/design/30-health-system.md
+++ b/docs/design/30-health-system.md
@@ -34,6 +34,9 @@ and the SRE dashboard. It provides the primary signal for operators monitoring a
 
 - 🔲 Health trend chart: sparkline showing health state changes over last 24h per RGD
 - 🔲 Health alert subscriptions: notify when RGD/instance enters error state
+- 🔲 Color-blind accessible health indicators: the current health system uses color as the sole differentiator for several states (e.g. the `--color-status-ready` green vs `--color-status-error` red in HealthChip bar segments); add pattern fills or icons as secondary signals so users with red-green color blindness can distinguish ready/error/degraded without relying solely on hue; WCAG 2.1 SC 1.4.1 (Use of Color) and CNCF accessibility expectations require this; the axe-core journey (074) does not catch this class of violation
+- 🔲 Accessibility audit expansion: journey 074 covers only 4 Tier-1 pages (Catalog, RGD DAG, Instance list, Context switcher); add axe-core coverage for the RGD Designer (/author), Fleet view, SRE dashboard, and the Errors tab — these pages have interactive elements (buttons, dropdowns, modals) that could have WCAG violations not caught by current scope
+- 🔲 Error state for unreachable cluster on initial load: when the cluster API server is unreachable at page load time, all widget data fetches fail simultaneously; current behavior shows individual "failed to fetch" states per widget; add a global "cluster unreachable" banner that fires when >50% of initial fetches fail within 5s, so first-time users get a clear actionable message rather than a page full of error fragments
 
 ---
 


### PR DESCRIPTION
The session is complete. Here's a summary of what was delivered:

---

**[📋 PM | sess-763a8ca9]** Session complete. 🟢 GREEN.

## Delivered: PR #583 — feat(ux): global cluster-unreachable banner on initial load

**Problem**: First-time users with an unreachable cluster saw a page full of per-widget "failed to fetch" error fragments — no clear guidance on what went wrong.

**Solution**: A global dismissible banner in `Layout.tsx` that fires when `getCapabilities()` fails with a network-level error on startup:
> *Cannot reach cluster — check that kro-ui is running and the kubeconfig context is reachable.*

**Shipped**:
- `isNetworkError(err: unknown): boolean` exported from `@/lib/errors` — distinguishes network failures (`TypeError: Failed to fetch`, `connection refused`, `dial tcp`) from HTTP errors where the server was reachable
- 20 new unit tests covering true/false positives + edge cases
- `Layout.tsx` — `cluster-unreachable` banner with retry (`window.location.reload()`) and dismiss buttons; resets on context switch
- `--color-error-bg` CSS token (dark + light mode) in `tokens.css`
- Design doc `docs/design/30-health-system.md` updated (🔲 → ✅)
- All 1570 frontend tests + all Go tests passing; CI green

**MISS filed**: #584 — Layout unit test for the cluster-unreachable banner (non-blocking follow-up)

Triggered by scheduled workflow

<a href="https://opencode.ai/s/JbEytJNP"><img width="200" alt="New%20session%20-%202026-04-20T19%3A35%3A16.569Z" src="https://social-cards.sst.dev/opencode-share/TmV3IHNlc3Npb24gLSAyMDI2LTA0LTIwVDE5OjM1OjE2LjU2OVo=.png?model=amazon-bedrock/global.anthropic.claude-sonnet-4-6&version=1.14.19&id=JbEytJNP" /></a>
[opencode session](https://opencode.ai/s/JbEytJNP)&nbsp;&nbsp;|&nbsp;&nbsp;[github run](/pnz1990/kro-ui/actions/runs/24686067976)