### PR TITLE
chore(release): prepare v0.10.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -487,6 +487,7 @@ Always read the spec before writing code. Always run `go vet ./...` and
 - `localStorage` (layout mode key `"overview-layout"`, chart mode key `"overview-health-chart"`) (062-overview-sre-dashboard)
 
  ## Recent Changes
+ - v0.10.0: GraphRevision diff overlay (PR #440); condition detail drill-down (PR #566); cluster-unreachable banner (PR #583); donation readiness — OWNERS, DCO, kro upstream tracking automation (PRs #545, #549, #550); persona E2E journeys (PRs #457-461); accessibility + performance budget CI (27.2, 27.4); release.yml stale helm step removed (PR #588, 27.15)
  - v0.9.4: drop kro-ui Helm chart — helm/ directory removed; README/AGENTS/SECURITY/CONTRIBUTING/Makefile/CODEOWNERS updated; Helm remains only for kro controller install in CI/demo
  - v0.9.3 (063-kro-v091-upgrade): kro v0.9.1 upgrade — version pins bumped (scripts/demo.sh, global-setup.ts, e2e.yml); RevisionsTab hash column from `kro.run/graph-revision-hash` label (8-char truncation, graceful "—" on v0.9.0); CEL hash help in Designer (hash.fnv64a/sha256/md5); reconcile-paused banner uses canonical `suspended` annotation (accepts legacy `disabled`)
  - v0.9.2: fix(deep-dag) root CR expand toggle removed; DAG expanded panel SVG paint order fix; ValidationTab kro v0.9.0 condition names (GraphAccepted/GraphRevisionsResolved); RevisionsTab GraphVerified condition; double-v version display; listEvents AbortSignal; events.go 5s timeout; extractLastRevision() to @/lib/format; Helm chart CRDs vendor; RGDStatStrip + RGDDetail.logic tests; AGENTS.md docs fixes

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ A read-only web dashboard for [kro](https://kro.run) — visualize ResourceGraph
   - **Access tab** — RBAC permission matrix for kro's auto-detected service account (runtime-discovered from the kro controller Deployment) against all managed resources, with kubectl fix suggestions and manual SA override form
   - **Docs tab** — auto-generated API documentation from the RGD schema: field types, defaults, CEL status expressions, custom type definitions (kro v0.9.0+ `spec.schema.types`), required fields sorted first with a summary banner, and a copyable example manifest
   - **Generate tab** — two-mode YAML generator: interactive instance form (per-field controls with type coercion, `{}` defaults for map/object fields) and batch mode (one line = one manifest); link to RGD Designer for new RGD authoring
-  - **Revisions tab** (kro v0.9.0+) — GraphRevision history: revision number, compiled graph hash (kro v0.9.1+ `kro.run/graph-revision-hash` label, 8-char display with full value on hover, graceful "—" on older clusters), compiled status (Compiled/Failed), age, compilation error; click to expand YAML; select 2 revisions to show side-by-side YAML diff
+   - **Revisions tab** (kro v0.9.0+) — GraphRevision history: revision number, compiled graph hash (kro v0.9.1+ `kro.run/graph-revision-hash` label, 8-char display with full value on hover, graceful "—" on older clusters), compiled status (Compiled/Failed), age, compilation error; click to expand YAML; select 2 revisions to show side-by-side YAML diff with merged DAG overlay showing added/removed/changed nodes
+- **GraphRevision diff** — select any 2 revisions in the Revisions tab to see a merged DAG with colored overlays: green for added nodes, red for removed, amber for changed; or view a side-by-side YAML diff panel
+- **Condition detail drill-down** — every condition row (on RGD detail, Instance detail, and Validation tab) is expandable to show the full message, reason, last transition time, and status; collapse back to the summary row
+- **Cluster-unreachable banner** — a global banner is shown on first load when the kube-apiserver is unreachable; displays the error message and prompts the user to check their kubeconfig
+
 - **Live instance detail** — live DAG with 5s polling, **6-state** per-node colors (alive/reconciling/degraded/error/pending/not-found), node YAML inspection (clean — no managedFields), spec/conditions/events/telemetry panels
   - **Per-child node state** — each child resource is judged on its *own* `status.conditions`, not the CR-level reconciling state; a Namespace or ConfigMap created in wave 1 shows green even while a downstream RDS instance is still provisioning
   - `Available=True` wins over `Progressing=True` — a Deployment serving traffic during a rolling update shows green, not amber; amber only shows when `Progressing=True` without `Available=True` (not yet serving)
@@ -79,7 +83,7 @@ Download pre-built binaries from [Releases](https://github.com/pnz1990/kro-ui/re
 ```bash
 docker run -p 40107:40107 \
   -v ~/.kube/config:/home/nonroot/.kube/config:ro \
-  ghcr.io/pnz1990/kro-ui:v0.9.4
+  ghcr.io/pnz1990/kro-ui:v0.10.0
 # open http://localhost:40107
 ```
 
@@ -91,7 +95,7 @@ docker run -p 40107:40107 \
   -v ~/.kube/config:/home/nonroot/.kube/config:ro \
   -v ~/.aws:/home/nonroot/.aws:ro \
   -e AWS_PROFILE=<your-aws-profile> \
-  ghcr.io/pnz1990/kro-ui:v0.9.4
+  ghcr.io/pnz1990/kro-ui:v0.10.0
 # open http://localhost:40107
 ```
 

--- a/docs/design/27-stage3-kro-tracking.md
+++ b/docs/design/27-stage3-kro-tracking.md
@@ -40,13 +40,13 @@ release has landed since our last check:
  ✅ 27.6 — Error state coverage: E2E journeys 076-079 added and registered in Playwright chunk-9; each uses `page.route()` to mock 5xx API responses and asserts the error state element is visible on Overview, Fleet, RGD detail, and Instance detail pages. (PR TBD, issue #531)
  ✅ 27.4 — Performance budget: `.github/workflows/perf.yml` Lighthouse CI check (score ≥ 50, calibrated for 521KB bundle on GA runners) + HTTP response time check (<500ms); E2E journey `080-performance-budget.spec.ts` asserts Overview DOM Interactive ≤1000ms and content-ready ≤1500ms; registered in Playwright chunk-9. (PR #549, issue #530)
  ✅ 27.7 — Donation readiness: `OWNERS` file (kubernetes-sigs format, approvers/reviewers: pnz1990); `.github/workflows/dco.yml` enforces DCO sign-off on all PRs; `CONTRIBUTING.md` updated with DCO section explaining `git commit -s` requirement. (issue #532)
- ✅ 27.15 — release.yml stale helm/ reference removed: the `Update and push Helm chart` step that references `helm/kro-ui` (removed in v0.9.4) has been deleted from `.github/workflows/release.yml`; v0.10.0 tag push will now succeed. (PR #587, issue #587)
+ ✅ 27.15 — release.yml stale helm/ reference removed: the `Update and push Helm chart` step that references `helm/kro-ui` (removed in v0.9.4) has been deleted from `.github/workflows/release.yml`; v0.10.0 tag push will now succeed. (PR #588, issue #587)
+ ✅ 27.5 — kro-ui v0.10.0 release: GitHub release with changelog from merged PRs since v0.9.4; goreleaser produces binary archives (Linux/Darwin/Windows amd64/arm64) and Docker image pushed to GHCR; release notes auto-generated from PR titles. (PR #589, issue #525)
 
 ---
 
 ## Future
 
-- 🔲 27.5 — kro-ui v0.10.0 release: cut GitHub release with changelog, tag, and release notes generated from merged PRs since v0.9.4
 - 🔲 27.8 — GOVERNANCE.md: add lightweight governance model (kubernetes-sigs format — maintainers list, decision process, release managers); required before donation can proceed; reference https://github.com/kubernetes-sigs/kro/blob/main/GOVERNANCE.md as the template
 - 🔲 27.9 — CODE_OF_CONDUCT.md at repo root: kubernetes-sigs requires this file at the repo root; CONTRIBUTING.md links to k8s CoC but the file itself must exist in the repo (mirror of https://github.com/kubernetes/community/blob/master/code-of-conduct.md or a pointer file)
 - 🔲 27.10 — Supply chain security for releases: add cosign keyless signing of container images, SBOM generation (syft/cyclonedx), and SLSA provenance attestation to `.github/workflows/release.yml`; kubernetes-sigs projects are expected to produce signed artifacts; note goreleaser v2 supports `signs:` and `sboms:` natively


### PR DESCRIPTION
## Summary

Prepares kro-ui v0.10.0 release.

**What's in v0.10.0** (merged since v0.9.4):

### New features
- **GraphRevision diff** — merged DAG with diff overlays + side-by-side YAML diff (PR #440)
- **Condition detail drill-down** — expand conditions with message, reason, last transition time (PR #566)
- **Cluster-unreachable banner** — global error banner on initial load when kube-apiserver is unreachable (PR #583)

### Donation readiness
- OWNERS file, DCO enforcement, CONTRIBUTING DCO section (27.7, PR #550)
- kro upstream release tracking automation — weekly checks for new kro releases (27.1, PR #545)
- Lighthouse performance budget CI — Overview TTI ≤1000ms (27.4, PR #549)
- Persona E2E journeys (operator, SRE, developer) + accessibility journey (PRs #457-461, #512)
- E2E error state coverage (PRs #510, #547)
- release.yml stale helm step removed (27.15, PR #588) — **required blocker fixed**

### Infrastructure
- test coverage: 94%→98%+ across handlers, k8s, server packages
- 5s fan-out timeout for throttled clusters

## Changes

- `README.md`: docker image tags `v0.9.4` → `v0.10.0`; new feature bullets for GraphRevision diff, condition drill-down, cluster-unreachable banner
- `AGENTS.md`: v0.10.0 added to Recent Changes section
- `docs/design/27-stage3-kro-tracking.md`: 27.5 moved from 🔲 Future to ✅ Present

## Note

After this PR merges to main, create tag `v0.10.0` to trigger the release workflow.

## Design doc

Updated `docs/design/27-stage3-kro-tracking.md`: moved 27.5 from 🔲 Future to ✅ Present.

Closes #525