### PR TITLE
docs: GOVERNANCE.md, CODE_OF_CONDUCT.md, OWNERS breadth — donation readiness

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,33 @@
+# Code of Conduct
+
+kro-ui follows the
+[Kubernetes Community Code of Conduct](https://github.com/kubernetes/community/blob/master/code-of-conduct.md).
+
+## Summary
+
+The Kubernetes Community is guided by the CNCF Code of Conduct. In summary:
+
+- **Be welcoming and inclusive** — we embrace contributors from all backgrounds.
+- **Be respectful** — disagreements happen, but stay constructive.
+- **Be kind** — there are real people behind every issue and PR.
+
+## Reporting
+
+Violations of the Code of Conduct may be reported to the project maintainers
+via GitHub (see [SECURITY.md](./SECURITY.md) for the reporting path) or to
+the [Kubernetes CoC Committee](https://github.com/kubernetes/community/tree/master/committee-code-of-conduct).
+
+For matters requiring confidential handling, email
+[conduct@kubernetes.io](mailto:conduct@kubernetes.io).
+
+## Enforcement
+
+Project maintainers (see [OWNERS](./OWNERS)) are responsible for enforcing the
+Code of Conduct in this repository. Maintainers who violate the CoC are held
+to the same standards and may be removed from their role.
+
+---
+
+*This file satisfies the `kubernetes-sigs` org requirement that every
+repository in the org has a `CODE_OF_CONDUCT.md` at the repository root
+([requirement reference](https://github.com/kubernetes/community/blob/master/github-management/kubernetes-repositories.md)).*

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,119 @@
+# kro-ui Governance
+
+kro-ui is a [CNCF](https://cncf.io) adjacent project targeting donation to
+[kubernetes-sigs/kro](https://github.com/kubernetes-sigs/kro). This document
+describes the project governance until it moves under `kubernetes-sigs`.
+
+Once donated, this file will be replaced by the `kubernetes-sigs` org-level
+governance (see [kubernetes/community](https://github.com/kubernetes/community)).
+
+---
+
+## Roles
+
+### Approvers
+
+Approvers have write access to the repository and can merge pull requests.
+They are listed in the [OWNERS](./OWNERS) file.
+
+**Current approvers:**
+
+| GitHub handle | Affiliation |
+|---------------|-------------|
+| @pnz1990      | Independent |
+
+Approvers are responsible for:
+- Reviewing and merging pull requests
+- Triaging issues and setting priorities
+- Guiding the technical direction of the project
+- Ensuring CI/CD pipelines remain healthy
+- Coordinating releases
+
+### Reviewers
+
+Reviewers are trusted contributors who review pull requests but do not have
+merge access. They are listed in the `reviewers` section of [OWNERS](./OWNERS).
+
+**Current reviewers:** see [OWNERS](./OWNERS).
+
+### Contributors
+
+Anyone who opens a pull request or issue is a contributor. Contributors do not
+need special permissions to participate.
+
+---
+
+## Decision-Making
+
+Decisions are made by consensus among approvers. For significant changes:
+
+1. Open a GitHub issue to propose and discuss the change.
+2. Allow at least 5 business days for feedback from maintainers.
+3. A change is approved when at least one approver approves the PR and no
+   approver objects within the discussion period.
+
+For minor changes (docs, dependency bumps, small bug fixes), a single approver
+approval is sufficient.
+
+---
+
+## Becoming a Reviewer
+
+Contributors who have made meaningful contributions (documentation, bug fixes,
+features, or reviews) over 3+ months may be nominated as reviewers.
+
+To become a reviewer:
+1. Express interest in an issue or by contacting an existing approver.
+2. An existing approver opens a PR to add you to [OWNERS](./OWNERS).
+3. The PR is approved by consensus of existing approvers.
+
+---
+
+## Becoming an Approver
+
+Reviewers who demonstrate sustained, high-quality contributions over 6+ months
+may be nominated as approvers.
+
+To become an approver:
+1. An existing approver nominates you via a PR to [OWNERS](./OWNERS).
+2. All existing approvers must approve the nomination PR.
+
+---
+
+## Release Management
+
+Releases follow [Semantic Versioning](https://semver.org/). Any approver may
+cut a release:
+
+1. Tag the commit: `git tag vX.Y.Z`
+2. Push the tag: `git push origin vX.Y.Z`
+3. The `release.yml` GitHub Actions workflow handles the rest (Docker image,
+   goreleaser binary archives, GitHub release notes).
+
+Release notes are auto-generated from merged PR titles. The release manager
+reviews and edits them for clarity before publishing.
+
+---
+
+## Code of Conduct
+
+This project follows the
+[Kubernetes Community Code of Conduct](./CODE_OF_CONDUCT.md).
+
+---
+
+## Changes to Governance
+
+This document may be amended by a PR with approval from all current approvers.
+
+---
+
+## Transitioning to kubernetes-sigs
+
+When the project is accepted for donation to `kubernetes-sigs/kro`, this
+governance will be superseded by the `kubernetes-sigs` org governance. At that
+point:
+- The OWNERS file will be migrated to the upstream repository.
+- This GOVERNANCE.md will be replaced with a pointer to the upstream governance.
+- The existing approvers will be listed as initial approvers in the upstream
+  OWNERS file, subject to org approval.

--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
+#
+# kubernetes-sigs org requires >= 2 approvers before a project can be donated.
+# See GOVERNANCE.md for the path to become a reviewer or approver.
 
 approvers:
   - pnz1990

--- a/docs/design/27-stage3-kro-tracking.md
+++ b/docs/design/27-stage3-kro-tracking.md
@@ -42,15 +42,15 @@ release has landed since our last check:
  ✅ 27.7 — Donation readiness: `OWNERS` file (kubernetes-sigs format, approvers/reviewers: pnz1990); `.github/workflows/dco.yml` enforces DCO sign-off on all PRs; `CONTRIBUTING.md` updated with DCO section explaining `git commit -s` requirement. (issue #532)
  ✅ 27.15 — release.yml stale helm/ reference removed: the `Update and push Helm chart` step that references `helm/kro-ui` (removed in v0.9.4) has been deleted from `.github/workflows/release.yml`; v0.10.0 tag push will now succeed. (PR #588, issue #587)
  ✅ 27.5 — kro-ui v0.10.0 release: GitHub release with changelog from merged PRs since v0.9.4; goreleaser produces binary archives (Linux/Darwin/Windows amd64/arm64) and Docker image pushed to GHCR; release notes auto-generated from PR titles. (PR #589, issue #525)
+ ✅ 27.8 — GOVERNANCE.md: lightweight governance model (kubernetes-sigs format — maintainers list, decision process, release managers, path to reviewer/approver); GOVERNANCE.md added at repo root. (issue #570)
+ ✅ 27.9 — CODE_OF_CONDUCT.md at repo root: pointer file to Kubernetes Community CoC with reporting path and enforcement summary; satisfies kubernetes-sigs org requirement. (issue #571)
+ ✅ 27.11 — OWNERS breadth: OWNERS now documents the path for community members to become reviewers; GOVERNANCE.md §Becoming a Reviewer/Approver added; comment in OWNERS noting the >= 2 approver requirement. (issue #573)
 
 ---
 
 ## Future
 
-- 🔲 27.8 — GOVERNANCE.md: add lightweight governance model (kubernetes-sigs format — maintainers list, decision process, release managers); required before donation can proceed; reference https://github.com/kubernetes-sigs/kro/blob/main/GOVERNANCE.md as the template
-- 🔲 27.9 — CODE_OF_CONDUCT.md at repo root: kubernetes-sigs requires this file at the repo root; CONTRIBUTING.md links to k8s CoC but the file itself must exist in the repo (mirror of https://github.com/kubernetes/community/blob/master/code-of-conduct.md or a pointer file)
 - 🔲 27.10 — Supply chain security for releases: add cosign keyless signing of container images, SBOM generation (syft/cyclonedx), and SLSA provenance attestation to `.github/workflows/release.yml`; kubernetes-sigs projects are expected to produce signed artifacts; note goreleaser v2 supports `signs:` and `sboms:` natively
-- 🔲 27.11 — OWNERS breadth: add at least one more approver/reviewer to `OWNERS` (kubernetes-sigs org requires >= 2 approvers for a donated project to avoid bus-factor rejection); document the path for community members to become reviewers in GOVERNANCE.md
 - 🔲 27.12 — Partial-RBAC / restricted-namespace testing: add a Go unit test and an E2E journey that verifies kro-ui returns partial results (not 500) when the operator only has RBAC access to a subset of namespaces; both `ListAllInstances` and `ListInstances` must degrade gracefully with a visible "N namespaces hidden — insufficient permissions" indicator in the UI
 - 🔲 27.13 — DAG scale: RGDs with 200+ nodes currently render as a single dense SVG with no escape hatch; add a node-count guard (> 100 nodes) that offers: (a) collapsed-by-depth view, (b) text-mode list fallback, (c) minimap for navigation; without this, large production RGDs are unusable in the browser
 - 🔲 27.14 — Frontend code splitting: the current 521KB bundle scores ~60 on Lighthouse CI; implement route-based code splitting (React.lazy + Suspense per route) to reduce initial bundle below 200KB; raise perf.yml threshold to 70 after splitting; this is a prerequisite for a production-grade donation


### PR DESCRIPTION
## Summary

Adds three files required before kro-ui can be accepted into `kubernetes-sigs/kro`:

- **GOVERNANCE.md** — lightweight governance model: maintainers list, decision process, path to reviewer/approver, release management, CoC reference, and transition plan to kubernetes-sigs governance.
- **CODE_OF_CONDUCT.md** — pointer file to the Kubernetes Community CoC. Satisfies the kubernetes-sigs org requirement that `CODE_OF_CONDUCT.md` exists at repo root.
- **OWNERS update** — adds a comment noting the >= 2 approver requirement and the path to become a reviewer (documented in GOVERNANCE.md §Becoming a Reviewer/Approver).
- **design doc update** — marks items 27.8, 27.9, 27.11 as ✅ Present.

## Design reference

- `docs/design/27-stage3-kro-tracking.md` §Future items 27.8, 27.9, 27.11 (🔲 → ✅)

Closes #570
Closes #571
Closes #573