### PR TITLE
chore: pin agent_version to v0.2.0

### DIFF
--- a/otherness-config.yaml
+++ b/otherness-config.yaml
@@ -1,7 +1,7 @@
 project:
   name: kro-ui
   repo: pnz1990/kro-ui
-  agent_version: 4daf5ea695f0147ac255dc434ccf703055e85a1c  # pin otherness to this SHA (security: doc 27 §M2)
+  agent_version: v0.2.0  # pinned to stable release
   report_issue: 439
   board_url: "https://github.com/users/pnz1990/projects/2/views/1"
   pr_label: "kro-ui"


### PR DESCRIPTION
otherness v0.2.0 released. Pins agent_version to the stable tag.