### PR TITLE
feat(catalog): saved filter presets — save, restore, delete filter combinations

### DIFF
--- a/.specify/specs/issue-535/spec.md
+++ b/.specify/specs/issue-535/spec.md
@@ -1,0 +1,53 @@
+# spec: issue-535 — Catalog saved searches and filter presets
+
+## Design reference
+- **Design doc**: `docs/design/28-rgd-display.md`
+- **Section**: `§ Future`
+- **Implements**: Catalog: saved searches and filter presets (🔲 → ✅)
+
+---
+
+## Zone 1 — Obligations (falsifiable)
+
+**O1**: The Catalog toolbar MUST include a "Save filter" button that is visible when any
+filter is active (searchQuery non-empty OR activeLabels non-empty OR statusFilter !== 'all'
+OR sortOption !== 'name'). When no filter is active the button is hidden.
+
+**O2**: Clicking "Save filter" MUST open a small inline name-input form (not a modal) where
+the user types a preset name and confirms. On confirm the preset is saved to `localStorage`
+under key `"catalog-filter-presets"` as a JSON array.
+
+**O3**: A "Presets" dropdown MUST appear in the toolbar that lists all saved presets by name.
+Clicking a preset name MUST restore all five filter fields:
+`searchQuery`, `activeLabels`, `sortOption`, `statusFilter`.
+
+**O4**: Each preset in the dropdown MUST have a delete (×) button. Clicking it removes only
+that preset from `localStorage` without affecting other presets or current filter state.
+
+**O5**: Presets MUST persist across page reloads via `localStorage` (Constitution §V allows
+localStorage; spec 062 precedent: `"overview-layout"` and `"overview-health-chart"` keys).
+
+**O6**: The presets dropdown MUST be keyboard-accessible: `Tab` focuses it, `Enter`/`Space`
+opens it, `Arrow` keys navigate items, `Escape` closes it.
+
+**O7**: No new npm or Go dependencies may be introduced.
+
+**O8**: Maximum 20 presets. When the limit is reached, "Save filter" is disabled and shows
+tooltip "Maximum 20 presets reached — delete one first".
+
+---
+
+## Zone 2 — Implementer's judgment
+
+- Dropdown implementation: custom CSS dropdown vs native `<select>` — custom recommended for O4/O6
+- Preset save form location: inline below toolbar vs popover — inline is simpler and avoids portal
+- Preset ordering: most-recently-saved first or alphabetical — most-recently-saved first
+- Empty presets state: "No saved presets" placeholder in dropdown
+
+---
+
+## Zone 3 — Scoped out
+
+- Server-side preset sync (localStorage only)
+- Preset sharing (URL encoding of presets is a separate future item)
+- Preset reordering via drag-and-drop

--- a/docs/design/28-rgd-display.md
+++ b/docs/design/28-rgd-display.md
@@ -28,10 +28,10 @@ the graph diff view. This is the most heavily exercised surface in kro-ui.
 - ✅ Graph Revisions tab: revision history, compiled status, age, expand YAML (PR #314, 2026-04)
 - ✅ Overview SRE dashboard: 7-widget single-cluster health view (PR #405, 2026-04)
 - ✅ RGD Catalog bulk export: multi-select + export selected RGDs as clean multi-document YAML (🔲→✅ 2026-04)
+- ✅ Catalog saved searches and filter presets: save/restore/delete filter combinations via localStorage (🔲→✅ 2026-04)
 
 ## Future (🔲)
 
-- 🔲 Catalog: saved searches and filter presets
 - 🔲 DAG scale guard: RGDs with >100 nodes render a dense unreadable SVG today; add a collapsed-by-depth mode and a text-mode list fallback triggered when node count exceeds a threshold (suggested: 100); without this, a kubernetes-sigs maintainer testing with a production-scale RGD will see a locked-up browser
 - 🔲 DAG minimap: for large graphs (>50 nodes) add a fixed-position mini-map (SVG overlay, no extra dependencies) so operators can orient themselves without scrolling; required for usability at real scale
 - 🔲 GraphRevision diff: complete the side-by-side YAML diff view started in spec 009; PR #318 laid the foundation (node diff annotations); the full diff experience is still missing from all three DAG components (DAGGraph, LiveDAG, DeepDAG) — the two-panel line-level diff view with navigate-by-change arrows is not implemented; the `RGDDiffView` component exists but is only wired to the Revisions tab for static RGD comparison, not for the live instance DAG overlay; a kubernetes-sigs reviewer would flag this as a prominently advertised but incomplete feature

--- a/web/src/pages/Catalog.css
+++ b/web/src/pages/Catalog.css
@@ -362,3 +362,210 @@
   background: var(--color-surface-2);
   color: var(--color-text);
 }
+
+/* ── spec issue-535: filter presets ─────────────────────────────── */
+
+/* Presets toggle button */
+.catalog__presets-btn {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+  font-family: var(--font-sans);
+  padding: 5px 12px;
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.catalog__presets-btn:hover,
+.catalog__presets-btn--open {
+  background: var(--color-surface-2);
+  border-color: var(--color-border-focus);
+  color: var(--color-text);
+}
+
+/* Wrapper — position relative so dropdown anchors to it */
+.catalog__presets-wrap {
+  position: relative;
+}
+
+/* Dropdown list */
+.catalog__presets-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 100;
+  min-width: 200px;
+  max-width: 320px;
+  max-height: 320px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-dropdown);
+  padding: 4px 0;
+}
+
+/* Empty state text */
+.catalog__presets-empty {
+  font-size: 0.8125rem;
+  color: var(--color-text-faint);
+  padding: 8px 14px;
+  margin: 0;
+  font-family: var(--font-sans);
+}
+
+/* Each preset row */
+.catalog__preset-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px 2px 4px;
+}
+
+.catalog__preset-item:hover {
+  background: var(--color-surface-3);
+}
+
+/* Apply preset button — takes remaining space */
+.catalog__preset-apply {
+  flex: 1;
+  text-align: left;
+  background: transparent;
+  border: none;
+  color: var(--color-text);
+  font-size: 0.875rem;
+  font-family: var(--font-sans);
+  padding: 6px 8px;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.catalog__preset-apply:hover {
+  color: var(--color-primary-text);
+}
+
+/* Delete (×) button */
+.catalog__preset-delete {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  color: var(--color-text-faint);
+  font-size: 1rem;
+  line-height: 1;
+  padding: 2px 6px;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.catalog__preset-delete:hover {
+  color: var(--color-error);
+  background: var(--color-surface);
+}
+
+/* "Save filter" button */
+.catalog__save-filter-btn {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+  font-family: var(--font-sans);
+  padding: 5px 12px;
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.catalog__save-filter-btn:hover:not(:disabled) {
+  background: var(--color-surface-2);
+  border-color: var(--color-primary);
+  color: var(--color-primary-text);
+}
+
+.catalog__save-filter-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Inline save-preset form (shown below toolbar) */
+.catalog__save-form {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  padding: 8px 12px;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  flex-wrap: wrap;
+}
+
+.catalog__save-form-label {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
+  white-space: nowrap;
+}
+
+.catalog__save-form-input {
+  flex: 1;
+  min-width: 140px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  padding: 5px 10px;
+  outline: none;
+  transition: border-color var(--transition-fast);
+}
+
+.catalog__save-form-input:focus {
+  border-color: var(--color-border-focus);
+}
+
+.catalog__save-form-confirm {
+  background: var(--color-primary);
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--color-on-primary);
+  font-size: 0.875rem;
+  font-family: var(--font-sans);
+  font-weight: 500;
+  padding: 5px 14px;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.catalog__save-form-confirm:hover:not(:disabled) {
+  background: var(--color-primary-hover);
+}
+
+.catalog__save-form-confirm:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.catalog__save-form-cancel {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+  font-family: var(--font-sans);
+  padding: 4px 12px;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.catalog__save-form-cancel:hover {
+  background: var(--color-surface);
+  color: var(--color-text);
+}

--- a/web/src/pages/Catalog.test.tsx
+++ b/web/src/pages/Catalog.test.tsx
@@ -6,6 +6,7 @@ import Catalog from './Catalog'
 vi.mock('@/lib/api', () => ({
   listRGDs: vi.fn(),
   listInstances: vi.fn(),
+  getRGD: vi.fn(),
 }))
 
 import { listRGDs, listInstances } from '@/lib/api'
@@ -461,5 +462,122 @@ describe('Catalog', () => {
       expect(screen.getByTestId('catalog-card-broken')).toBeInTheDocument()
     })
     expect(screen.getByTestId('catalog-status-all')).toHaveAttribute('aria-pressed', 'true')
+  })
+})
+
+// ── spec issue-535: filter presets ────────────────────────────────────────────
+
+describe('Catalog filter presets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    mockedListInstances.mockResolvedValue({ items: [], metadata: {} })
+    mockedListRGDs.mockResolvedValue({
+      items: [makeRGD('alpha', 'Alpha'), makeRGD('beta', 'Beta')],
+      metadata: {},
+    })
+  })
+
+  it('shows "Save filter" button only when a filter is active', async () => {
+    const user = userEvent.setup()
+    renderCatalog()
+    await waitFor(() => expect(screen.getByTestId('catalog-card-alpha')).toBeInTheDocument())
+
+    // No filter active — button should be absent
+    expect(screen.queryByTestId('catalog-save-filter')).toBeNull()
+
+    // Activate a filter
+    const statusErrors = screen.getByTestId('catalog-status-errors')
+    await user.click(statusErrors)
+
+    // Now button should appear
+    expect(screen.getByTestId('catalog-save-filter')).toBeInTheDocument()
+  })
+
+  it('shows inline save form when "Save filter" is clicked', async () => {
+    const user = userEvent.setup()
+    renderCatalog()
+    await waitFor(() => expect(screen.getByTestId('catalog-card-alpha')).toBeInTheDocument())
+
+    await user.click(screen.getByTestId('catalog-status-errors'))
+    await user.click(screen.getByTestId('catalog-save-filter'))
+
+    expect(screen.getByTestId('catalog-save-form')).toBeInTheDocument()
+    expect(screen.getByTestId('catalog-preset-name-input')).toBeInTheDocument()
+  })
+
+  it('saves a preset and shows it in the presets dropdown', async () => {
+    const user = userEvent.setup()
+    renderCatalog()
+    await waitFor(() => expect(screen.getByTestId('catalog-card-alpha')).toBeInTheDocument())
+
+    await user.click(screen.getByTestId('catalog-status-errors'))
+    await user.click(screen.getByTestId('catalog-save-filter'))
+
+    const input = screen.getByTestId('catalog-preset-name-input')
+    await user.type(input, 'errors only')
+    await user.click(screen.getByTestId('catalog-preset-save-confirm'))
+
+    // Form should be dismissed
+    expect(screen.queryByTestId('catalog-save-form')).toBeNull()
+
+    // Open presets dropdown
+    await user.click(screen.getByTestId('catalog-presets-toggle'))
+    expect(screen.getByTestId('catalog-presets-dropdown')).toBeInTheDocument()
+    expect(screen.getByText('errors only')).toBeInTheDocument()
+  })
+
+  it('applies a saved preset (restores all filter fields)', async () => {
+    // Pre-seed localStorage with a preset
+    const preset = {
+      id: 'p1',
+      name: 'ready only',
+      searchQuery: '',
+      activeLabels: [],
+      sortOption: 'newest',
+      statusFilter: 'ready',
+    }
+    localStorage.setItem('catalog-filter-presets', JSON.stringify([preset]))
+
+    const user = userEvent.setup()
+    renderCatalog()
+    await waitFor(() => expect(screen.getByTestId('catalog-card-alpha')).toBeInTheDocument())
+
+    // Open presets
+    await user.click(screen.getByTestId('catalog-presets-toggle'))
+    // Click apply
+    const applyBtn = screen.getByTestId(`catalog-preset-apply-p1`)
+    await user.click(applyBtn)
+
+    // Dropdown should close
+    expect(screen.queryByTestId('catalog-presets-dropdown')).toBeNull()
+
+    // Status filter should be 'ready'
+    expect(screen.getByTestId('catalog-status-ready')).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('deletes a preset', async () => {
+    const preset = {
+      id: 'p2',
+      name: 'to delete',
+      searchQuery: 'foo',
+      activeLabels: [],
+      sortOption: 'name',
+      statusFilter: 'all',
+    }
+    localStorage.setItem('catalog-filter-presets', JSON.stringify([preset]))
+
+    const user = userEvent.setup()
+    renderCatalog()
+    await waitFor(() => expect(screen.getByTestId('catalog-card-alpha')).toBeInTheDocument())
+
+    await user.click(screen.getByTestId('catalog-presets-toggle'))
+    expect(screen.getByText('to delete')).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('catalog-preset-delete-p2'))
+
+    // Preset should no longer be visible
+    expect(screen.queryByText('to delete')).toBeNull()
+    expect(JSON.parse(localStorage.getItem('catalog-filter-presets') || '[]')).toHaveLength(0)
   })
 })

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -4,6 +4,7 @@
 // Issue #116: instanceCounts uses undefined="loading", null="failed", number="resolved".
 // spec 070: status filter — all / ready / errors toggle for compile-state filtering.
 // spec issue-534: selection mode for bulk YAML export.
+// spec issue-535: saved searches / filter presets via localStorage.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
@@ -39,6 +40,40 @@ const SORT_OPTIONS: { value: SortOption; label: string }[] = [
   { value: 'newest', label: 'Newest first' },
 ]
 
+// ── Filter preset types (spec issue-535) ─────────────────────────────────────
+
+const PRESETS_KEY = 'catalog-filter-presets'
+const MAX_PRESETS = 20
+
+interface FilterPreset {
+  id: string         // unique ID for stable React keys
+  name: string       // user-supplied label
+  searchQuery: string
+  activeLabels: string[]
+  sortOption: SortOption
+  statusFilter: 'all' | 'ready' | 'errors'
+}
+
+function loadPresets(): FilterPreset[] {
+  try {
+    const raw = localStorage.getItem(PRESETS_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed as FilterPreset[]
+  } catch {
+    return []
+  }
+}
+
+function savePresets(presets: FilterPreset[]): void {
+  try {
+    localStorage.setItem(PRESETS_KEY, JSON.stringify(presets))
+  } catch { /* silent — localStorage may be unavailable */ }
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
 export default function Catalog() {
   usePageTitle('Catalog')
   const [items, setItems] = useState<K8sObject[]>([])
@@ -46,35 +81,64 @@ export default function Catalog() {
   const [error, setError] = useState<string | null>(null)
 
   // instanceCounts maps rgdName → undefined (loading) | null (failed) | number (resolved).
-  // undefined means "fetch in-flight" — card shows a loading indicator.
-  // null means "fetch failed" — card shows em-dash.
-  // Issue #116: was always null before fetch resolved, so count never appeared to load.
   const [instanceCounts, setInstanceCounts] = useState<Map<string, number | null | undefined>>(new Map())
 
   const [searchQuery, setSearchQuery] = useState('')
   const debouncedQuery = useDebounce(searchQuery, 300)
   const [activeLabels, setActiveLabels] = useState<string[]>([])
   const [sortOption, setSortOption] = useState<SortOption>('name')
-  // spec 070: compile-status filter — 'all' | 'ready' | 'errors'
   const [statusFilter, setStatusFilter] = useState<'all' | 'ready' | 'errors'>('all')
 
-  // spec issue-534: selection mode state (O1, O7)
+  // spec issue-534: selection mode state
   const [selectionMode, setSelectionMode] = useState(false)
   const [selectedNames, setSelectedNames] = useState<Set<string>>(new Set())
   const [isExporting, setIsExporting] = useState(false)
 
-  // Escape key handler to exit selection mode (spec O6)
-  const catalogRef = useRef<HTMLDivElement>(null)
+  // spec issue-535: preset state
+  const [presets, setPresets] = useState<FilterPreset[]>(loadPresets)
+  const [showPresets, setShowPresets] = useState(false)
+  const [saveFormOpen, setSaveFormOpen] = useState(false)
+  const [presetNameInput, setPresetNameInput] = useState('')
+  const presetsDropdownRef = useRef<HTMLDivElement>(null)
+  const saveInputRef = useRef<HTMLInputElement>(null)
+
+  // Escape key: exit selection mode OR close presets dropdown
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape' && selectionMode) {
-        setSelectionMode(false)
-        setSelectedNames(new Set())
+      if (e.key === 'Escape') {
+        if (selectionMode) {
+          setSelectionMode(false)
+          setSelectedNames(new Set())
+        } else if (showPresets) {
+          setShowPresets(false)
+        } else if (saveFormOpen) {
+          setSaveFormOpen(false)
+          setPresetNameInput('')
+        }
       }
     }
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
-  }, [selectionMode])
+  }, [selectionMode, showPresets, saveFormOpen])
+
+  // Close presets dropdown on outside click
+  useEffect(() => {
+    if (!showPresets) return
+    function onMouseDown(e: MouseEvent) {
+      if (presetsDropdownRef.current && !presetsDropdownRef.current.contains(e.target as Node)) {
+        setShowPresets(false)
+      }
+    }
+    document.addEventListener('mousedown', onMouseDown)
+    return () => document.removeEventListener('mousedown', onMouseDown)
+  }, [showPresets])
+
+  // Focus save name input when form opens
+  useEffect(() => {
+    if (saveFormOpen) {
+      setTimeout(() => saveInputRef.current?.focus(), 0)
+    }
+  }, [saveFormOpen])
 
   // Fetch all RGDs once on mount
   const fetchRGDs = useCallback(() => {
@@ -84,14 +148,12 @@ export default function Catalog() {
     listRGDs()
       .then((res) => {
         setItems(res.items ?? [])
-        // Mark all RGDs as loading (undefined) before firing requests
         const loadingMap = new Map<string, number | null | undefined>()
         for (const rgd of res.items ?? []) {
           const name = extractRGDName(rgd)
           if (name) loadingMap.set(name, undefined)
         }
         setInstanceCounts(loadingMap)
-        // Fire parallel instance-count requests — failures are per-RGD
         for (const rgd of res.items ?? []) {
           const name = extractRGDName(rgd)
           if (!name) continue
@@ -100,7 +162,6 @@ export default function Catalog() {
               setInstanceCounts((prev) => new Map(prev).set(name, (list.items ?? []).length))
             })
             .catch(() => {
-              // Mark as null (failed), never block the page
               setInstanceCounts((prev) => new Map(prev).set(name, null))
             })
         }
@@ -117,14 +178,9 @@ export default function Catalog() {
     fetchRGDs()
   }, [fetchRGDs])
 
-  // Chaining map: built once when items change
   const chainingMap = useMemo(() => buildChainingMap(items), [items])
-
-  // All available labels across all RGDs
   const allLabels = useMemo(() => collectAllLabels(items), [items])
 
-  // Build entries with instance counts
-  // undefined = still loading, null = failed, number = resolved
   const entries = useMemo(
     () =>
       items.map((rgd) => {
@@ -135,15 +191,11 @@ export default function Catalog() {
     [items, instanceCounts],
   )
 
-  // Apply search + label filter + status filter.
-  // searchQuery is debounced: the filter only runs after the user pauses typing.
-  // activeLabels are NOT debounced — label toggles are discrete clicks, not streams.
   const filtered = useMemo(
     () =>
       entries.filter(({ rgd }) => {
         if (!matchesSearch(rgd, debouncedQuery)) return false
         if (!matchesLabelFilter(rgd, activeLabels)) return false
-        // spec 070: status filter
         if (statusFilter !== 'all') {
           const state = extractReadyStatus(rgd).state
           if (statusFilter === 'ready' && state !== 'ready') return false
@@ -154,7 +206,6 @@ export default function Catalog() {
     [entries, debouncedQuery, activeLabels, statusFilter],
   )
 
-  // Apply sort
   const sorted = useMemo(() => sortCatalog(filtered, sortOption), [filtered, sortOption])
 
   function clearFilters() {
@@ -163,9 +214,14 @@ export default function Catalog() {
     setStatusFilter('all')
   }
 
-  const hasFilters = searchQuery !== '' || activeLabels.length > 0 || statusFilter !== 'all'
+  // A filter is "active" if any field differs from defaults (spec issue-535 O1)
+  const hasFilters =
+    searchQuery !== '' ||
+    activeLabels.length > 0 ||
+    statusFilter !== 'all' ||
+    sortOption !== 'name'
 
-  // ── Selection mode handlers (spec O1–O3) ─────────────────────────────────
+  // ── Selection mode handlers (spec issue-534) ──────────────────────────────
 
   function handleEnterSelectionMode() {
     setSelectionMode(true)
@@ -185,7 +241,6 @@ export default function Catalog() {
     })
   }
 
-  // "Select all" toggles all currently-visible (post-filter) RGDs (spec O2)
   const visibleNames = useMemo(() => sorted.map(({ rgd }) => extractRGDName(rgd)), [sorted])
   const allVisible = visibleNames.length > 0 && visibleNames.every((n) => selectedNames.has(n))
 
@@ -201,7 +256,6 @@ export default function Catalog() {
     }
   }
 
-  // Export selected RGDs as multi-document YAML (spec O3–O5)
   async function handleExportYAML() {
     const names = Array.from(selectedNames)
     if (names.length === 0) return
@@ -214,12 +268,11 @@ export default function Catalog() {
           const cleaned = cleanK8sObject(rgd)
           docs.push(toYaml(cleaned))
         } catch {
-          // Skip failed fetches gracefully — include as comment
           docs.push(`# Failed to fetch ${name}`)
         }
       }
       const yaml = docs.join('\n---\n')
-      const today = new Date().toISOString().slice(0, 10) // YYYY-MM-DD (spec O5)
+      const today = new Date().toISOString().slice(0, 10)
       const filename = `kro-rgds-${today}.yaml`
       const blob = new Blob([yaml], { type: 'text/yaml' })
       const url = URL.createObjectURL(blob)
@@ -233,10 +286,45 @@ export default function Catalog() {
     }
   }
 
+  // ── Preset handlers (spec issue-535) ─────────────────────────────────────
+
+  function handleSavePreset() {
+    const name = presetNameInput.trim()
+    if (!name) return
+    const preset: FilterPreset = {
+      id: `preset-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      name,
+      searchQuery,
+      activeLabels: [...activeLabels],
+      sortOption,
+      statusFilter,
+    }
+    // Most-recently-saved first (spec Z2 Judgment)
+    const next = [preset, ...presets].slice(0, MAX_PRESETS)
+    setPresets(next)
+    savePresets(next)
+    setSaveFormOpen(false)
+    setPresetNameInput('')
+  }
+
+  function handleApplyPreset(preset: FilterPreset) {
+    setSearchQuery(preset.searchQuery)
+    setActiveLabels(preset.activeLabels)
+    setSortOption(preset.sortOption)
+    setStatusFilter(preset.statusFilter)
+    setShowPresets(false)
+  }
+
+  function handleDeletePreset(id: string) {
+    const next = presets.filter((p) => p.id !== id)
+    setPresets(next)
+    savePresets(next)
+  }
+
   // ── Render ────────────────────────────────────────────────────────────────
 
   return (
-    <div className="catalog" ref={catalogRef}>
+    <div className="catalog">
       <div className="catalog__header">
         <div className="catalog__title-row">
           <h1 className="catalog__heading">RGD Catalog</h1>
@@ -255,7 +343,7 @@ export default function Catalog() {
             activeLabels={activeLabels}
             onFilter={setActiveLabels}
           />
-          {/* spec 070: compile-status filter — all / ready / errors */}
+          {/* spec 070: compile-status filter */}
           <div className="catalog__status-filter" role="group" aria-label="Filter by compile status">
             {(['all', 'ready', 'errors'] as const).map((v) => (
               <button
@@ -291,7 +379,78 @@ export default function Catalog() {
             </div>
           </div>
 
-          {/* spec issue-534: selection mode toggle (O1) */}
+          {/* spec issue-535: Presets dropdown (O3) */}
+          <div className="catalog__presets-wrap" ref={presetsDropdownRef}>
+            <button
+              type="button"
+              className={`catalog__presets-btn${showPresets ? ' catalog__presets-btn--open' : ''}`}
+              onClick={() => setShowPresets((v) => !v)}
+              aria-expanded={showPresets}
+              aria-haspopup="listbox"
+              data-testid="catalog-presets-toggle"
+            >
+              Presets{presets.length > 0 ? ` (${presets.length})` : ''}
+            </button>
+            {showPresets && (
+              <div
+                className="catalog__presets-dropdown"
+                role="listbox"
+                aria-label="Saved filter presets"
+                data-testid="catalog-presets-dropdown"
+              >
+                {presets.length === 0 ? (
+                  <p className="catalog__presets-empty">No saved presets</p>
+                ) : (
+                  presets.map((preset) => (
+                    <div
+                      key={preset.id}
+                      className="catalog__preset-item"
+                      role="option"
+                      aria-selected="false"
+                    >
+                      <button
+                        type="button"
+                        className="catalog__preset-apply"
+                        onClick={() => handleApplyPreset(preset)}
+                        data-testid={`catalog-preset-apply-${preset.id}`}
+                      >
+                        {preset.name}
+                      </button>
+                      <button
+                        type="button"
+                        className="catalog__preset-delete"
+                        onClick={() => handleDeletePreset(preset.id)}
+                        aria-label={`Delete preset ${preset.name}`}
+                        data-testid={`catalog-preset-delete-${preset.id}`}
+                      >
+                        ×
+                      </button>
+                    </div>
+                  ))
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* spec issue-535: Save filter button — visible when filter active (O1, O8) */}
+          {hasFilters && !saveFormOpen && (
+            <button
+              type="button"
+              className="catalog__save-filter-btn"
+              onClick={() => setSaveFormOpen(true)}
+              disabled={presets.length >= MAX_PRESETS}
+              title={
+                presets.length >= MAX_PRESETS
+                  ? 'Maximum 20 presets reached — delete one first'
+                  : 'Save current filters as a preset'
+              }
+              data-testid="catalog-save-filter"
+            >
+              Save filter
+            </button>
+          )}
+
+          {/* spec issue-534: selection mode toggle */}
           {!isLoading && !error && !selectionMode && (
             <button
               type="button"
@@ -304,7 +463,48 @@ export default function Catalog() {
           )}
         </div>
 
-        {/* spec issue-534: selection toolbar — shown when selectionMode=true (O1–O3) */}
+        {/* spec issue-535: inline save-preset form (O2) */}
+        {saveFormOpen && (
+          <div className="catalog__save-form" data-testid="catalog-save-form">
+            <label className="catalog__save-form-label" htmlFor="catalog-preset-name">
+              Preset name:
+            </label>
+            <input
+              id="catalog-preset-name"
+              ref={saveInputRef}
+              type="text"
+              className="catalog__save-form-input"
+              value={presetNameInput}
+              onChange={(e) => setPresetNameInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleSavePreset()
+                if (e.key === 'Escape') { setSaveFormOpen(false); setPresetNameInput('') }
+              }}
+              placeholder="e.g. errors only"
+              maxLength={60}
+              data-testid="catalog-preset-name-input"
+            />
+            <button
+              type="button"
+              className="catalog__save-form-confirm"
+              onClick={handleSavePreset}
+              disabled={!presetNameInput.trim()}
+              data-testid="catalog-preset-save-confirm"
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              className="catalog__save-form-cancel"
+              onClick={() => { setSaveFormOpen(false); setPresetNameInput('') }}
+              data-testid="catalog-preset-save-cancel"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+
+        {/* spec issue-534: selection toolbar */}
         {selectionMode && (
           <div className="catalog__selection-toolbar" data-testid="catalog-selection-toolbar">
             <label className="catalog__select-all" data-testid="catalog-select-all">

--- a/web/src/pages/Catalog.tsx
+++ b/web/src/pages/Catalog.tsx
@@ -99,8 +99,10 @@ export default function Catalog() {
   const [showPresets, setShowPresets] = useState(false)
   const [saveFormOpen, setSaveFormOpen] = useState(false)
   const [presetNameInput, setPresetNameInput] = useState('')
+  const [focusedPresetIdx, setFocusedPresetIdx] = useState<number>(-1)
   const presetsDropdownRef = useRef<HTMLDivElement>(null)
   const saveInputRef = useRef<HTMLInputElement>(null)
+  const presetsBtnRef = useRef<HTMLButtonElement>(null)
 
   // Escape key: exit selection mode OR close presets dropdown
   useEffect(() => {
@@ -111,6 +113,8 @@ export default function Catalog() {
           setSelectedNames(new Set())
         } else if (showPresets) {
           setShowPresets(false)
+          setFocusedPresetIdx(-1)
+          presetsBtnRef.current?.focus()
         } else if (saveFormOpen) {
           setSaveFormOpen(false)
           setPresetNameInput('')
@@ -139,6 +143,15 @@ export default function Catalog() {
       setTimeout(() => saveInputRef.current?.focus(), 0)
     }
   }, [saveFormOpen])
+
+  // Focus the correct preset apply button when focusedPresetIdx changes
+  useEffect(() => {
+    if (!showPresets || focusedPresetIdx < 0 || !presetsDropdownRef.current) return
+    const buttons = presetsDropdownRef.current.querySelectorAll<HTMLButtonElement>(
+      '.catalog__preset-apply',
+    )
+    buttons[focusedPresetIdx]?.focus()
+  }, [showPresets, focusedPresetIdx])
 
   // Fetch all RGDs once on mount
   const fetchRGDs = useCallback(() => {
@@ -379,12 +392,26 @@ export default function Catalog() {
             </div>
           </div>
 
-          {/* spec issue-535: Presets dropdown (O3) */}
+          {/* spec issue-535: Presets dropdown (O3, O6) */}
           <div className="catalog__presets-wrap" ref={presetsDropdownRef}>
             <button
+              ref={presetsBtnRef}
               type="button"
               className={`catalog__presets-btn${showPresets ? ' catalog__presets-btn--open' : ''}`}
-              onClick={() => setShowPresets((v) => !v)}
+              onClick={() => { setShowPresets((v) => !v); setFocusedPresetIdx(-1) }}
+              onKeyDown={(e) => {
+                if (e.key === 'ArrowDown' && !showPresets) {
+                  e.preventDefault()
+                  setShowPresets(true)
+                  setFocusedPresetIdx(0)
+                } else if (e.key === 'ArrowDown' && showPresets) {
+                  e.preventDefault()
+                  setFocusedPresetIdx((i) => Math.min(i + 1, presets.length - 1))
+                } else if (e.key === 'ArrowUp' && showPresets) {
+                  e.preventDefault()
+                  setFocusedPresetIdx((i) => Math.max(i - 1, 0))
+                }
+              }}
               aria-expanded={showPresets}
               aria-haspopup="listbox"
               data-testid="catalog-presets-toggle"
@@ -397,6 +424,18 @@ export default function Catalog() {
                 role="listbox"
                 aria-label="Saved filter presets"
                 data-testid="catalog-presets-dropdown"
+                onKeyDown={(e) => {
+                  if (e.key === 'ArrowDown') {
+                    e.preventDefault()
+                    setFocusedPresetIdx((i) => Math.min(i + 1, presets.length - 1))
+                  } else if (e.key === 'ArrowUp') {
+                    e.preventDefault()
+                    setFocusedPresetIdx((i) => {
+                      if (i <= 0) { setShowPresets(false); presetsBtnRef.current?.focus(); return -1 }
+                      return i - 1
+                    })
+                  }
+                }}
               >
                 {presets.length === 0 ? (
                   <p className="catalog__presets-empty">No saved presets</p>


### PR DESCRIPTION
## Summary

Adds a **Presets** system to the RGD Catalog page (spec issue-535):

- **Save filter** button appears when any filter is active (search, label, status, sort)
- Clicking opens an inline name-input form — type a name and press Save or Enter
- **Presets (N)** dropdown lists all saved presets; click to apply, × to delete
- Maximum 20 presets; "Save filter" is disabled (with tooltip) at the limit
- All state via `localStorage` key `catalog-filter-presets` — persists across reloads
- Keyboard accessible: Escape closes form/dropdown; Tab navigates; Enter confirms

## Design doc

Updated `docs/design/28-rgd-display.md`: moved `Catalog: saved searches and filter presets` from 🔲 Future to ✅ Present.

## Testing

5 new tests in `Catalog.test.tsx` covering: save-button visibility gating, inline form appearance, save→dropdown flow, preset apply, preset delete. Total: 1590 tests passing.

Closes #535