### PR TITLE
fix(config): session_item_limit 3→2 — prevent OIDC expiry

### DIFF
--- a/otherness-config.yaml
+++ b/otherness-config.yaml
@@ -13,7 +13,7 @@ maqa:
   agents_path: ~/.otherness/agents
   status_update_cycles: 5
   product_validation_cycles: 3
-  session_item_limit: 3    # 3 items fits hourly cron (sessions ~30min)
+  session_item_limit: 2    # 2 items — kro-ui e2e is slow, keep under 60min OIDC window
   autonomous_mode: true    # operator authorized — agent acts on their behalf
 
 schedule:


### PR DESCRIPTION
kro-ui e2e tests are slow. Reducing from 3 to 2 items keeps sessions under 45min.