### PR TITLE
fix(ci): restore missing newline — opencode step YAML invalid

### DIFF
--- a/.github/workflows/otherness-scheduled.yml
+++ b/.github/workflows/otherness-scheduled.yml
@@ -224,7 +224,8 @@ jobs:
       # Failure here is non-blocking — Step B always runs regardless.
       - name: Otherness — Vision scan (Step A)
         continue-on-error: true
-        uses: anomalyco/opencode/github@3175a3c61853e4666acb24fa435783826596665d  # v1.14.20env:
+        uses: anomalyco/opencode/github@3175a3c61853e4666acb24fa435783826596665d  # v1.14.20
+        env:
           AWS_REGION:          us-east-1
           GH_TOKEN:            ${{ steps.app-token.outputs.token || secrets.GH_TOKEN }}
           GITHUB_TOKEN:        ${{ steps.app-token.outputs.token || secrets.GH_TOKEN }}
@@ -288,7 +289,8 @@ jobs:
       # agents_path validated against allowlist before agent reads it (doc 27 §M6).
       # Uses App token when available (M3), falls back to GH_TOKEN PAT.
       - name: Run otherness
-        uses: anomalyco/opencode/github@3175a3c61853e4666acb24fa435783826596665d  # v1.14.20env:
+        uses: anomalyco/opencode/github@3175a3c61853e4666acb24fa435783826596665d  # v1.14.20
+        env:
           AWS_REGION:          us-east-1
           GH_TOKEN:            ${{ steps.app-token.outputs.token || secrets.GH_TOKEN }}
           GITHUB_TOKEN:        ${{ steps.app-token.outputs.token || secrets.GH_TOKEN }}


### PR DESCRIPTION
SHA upgrade lost newline between `uses:` and `env:`. Restoring.