### PR TITLE
chore: upgrade agent_version v0.2.0 → v0.4.0

### DIFF
--- a/otherness-config.yaml
+++ b/otherness-config.yaml
@@ -1,7 +1,7 @@
 project:
   name: kro-ui
   repo: pnz1990/kro-ui
-  agent_version: v0.2.0  # pinned to stable release
+  agent_version: v0.4.0  # pinned to stable release
   upgrade_policy: "0.x.x"  # auto-upgrade any 0.* release
   report_issue: 439
   board_url: "https://github.com/users/pnz1990/projects/2/views/1"


### PR DESCRIPTION
kro-ui missed the v0.3.0 upgrade. Bumping to v0.4.0 which includes fixed upgrade logic (regex fix, missing fi fix, bash -n validation). Future upgrades are automatic.